### PR TITLE
Enable Agent TLS mode when installing turtles

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/turtles_operator.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/turtles_operator.spec.ts
@@ -43,33 +43,10 @@ describe('Install Turtles Operator', { tags: '@install' }, () => {
 
       // Used for enabling fleet-addon feature within Rancher Turtles installation
       const questions = [
-        { menuEntry: 'Rancher Turtles Features Settings', checkbox: 'Seamless integration with Fleet and CAPI' }
+        { menuEntry: 'Rancher Turtles Features Settings', checkbox: 'Seamless integration with Fleet and CAPI' },
+        { menuEntry: 'Rancher Turtles Features Settings', checkbox: 'Enable Agent TLS Mode' }
       ];
       cy.installApp('Rancher Turtles', 'rancher-turtles-system', questions);
     })
   );
-
-  it('Turtles prerequisites', () => {
-
-    // Open Rancher turtles deployment
-    cy.contains('local')
-      .click();
-    cy.get('.nav').contains('Workloads')
-      .click();
-    cy.get('.nav').contains('Deployments')
-      .click();
-    cy.setNamespace('rancher-turtles-system');
-
-    // Edit Rancher turtles deployment
-    cy.typeInFilter(deployment);
-    cy.getBySel('sortable-table-0-action-button').click();
-    cy.contains('Edit Config')
-      .click();
-    cy.byLabel('Arguments').as('label')
-    cy.get('@label').type(' --insecure-skip-verify=true')
-    cy.clickButton('Save');
-    cy.contains(new RegExp('Active.*' + deployment));
-    cy.namespaceReset();
-  })
-
 });


### PR DESCRIPTION
### What does this PR do?

Toggle new feature for enabling Agent tls mode when installing turtles over questions.yaml dialog. Replaces `--insecure-skip-verify=true` flag in the controller deployment.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [ ] GitHub Actions (if applicable) TBD (waiting for the feature code merge)

### Special notes for your reviewer:
