### PR TITLE
Add checks for fleet-addon provider

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/capd_kubeadm_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capd_kubeadm_cluster.spec.ts
@@ -76,6 +76,35 @@ describe('Import CAPD Kubeadm', { tags: '@short' }, () => {
       })
     );
 
+    // fleet-addon provider checks (for rancher dev/2.10.3 and up)
+    if (path.includes('clusterclass_autoimport')) {
+      qase(42,
+        it('Check if cluster is registered in Fleet only once', () => {
+          cypressLib.accesMenu('Continuous Delivery');
+          cy.contains('Dashboard').should('be.visible');
+          cypressLib.accesMenu('Clusters');
+          cy.fleetNamespaceToggle('fleet-default');
+          // Verify the cluster is registered and Active
+          cy.verifyTableRow(0, 'Active', clusterName );
+          // Make sure there is only one registered cluster in fleet (there should be one table row)
+          cy.get('table.sortable-table').find('tbody tr').should('have.length', 1);
+        })
+      )
+      qase(43,
+        it('Check if annotation for externally-managed cluster is set', () => {
+          cy.searchCluster(clusterName)
+          // click three dots menu and click View YAML
+          cy.getBySel('sortable-table-0-action-button').click();
+          cy.contains('View YAML').click();
+          const annotation = 'provisioning.cattle.io/externally-managed: \'true\'';
+          cy.get('.CodeMirror').then((editor) => {
+            var text = editor[0].CodeMirror.getValue();
+            expect(text).to.include(annotation);
+          });
+        })
+      )
+    }
+
     // TODO: Refactor for other paths
     if (path.includes('namespace_autoimport')) {
       qase(7,

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -428,3 +428,43 @@ Cypress.Commands.add('checkFleetGitRepo', (repoName, workspace) => {
   cy.contains(repoName).click();
   cy.url().should("include", "fleet/fleet.cattle.io.gitrepo/" + workspace + "/" + repoName)
 })
+
+// Fleet namespace toggle
+Cypress.Commands.add('fleetNamespaceToggle', (toggleOption='local') => {
+  cy.contains('fleet-').click();
+  cy.contains(toggleOption).should('be.visible').click();
+});
+
+
+// Verify textvalues in table giving the row number
+// More items can be added with new ".and"
+Cypress.Commands.add('verifyTableRow', (rowNumber, expectedText1, expectedText2) => {
+  // Adding small wait to give time for things to settle a bit
+  // Could not find a better way to wait, but can be improved
+  cy.wait(1000)
+  // Ensure table is loaded and visible
+  cy.contains('tr.main-row[data-testid="sortable-table-0-row"]').should('not.be.empty', { timeout: 25000 });
+  cy.get(`table > tbody > tr.main-row[data-testid="sortable-table-${rowNumber}-row"]`, { timeout: 60000 }).should(($row) => {
+    // Replace whitespaces by a space and trim the string for both expected texts
+    const text = $row.text().replace(/\s+/g, ' ').trim();
+
+    // Check if expectedTextX is a regular expression or a string and perform the assertion
+    if (expectedText1) {
+      // If expectedText1 is provided, perform the check
+      if (expectedText1 instanceof RegExp) {
+        expect(text).to.match(expectedText1);
+      } else {
+        expect(text).to.include(expectedText1);
+      }
+    }
+
+    if (expectedText2) {
+      // If expectedText2 is provided, perform the check
+      if (expectedText2 instanceof RegExp) {
+        expect(text).to.match(expectedText2);
+      } else {
+        expect(text).to.include(expectedText2);
+      }
+    }
+  });
+});

--- a/tests/cypress/latest/support/e2e.ts
+++ b/tests/cypress/latest/support/e2e.ts
@@ -25,6 +25,8 @@ declare global {
       removeFleetGitRepo(repoName: string, noRepoCheck?: boolean, workspace?: string): Chainable<Element>;
       forceUpdateFleetGitRepo(repoName: string, workspace?: string): Chainable<Element>;
       checkFleetGitRepo(repoName: string, workspace?: string): Chainable<Element>;
+      fleetNamespaceToggle(toggleOption: string): Chainable<Element>;
+      verifyTableRow(rowNumber: number, expectedText1?: string|RegExp, expectedText2?: string|RegExp): Chainable<Element>;
       accesMenuSelection(firstAccessMenu: string, secondAccessMenu?: string): Chainable<Element>;
       checkChart(operation: string, chartName: string, namespace: string, version?: string, questions?: any): Chainable<Element>;
       deleteCluster(clusterName: string): Chainable<Element>;


### PR DESCRIPTION
### What does this PR do?
ref. https://github.com/rancher/rancher-turtles-e2e/issues/111

borrowed few lines from fleet-e2e, 2 new caapf tests implemented, qase cases were created as RT-42 and RT-43

* checks whether the capi cluster is registered only once under CD/Fleet/Clusters
* check whether v3 annotation for externally-provisioned cluster is set in Cluster management/Clusters

The annotation should be automatically added into clusters provisioned by upcoming R 2.10.3 or 2.10-head via dev turtles.

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions (if applicable) https://github.com/rancher/rancher-turtles-e2e/actions/runs/13332216886

### Special notes for your reviewer:
