### PR TITLE
Add CAPIMenu check

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/capa_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capa_cluster.spec.ts
@@ -35,6 +35,7 @@ describe('Import CAPA', () => {
       // Go to Cluster Management > CAPI > Clusters and check if the cluster has started provisioning
       cypressLib.burgerMenuToggle();
       cy.accesMenuSelection('Cluster Management', 'CAPI');
+      cy.checkCAPIMenu();
       cy.contains('Provisioned ' + clusterShort, { timeout: timeout });
     })
   );
@@ -70,6 +71,7 @@ describe('Import CAPA', () => {
       cy.visit('/');
       cypressLib.burgerMenuToggle();
       cy.accesMenuSelection('Cluster Management', 'CAPI');
+      cy.checkCAPIMenu();
       cy.contains('Provisioned ' + clusterShort);
     })
   );
@@ -85,6 +87,7 @@ describe('Import CAPA', () => {
       cy.contains(clusterFull, { timeout: timeout }).should('not.exist');
       cypressLib.burgerMenuToggle();
       cy.accesMenuSelection('Cluster Management', 'CAPI');
+      cy.checkCAPIMenu();
       cy.contains(clusterShort, { timeout: timeout }).should('not.exist');
     })
   );

--- a/tests/cypress/latest/e2e/unit_tests/capd_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capd_cluster.spec.ts
@@ -83,6 +83,7 @@ describe('Import CAPD', () => {
 
         // Access CAPI cluster
         cy.accesMenuSelection('Cluster Management', 'CAPI');
+        cy.checkCAPIMenu();
         cy.contains("Machine Deployments").click();
         cy.getBySel('sortable-table-0-action-button').click();
         cy.contains('Edit YAML')
@@ -123,6 +124,7 @@ describe('Import CAPD', () => {
         cy.contains(clusterFull, { timeout: 120000 }).should('not.exist');
         cypressLib.burgerMenuToggle();
         cy.accesMenuSelection('Cluster Management', 'CAPI');
+        cy.checkCAPIMenu();
         cy.contains(clusterShort, { timeout: 150000 }).should('not.exist');
       })
     );

--- a/tests/cypress/latest/e2e/unit_tests/menu.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/menu.spec.ts
@@ -34,12 +34,7 @@ describe('Menu testing', () => {
       cy.accesMenuSelection('Cluster Management', 'CAPI');
 
       // Check Turtles's side menu
-      // TODO: DO a loop to check all the menu
-      cy.contains('.nav', "Clusters")
-      cy.contains('.nav', "Machine Deployments")
-      cy.contains('.nav', "Machine Sets")
-      cy.contains('.nav', "Cluster Classes")
-      cy.contains('.nav', "Providers")
+      cy.checkCAPIMenu();
     })
   );
 });

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -80,6 +80,7 @@ Cypress.Commands.add('namespaceReset', () => {
 Cypress.Commands.add('checkCAPICluster', (clusterName) => {
   cypressLib.burgerMenuToggle();
   cy.accesMenuSelection('Cluster Management', 'CAPI');
+  cy.checkCAPIMenu();
   cy.contains('Provisioned ' + clusterName, { timeout: 30000 });
   cy.contains('Machine Deployments').click();
   cy.contains('Running ' + clusterName, { timeout: 30000 });
@@ -87,10 +88,20 @@ Cypress.Commands.add('checkCAPICluster', (clusterName) => {
   cy.contains('Active ' + clusterName, { timeout: 30000 });
 });
 
+// Command to check CAPI Menu is visible
+Cypress.Commands.add('checkCAPIMenu', () => {
+  cy.contains('.nav', 'Clusters')
+  cy.contains('.nav', 'Machine Deployments')
+  cy.contains('.nav', 'Machine Sets')
+  cy.contains('.nav', 'Cluster Classes')
+  cy.contains('.nav', 'Providers')
+});
+
 // Command to add CAPI Custom provider
 Cypress.Commands.add('addCustomProvider', (name, namespace, providerName, providerType, version, url) => {
   // Navigate to providers Menu
   cy.accesMenuSelection('Cluster Management', 'CAPI');
+  cy.checkCAPIMenu();
   cy.contains('Providers').click();
   cy.clickButton('Create');
   cy.contains('Custom').click();
@@ -112,6 +123,7 @@ Cypress.Commands.add('addCustomProvider', (name, namespace, providerName, provid
 Cypress.Commands.add('addInfraProvider', (providerType, name, namespace, cloudCredentials) => {
   // Navigate to providers Menu
   cy.accesMenuSelection('Cluster Management', 'CAPI');
+  cy.checkCAPIMenu();
   cy.contains('Providers').click();
   cy.clickButton('Create');
   cy.contains(providerType, { matchCase: false }).click();

--- a/tests/cypress/latest/support/e2e.ts
+++ b/tests/cypress/latest/support/e2e.ts
@@ -29,6 +29,7 @@ declare global {
       createNamespace(namespace: string): Chainable<Element>;
       setNamespace(namespace: string): Chainable<Element>;
       checkCAPICluster(clustername: string): Chainable<Element>;
+      checkCAPIMenu(): Chainable<Element>;
       namespaceReset(): Chainable<Element>;
       addCustomProvider(name: string, namespace: string, providerName: string, providerType: string, version: string, url: string): Chainable<Element>;
       addInfraProvider(providerType: string, name: string, namespace: string, cloudCredentials?: string): Chainable<Element>;


### PR DESCRIPTION
### What does this PR do?
Due to new UI changes, added a check to make sure CAPI Menu is visible

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes - Cluster deletion assertion check

### Checklist:
- [x] GitHub Actions
https://github.com/rancher/rancher-turtles-e2e/actions/runs/8876151687
