### PR TITLE
Bump ele-testhelpers to support v2.10-head and new location for v2.9-head

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/onsi/ginkgo/v2 v2.12.1
 	github.com/onsi/gomega v1.28.0
-	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240814133125-6458c0123aad
+	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20241105101633-1357dc536a2e
 	github.com/rancher-sandbox/qase-ginkgo v1.0.1
 	github.com/sirupsen/logrus v1.9.3
 )

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -132,6 +132,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240814133125-6458c0123aad h1:TM0FVtBT+A1RT7mcFVW3i5JaxMcAEWMe0diHLQlUg9s=
 github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240814133125-6458c0123aad/go.mod h1:Ex+a/ng4u2BvcGQdQjTHI48h88bQ6k2a7q8rnvU0XbQ=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20241105101633-1357dc536a2e h1:sBIQJXNx+FS4dXdJjczYMvMwS2N4CsauXrYL9ye8yGc=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20241105101633-1357dc536a2e/go.mod h1:Ex+a/ng4u2BvcGQdQjTHI48h88bQ6k2a7q8rnvU0XbQ=
 github.com/rancher-sandbox/qase-ginkgo v1.0.1 h1:LB9ITLavX3PmcOe0hp0Y7rwQCjJ3WpL8kG8v1MxPadE=
 github.com/rancher-sandbox/qase-ginkgo v1.0.1/go.mod h1:sIF43xaLHtEzmPqADKlZZV6oatc66GHz1N6gpBNn6QY=
 github.com/rancher/qase-go/client v0.0.0-20231114201952-65195ec001fa h1:/qeYlQVfyvsO5yY0dZmm7mRTAsDm54jACiRDx3LAwsA=


### PR DESCRIPTION
Testrun: https://github.com/rancher/rancher-turtles-e2e/actions/runs/11689526220