### PR TITLE
Update defaultCommandTimeout

### DIFF
--- a/tests/cypress/latest/cypress.config.ts
+++ b/tests/cypress/latest/cypress.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'cypress'
 const qaseAPIToken = process.env.QASE_API_TOKEN
 
 export default defineConfig({
-  defaultCommandTimeout: 20000,
+  defaultCommandTimeout: 30000,
   video: true,
   reporter: 'cypress-multi-reporters',
   reporterOptions: {


### PR DESCRIPTION
### What does this PR do?
Updated defaultCommandTimeout to avoid page loading issues
![image](https://github.com/rancher/rancher-turtles-e2e/assets/73099870/b58c15cb-f51b-4303-be0a-f7bb701b430f)

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes - Failing CI flaky tests
