### PR TITLE
Bump k3s version to v1.30.6+k3s1

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -84,7 +84,7 @@ on:
         type: string
       upstream_cluster_version:
         description: Cluster upstream version where to install Rancher (K3s or RKE2)
-        default: v1.28.11+k3s1
+        default: v1.30.6+k3s1
         type: string
       zone:
         description: GCP zone to host the runner


### PR DESCRIPTION
### What does this PR do?

Bump k3s version as new CAPI UI 0.7.0 is already compatible with 1.30.x

Ref. https://github.com/rancher/capi-ui-extension/issues/84

Testrun: https://github.com/rancher/rancher-turtles-e2e/actions/runs/11689436994