### PR TITLE
Different versions of fleet provider for nightly and stable

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/providers_setup.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/providers_setup.spec.ts
@@ -90,9 +90,7 @@ describe('Enable CAPI Providers', () => {
       cy.checkCAPIMenu();
       cy.contains('Providers').click();
       var statusReady = 'Ready'
-      // In nightly builds, the fleet version is v0.5.0
-      const fleetVersion = Cypress.env('chartmuseum_repo') !== '' ? 'v0.5.0' : 'v0.4.0';
-      statusReady = statusReady.concat(fleetProvider, 'addon', fleetProvider, fleetVersion);
+      statusReady = statusReady.concat(fleetProvider, 'addon', fleetProvider, 'v0.5.0');
       cy.contains(statusReady).scrollIntoView();
     });
   });

--- a/tests/cypress/latest/e2e/unit_tests/providers_setup.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/providers_setup.spec.ts
@@ -90,7 +90,9 @@ describe('Enable CAPI Providers', () => {
       cy.checkCAPIMenu();
       cy.contains('Providers').click();
       var statusReady = 'Ready'
-      statusReady = statusReady.concat(fleetProvider, 'addon', fleetProvider, 'v0.4.0')
+      // In nightly builds, the fleet version is v0.5.0
+      const fleetVersion = Cypress.env('chartmuseum_repo') !== '' ? 'v0.5.0' : 'v0.4.0';
+      statusReady = statusReady.concat(fleetProvider, 'addon', fleetProvider, fleetVersion);
       cy.contains(statusReady).scrollIntoView();
     });
   });

--- a/tests/cypress/latest/e2e/unit_tests/turtles_operator.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/turtles_operator.spec.ts
@@ -42,7 +42,7 @@ describe('Install Turtles Operator', { tags: '@install' }, () => {
   it('Add turtles repo', { retries: 2 }, () => {
     var turtlesHelmRepo = Cypress.env('chartmuseum_repo')
     // if the env var is empty or not defined at all; use the normal repo
-    if (turtlesHelmRepo == "" || turtlesHelmRepo == undefined) {
+    if (turtlesHelmRepo == '') {
       turtlesHelmRepo = 'https://rancher.github.io/turtles/'
     } else {
       turtlesHelmRepo += ':8080'

--- a/tests/cypress/latest/plugins/index.ts
+++ b/tests/cypress/latest/plugins/index.ts
@@ -31,7 +31,7 @@ module.exports = (on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions)
 
   config.baseUrl = url.replace(/\/$/,);
   config.env.cache_session = process.env.CACHE_SESSION || false;
-  config.env.chartmuseum_repo = process.env.CHARTMUSEUM_REPO;
+  config.env.chartmuseum_repo = process.env.CHARTMUSEUM_REPO || '';
   config.env.turtles_operator_version = process.env.TURTLES_OPERATOR_VERSION;
   config.env.cluster = process.env.CLUSTER_NAME;
   config.env.capi_ui_version = process.env.CAPI_UI_VERSION;


### PR DESCRIPTION
### What does this PR do?

~Use different versions of the fleet provider for nightly and stable runs. The version is determined by the presence of the `chartmuseum_repo` string, which indicates a nightly build.~

Reverting back to hardcoded version approach as the nightly and stable versions are in sync now.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [ ] GitHub Actions (if applicable)
~* https://github.com/rancher/rancher-turtles-e2e/actions/runs/13049910755 nightly~
~* https://github.com/rancher/rancher-turtles-e2e/actions/runs/13049924421 stable~
* (hardcoded) nightly=false https://github.com/rancher/rancher-turtles-e2e/actions/runs/13051155539

### Special notes for your reviewer:
