### PR TITLE
New GCP template based on 15.6 with cgroupfs enabled to make RKE2-v1.28 work

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -65,7 +65,7 @@ on:
         type: string
       runner_template:
         description: Runner template to use
-        default: capi-e2e-ci-runner-spot-n2-highmem-16-template-v1
+        default: capi-e2e-ci-runner-spot-n2-highmem-16-template-v2
         type: string
       test_description:
         description: Short description of the test
@@ -76,7 +76,7 @@ on:
         type: string
       upstream_cluster_version:
         description: Cluster upstream version where to install Rancher (K3s or RKE2)
-        default: v1.26.10+k3s2
+        default: v1.28.10+k3s2
         type: string
       zone:
         description: GCP zone to host the runner
@@ -207,6 +207,12 @@ jobs:
       TURTLES_REPO: rancher-sandbox/rancher-turtles
       MANIFEST_IMG: localhost:5000/$TURTLES_REPO-$ARCH
     steps:
+      - name: Add /usr/local/bin into PATH
+        run: |
+          echo "/usr/local/bin/" >> ${GITHUB_PATH}
+          echo 'Defaults secure_path="/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin"' | sudo tee /etc/sudoers.d/0-custom_secure_path
+      - name: Install helm
+        run: curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
       # Build rancher-turtles nightly chart
       - name: Check out rancher-turtles repo
         uses: actions/checkout@v4

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -76,7 +76,7 @@ on:
         type: string
       upstream_cluster_version:
         description: Cluster upstream version where to install Rancher (K3s or RKE2)
-        default: v1.28.10+k3s2
+        default: v1.28.11+k3s1
         type: string
       zone:
         description: GCP zone to host the runner

--- a/tests/assets/rancher-turtles-fleet-example/rke2_namespace_autoimport/clusters/cluster1.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/rke2_namespace_autoimport/clusters/cluster1.yaml
@@ -67,7 +67,7 @@ spec:
     kind: DockerMachineTemplate
     name:  cluster1-control-plane
   nodeDrainTimeout: 30s
-  version: v1.26.4+rke2r1
+  version: v1.28.9+rke2r1
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
@@ -110,7 +110,7 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: DockerMachineTemplate
         name: cluster1-md-0
-      version: v1.26.4+rke2r1
+      version: v1.28.9+rke2r1
 ---
 apiVersion: v1
 data:

--- a/tests/assets/rancher-turtles-fleet-example/rke2_namespace_autoimport/clusters/fleet.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/rke2_namespace_autoimport/clusters/fleet.yaml
@@ -1,1 +1,22 @@
 namespace: default
+
+diff:
+  comparePatches:
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: DockerCluster
+    name: cluster1
+    namespace: default
+    operations:
+    - {"op":"remove", "path":"/spec/loadBalancer"}
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: DockerMachineTemplate
+    name: cluster1-control-plane
+    namespace: default
+    operations:
+    - {"op":"remove", "path":"/spec/template/spec/bootstrapTimeout"}
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: DockerMachineTemplate
+    name: cluster1-md-0
+    namespace: default
+    operations:
+    - {"op":"remove", "path":"/spec/template/spec/bootstrapTimeout"}


### PR DESCRIPTION
### What does this PR do?
* bump of GCP template to `capi-e2e-ci-runner-spot-n2-highmem-16-template-v2` based on opensuse 15.6 with by-default enabled `cgroup2fs`, see https://kubernetes.io/docs/concepts/architecture/cgroups/
* upstream k3s bumped to `v1.28.11+k3s1`
* rke2-docker bumped to `v1.28.9+rke2r1` -  there is a bug that k8s version patch level cannot contains 2 digits
* rke2-docker - ignore modified resources by CAPI in fleet gitrepo

### Which issue(s) this PR fixes:
Fixes #44 

### Checklist:
- [x] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions (if applicable) https://github.com/rancher/rancher-turtles-e2e/actions/runs/9759991962/job/26937865278
(unrealted failure when deleting clusters - they are getting recreated for some reason)