### PR TITLE
Set expiration time for GCP runner secrets

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -118,9 +118,9 @@ jobs:
       - name: Create GCP secrets
         run: |
           echo -n ${{ secrets.pat_token }} \
-            | gcloud secrets create PAT_TOKEN_${{ steps.generator.outputs.uuid }} --data-file=-
+            | gcloud secrets create PAT_TOKEN_${{ steps.generator.outputs.uuid }} --ttl="36000s" --quiet --data-file=-
           echo -n ${{ github.repository }} \
-            | gcloud secrets create GH_REPO_${{ steps.generator.outputs.uuid }} --data-file=-
+            | gcloud secrets create GH_REPO_${{ steps.generator.outputs.uuid }} --ttl="36000s" --quiet --data-file=-
       - name: Get public dns name in GCP
         id: dns
         run: |


### PR DESCRIPTION
### What does this PR do?
There was about 8000 Managed Secrets on GCP created by various GCP runners which costs money.

This PR will set Expiration time by `--ttl=36000s` for newly created secrets so they will be auto removed after 10h.

### Checklist:
- [ ] GitHub Actions (if applicable) https://github.com/rancher/rancher-turtles-e2e/actions/runs/11181445581
