### PR TITLE
Add option to select nightly/stable rancher turtles chart  and Set qase_run_id default to none

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -68,6 +68,10 @@ on:
         description: Rancher Manager channel/version/head_version to use for installation
         default: stable/latest/none
         type: string
+      operator_nightly_chart:
+        description: Install rancher turtles nightly chart
+        required: true
+        type: boolean
       rancher_upgrade:
         description: Rancher Manager channel/version to upgrade to
         type: string
@@ -244,10 +248,12 @@ jobs:
         run: curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
       # Build rancher-turtles latest chart
       - name: Check out rancher-turtles repo
+        if: ${{ inputs.operator_nightly_chart == true }}
         uses: actions/checkout@v4
         with:
           repository: ${{ env.TURTLES_REPO }}
       - name: Install Go
+        if: ${{ inputs.operator_nightly_chart == true }}
         uses: actions/setup-go@v5
         with:
           cache: false
@@ -255,6 +261,7 @@ jobs:
 
       # This step builds latest turtles chart and pushes latest turtles docker image to local docker registry
       - name: Make chart
+        if: ${{ inputs.operator_nightly_chart == true }}
         run: |
           CONTROLLER_IMG=${{ env.CONTROLLER_IMG }} make e2e-image-build
           RELEASE_TAG=v${{ env.TAG }} CONTROLLER_IMG=${{ env.CONTROLLER_IMG }} CONTROLLER_IMAGE_VERSION=v${{ env.TAG }} make build-chart
@@ -262,6 +269,7 @@ jobs:
           docker push ${{ env.CONTROLLER_IMG }}:v${{ env.TAG }}
 
       - name: Copy chart file
+        if: ${{ inputs.operator_nightly_chart == true }}
         run: sudo cp ${{ github.workspace }}/out/package/rancher-turtles-${{ env.TAG }}.tgz ${{ runner.temp }}
 
       - name: Checkout
@@ -272,8 +280,9 @@ jobs:
           cache: false
           go-version-file: tests/go.mod
       - name: Copy chart file for chartmuseum
+        if: ${{ inputs.operator_nightly_chart == true }}
         run: sudo cp ${{ runner.temp }}/rancher-turtles-${{ env.TAG }}.tgz ${{ github.workspace }}/tests/assets
-      - name: Install prerequisite components
+      - name: Install Rancher Manager
         env:
           PUBLIC_DNS: ${{ needs.create-runner.outputs.public_dns }}
           PUBLIC_DOMAIN: bc.googleusercontent.com
@@ -295,11 +304,11 @@ jobs:
           echo "cert_manager_version=${CERT_MANAGER_VERSION}" >> ${GITHUB_OUTPUT}
           echo "rm_version=${RM_VERSION}" >> ${GITHUB_OUTPUT}
       - name: Install Chartmuseum
+        if: ${{ inputs.operator_nightly_chart == true }}
         run: cd tests && make e2e-install-chartmuseum
       - name: Cypress tests
         env:
           BROWSER: chrome
-          CHARTMUSEUM_REPO: http://${{ needs.create-runner.outputs.public_dns }}
           CYPRESS_DOCKER: 'cypress/included:13.6.4'
           CAPI_UI_VERSION: ${{ inputs.capi_ui_version }}
           K8S_UPSTREAM_VERSION: ${{ inputs.upstream_cluster_version }}
@@ -338,6 +347,10 @@ jobs:
             unset QASE_REPORT
             unset QASE_API_TOKEN
             # QASE_RUN_ID is empty string already
+          fi
+
+          if [ ${{ inputs.operator_nightly_chart }} == true ]; then
+            export CHARTMUSEUM_REPO=http://${{ needs.create-runner.outputs.public_dns }}
           fi
           cd tests && make start-cypress-tests
       - name: Upload Cypress screenshots (Basics)

--- a/.github/workflows/ui-e2e.yaml
+++ b/.github/workflows/ui-e2e.yaml
@@ -1,13 +1,13 @@
 # This workflow calls the master E2E workflow with custom variables
 name: UI-E2E
-run-name: ${{ github.event_name == 'workflow_dispatch' && format('Rancher-`{0}` - `{1}` destroy={2}', inputs.rancher_version, inputs.grep_test_by_tag, inputs.destroy_runner) || github.event_name == 'schedule' && 'UI-E2E on Rancher-latest/devel/2.10' }}
+run-name: ${{ github.event_name == 'workflow_dispatch' && format('Rancher-`{0}` - `{1}` destroy={2} nightly={3}', inputs.rancher_version, inputs.grep_test_by_tag, inputs.destroy_runner, inputs.operator_nightly_chart) || github.event_name == 'schedule' && 'UI-E2E on Rancher-latest/devel/2.10' }}
 
 on:
   workflow_dispatch:
     inputs:
       qase_run_id:
         description: Qase run ID where the results will be reported (auto|none|existing_run_id)
-        default: auto
+        default: none
         type: string
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
@@ -22,6 +22,10 @@ on:
         required: true
         type: string
         default: '@install @short @full'
+      operator_nightly_chart:
+        description: Install rancher turtles nightly chart
+        default: true
+        type: boolean
   schedule:
     - cron: '0 4 * * *'
 
@@ -48,4 +52,5 @@ jobs:
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.10' }}
       qase_run_id: ${{ inputs.qase_run_id || 'auto' }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag || '@install @short' }}
+      operator_nightly_chart: ${{ inputs.operator_nightly_chart == true || (github.event_name == 'schedule' && true) }}
 

--- a/tests/cypress/latest/e2e/unit_tests/turtles_operator.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/turtles_operator.spec.ts
@@ -28,7 +28,8 @@ describe('Install Turtles Operator', { tags: '@install' }, () => {
 
   it('Add turtles repo', { retries: 2 }, () => {
     var turtlesHelmRepo = Cypress.env('chartmuseum_repo')
-    if (turtlesHelmRepo == undefined) {
+    // if the env var is empty or not defined at all; use the normal repo
+    if (turtlesHelmRepo == "" || turtlesHelmRepo == undefined) {
       turtlesHelmRepo = 'https://rancher.github.io/turtles/'
     } else {
       turtlesHelmRepo += ':8080'


### PR DESCRIPTION
### What does this PR do?
Add option to select nightly/stable rancher turtles chart  and Set qase_run_id default to none
### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions (if applicable) - [Nightly Charts (tests failed but unrelated to changes made in the PR) ](https://github.com/rancher/rancher-turtles-e2e/actions/runs/12430525829), [Stable Charts :runner: ](https://github.com/rancher/rancher-turtles-e2e/actions/runs/12431121217/job/34707950627)

### Special notes for your reviewer:
