### PR TITLE
Update caapf enablement

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/turtles_operator.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/turtles_operator.spec.ts
@@ -57,7 +57,6 @@ describe('Install Turtles Operator', { tags: '@install' }, () => {
 
       // Used for enabling fleet-addon feature within Rancher Turtles installation
       const questions = [
-        { menuEntry: 'Rancher Turtles Features Settings', checkbox: 'Seamless integration with Fleet and CAPI' },
         { menuEntry: 'Rancher Turtles Features Settings', checkbox: 'Enable Agent TLS Mode' }
       ];
 


### PR DESCRIPTION
### What does this PR do?
Fleet-addon is now enabled by default while installation. Ref: turtles/pull/1004

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes - Nightly CI

### Checklist:
- [x] GitHub Actions:
https://github.com/rancher/rancher-turtles-e2e/actions/runs/12804611944
