### PR TITLE
Do not set hostNetwork in fleet-addon-config

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/providers_setup.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/providers_setup.spec.ts
@@ -80,7 +80,7 @@ describe('Enable CAPI Providers', () => {
       const resourceKind = 'configMap';
       const resourceName = 'fleet-addon-config';
       const namespace = 'rancher-turtles-system';
-      const patch = { data: { manifests: { isNestedIn: true, spec: { cluster: { hostNetwork: true, selector: { matchLabels: { cni: 'by-fleet-addon-kindnet' } } } } } } };
+      const patch = { data: { manifests: { isNestedIn: true, spec: { cluster: { selector: { matchLabels: { cni: 'by-fleet-addon-kindnet' } } } } } } };
 
       cy.patchYamlResource(clusterName, namespace, resourceKind, resourceName, patch);
     });

--- a/tests/cypress/latest/e2e/unit_tests/providers_setup.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/providers_setup.spec.ts
@@ -74,7 +74,6 @@ describe('Enable CAPI Providers', () => {
 
     it('Custom Fleet addon config', () => {
       // Allows Fleet addon to be installed on specific clusters only
-      // Enables hostNetwork for Fleet addon
 
       const clusterName = 'local';
       const resourceKind = 'configMap';


### PR DESCRIPTION
### What does this PR do?
Configuration for fleet-agent to use `hostNetwork` is not needed anymore as it become default.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes https://github.com/rancher/rancher-turtles-e2e/issues/101

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions (if applicable) https://github.com/rancher/rancher-turtles-e2e/actions/runs/13414777101


