### PR TITLE
Rename Workflow

### DIFF
--- a/.github/workflows/ui-e2e.yaml
+++ b/.github/workflows/ui-e2e.yaml
@@ -1,5 +1,6 @@
 # This workflow calls the master E2E workflow with custom variables
-name: UI-RM_head_2.8
+name: UI-E2E
+run-name: UI-E2E on Rancher v${{ inputs.rancher_version || '2.9-head' }}
 
 on:
   workflow_dispatch:
@@ -10,7 +11,7 @@ on:
         type: boolean
       rancher_version:
         description: Rancher Manager channel/version/head_version to use for installation
-        default: latest/devel/2.8
+        default: latest/devel/2.9
         type: string
   schedule:
     - cron: '0 4 * * *'
@@ -31,4 +32,4 @@ jobs:
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       capi_ui_version: dev
       k8s_version_to_provision: v1.27.9+k3s2
-      rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.8' }}
+      rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.9' }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rancher-turtles-e2e
 
-[![UI-RM_head_2.8](https://github.com/rancher-sandbox/rancher-turtles-e2e/actions/workflows/ui-rm_head_2.8.yaml/badge.svg?branch=main)](https://github.com/rancher-sandbox/rancher-turtles-e2e/actions/workflows/ui-rm_head_2.8.yaml)
+[![UI-E2E_head_2.9](https://github.com/rancher-sandbox/rancher-turtles-e2e/actions/workflows/ui-e2e.yaml/badge.svg?branch=main)](https://github.com/rancher-sandbox/rancher-turtles-e2e/actions/workflows/ui-e2e.yaml)
 
 What tests are doing:
 1. Create the infra stack ( GCP runner, cert-manager, rancher )


### PR DESCRIPTION
### What does this PR do?
- Renames e2e workflow name to generic one and adds description for Rancher version
- Bumps Rancher version to 2.9 with respect to upcoming Turtles release 

- [x] GitHub Actions - not applicable, would be available after merge
![image](https://github.com/user-attachments/assets/081fcb6d-497a-414e-8758-01eb48c74f7b)

### Special notes for your reviewer:
Operator version bumps upcoming in follow-up PR