### PR TITLE
Report Turtles and CAPI UI versions

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -386,11 +386,13 @@ jobs:
           echo "Rancher Manager Image: ${{ steps.component.outputs.rm_version }}" >> ${GITHUB_STEP_SUMMARY}
           echo "Rancher Manager Version: ${{ inputs.rancher_version }}" >> ${GITHUB_STEP_SUMMARY}
           echo "CertManager Image: ${{ steps.component.outputs.cert_manager_version }}" >> ${GITHUB_STEP_SUMMARY}
-          echo "CAPI UI Extension Version: ${{ inputs.capi_ui_version }}" >> ${GITHUB_STEP_SUMMARY}
+          UI_VERSION=$(helm list -n cattle-ui-plugin-system -o json 2> /dev/null |  jq -r '.[] | .chart')
+          TURTLES_VERSION=$(helm list -n rancher-turtles-system -o json 2> /dev/null | jq -r '.[] | .chart')
+          echo "CAPI UI Extension Version: $UI_VERSION" >> ${GITHUB_STEP_SUMMARY}
+          echo "Rancher Turtles Operator Version: $TURTLES_VERSION" >> ${GITHUB_STEP_SUMMARY}
           if ${{ inputs.ui_account != '' }}; then
             echo "UI User: ${{ inputs.ui_account }}" >> ${GITHUB_STEP_SUMMARY}
           fi
-          echo "Rancher Turtles Operator Version: ${{ inputs.turtles_operator_version }}" >> ${GITHUB_STEP_SUMMARY}
           echo "### Kubernetes" >> ${GITHUB_STEP_SUMMARY}
           echo "K3s on Rancher Manager: ${{ env.INSTALL_K3S_VERSION }}" >> ${GITHUB_STEP_SUMMARY}
 


### PR DESCRIPTION
### What does this PR do?

Better turtles + ui version reporting in gh run summary

nightly: https://github.com/rancher/rancher-turtles-e2e/actions/runs/13048493540
![image](https://github.com/user-attachments/assets/4ed391e1-5e62-4423-b91a-844c17aaa4aa)

stable: https://github.com/rancher/rancher-turtles-e2e/actions/runs/13048498019
![image](https://github.com/user-attachments/assets/28676774-2ae7-4c65-9c2e-eb4defc7b1e9)

~I also removed `capi_ui_version` variable and related function which is not in use and I don't see any use case for that.~

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions (if applicable) `@short nightly`: ~https://github.com/rancher/rancher-turtles-e2e/actions/runs/13049223609/job/36405608589~
* `@short stable` https://github.com/rancher/rancher-turtles-e2e/actions/runs/13052850388
