### PR TITLE
Add support for stable rancher versions like prime/2.9.1 or latest/2.9.0

### DIFF
--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -84,9 +84,17 @@ var _ = BeforeSuite(func() {
 
 	// Extract Rancher Manager channel/version to install
 	if rancherVersion != "" {
+		// Split rancherVersion and reset it
 		s := strings.Split(rancherVersion, "/")
+		rancherVersion = ""
+
+		// Get needed informations
 		rancherChannel = s[0]
-		rancherVersion = s[1]
-		rancherHeadVersion = s[2]
+		if len(s) > 1 {
+			rancherVersion = s[1]
+		}
+		if len(s) > 2 {
+			rancherHeadVersion = s[2]
+		}
 	}
 })


### PR DESCRIPTION
### What does this PR do?
Fixes issue when running CI against `prime/2.9.1` is failing on `index out of range` error. The code was originally designed for `latest/devel/2.9` and not for `latest/2.9.0` nor `prime/2.9.1` which are supported by ele-testhelpers.

Failure for `prime/2.9.1`: https://github.com/rancher/rancher-turtles-e2e/actions/runs/10578000973/job/29307217653
Testrun: https://github.com/rancher/rancher-turtles-e2e/actions/runs/10578590235

