### PR TITLE
Adapt RKE2 resources to be compatible with CAPI 1.9+

### DIFF
--- a/tests/assets/rancher-turtles-fleet-example/rke2_clusterclass_autoimport/classes/quickstart.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/rke2_clusterclass_autoimport/classes/quickstart.yaml
@@ -94,10 +94,12 @@ data:
       default-server init-addr none
 
     frontend stats
+      mode http
       bind *:8404
       stats enable
-      stats uri /
+      stats uri /stats
       stats refresh 10s
+      stats admin if TRUE
 
     frontend control-plane
       bind *:{{ .FrontendControlPlanePort }}
@@ -108,10 +110,9 @@ data:
 
     backend kube-apiservers
       option httpchk GET /healthz
-      http-check expect status 401
-      # TODO: we should be verifying (!)
-      {{range $server, $address := .BackendServers}}
-      server {{ $server }} {{ JoinHostPort $address $.BackendControlPlanePort }} check check-ssl verify none resolvers docker resolve-prefer {{ if $.IPv6 -}} ipv6 {{- else -}} ipv4 {{- end }}
+
+      {{range $server, $backend := .BackendServers }}
+      server {{ $server }} {{ JoinHostPort $backend.Address $.BackendControlPlanePort }} check check-ssl verify none resolvers docker resolve-prefer {{ if $.IPv6 -}} ipv6 {{- else -}} ipv4 {{- end }}
       {{- end}}
 
     frontend rke2-join
@@ -124,8 +125,8 @@ data:
     backend rke2-servers
       option httpchk GET /v1-rke2/readyz
       http-check expect status 403
-      {{range $server, $address := .BackendServers}}
-      server {{ $server }} {{ $address }}:9345 check check-ssl verify none
+      {{range $server, $backend := .BackendServers }}
+      server {{ $server }} {{ $backend.Address }}:9345 check check-ssl verify none
       {{- end}}
 kind: ConfigMap
 metadata:
@@ -161,8 +162,14 @@ spec:
         name: quick-start-control-plane
       serverConfig:
         cni: calico
+        kubeAPIServer:
+          extraArgs:
+          - --anonymous-auth=true
         disableComponents:
-          kubernetesComponents: ["cloudController"]
+          pluginComponents:
+          - rke2-ingress-nginx
+          kubernetesComponents:
+          - cloudController
       rolloutStrategy:
         type: "RollingUpdate"
         rollingUpdate:

--- a/tests/assets/rancher-turtles-fleet-example/rke2_namespace_autoimport/clusters/cluster1.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/rke2_namespace_autoimport/clusters/cluster1.yaml
@@ -58,7 +58,13 @@ spec:
       maxSurge: 1
     type: RollingUpdate
   serverConfig:
+    cni: calico
+    kubeAPIServer:
+      extraArgs:
+      - --anonymous-auth=true
     disableComponents:
+      pluginComponents:
+      - rke2-ingress-nginx
       kubernetesComponents:
       - cloudController
   infrastructureRef:
@@ -138,10 +144,12 @@ data:
       default-server init-addr none
 
     frontend stats
+      mode http
       bind *:8404
       stats enable
-      stats uri /
+      stats uri /stats
       stats refresh 10s
+      stats admin if TRUE
 
     frontend control-plane
       bind *:{{ .FrontendControlPlanePort }}
@@ -152,11 +160,10 @@ data:
 
     backend kube-apiservers
       option httpchk GET /healthz
-      http-check expect status 401
-      # TODO: we should be verifying (!)
-      {{range $server, $address := .BackendServers}}
-      server {{ $server }} {{ JoinHostPort $address $.BackendControlPlanePort }} check check-ssl verify none resolvers docker resolve-prefer {{ if $.IPv6 -}} ipv6 {{- else -}} ipv4 {{- end }}
-      {{- end}}
+
+      {{range $server, $backend := .BackendServers }}
+      server {{ $server }} {{ JoinHostPort $backend.Address $.BackendControlPlanePort }} check check-ssl verify none resolvers docker resolve-prefer {{ if $.IPv6 -}} ipv6 {{- else -}} ipv4 {{- end }}
+      {{- end }}
 
     frontend rke2-join
       bind *:9345
@@ -168,8 +175,8 @@ data:
     backend rke2-servers
       option httpchk GET /v1-rke2/readyz
       http-check expect status 403
-      {{range $server, $address := .BackendServers}}
-      server {{ $server }} {{ $address }}:9345 check check-ssl verify none
+      {{range $server, $backend := .BackendServers }}
+      server {{ $server }} {{ $backend.Address }}:9345 check check-ssl verify none
       {{- end}}
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
### What does this PR do?
Makes capd rke2 tests work on capi/capd 1.9+

Related code: `https://github.com/rancher/turtles/pull/961/files#diff-2ec716dc6284543a12fd427cc46b7efff72a43e217b473209caf237e59902eb2`

WARNING: It is not backward compatible so it won't work with released/stable turtles v0.15.0

Both cases for clusterclass and standalone cluster tested locally only:
![image](https://github.com/user-attachments/assets/ba9c5c83-fe3a-417d-8fef-522b1d53cffb)

![image](https://github.com/user-attachments/assets/9114a88c-0fe2-4029-9ece-dc478247c90e)

