### PR TITLE
Refresh repos before installing App

### DIFF
--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -329,6 +329,11 @@ Cypress.Commands.add('addRepository', (repositoryName: string, repositoryURL: st
 Cypress.Commands.add('checkChart', (operation, chartName, namespace, version, questions) => {
   cy.get('.nav').contains('Apps').click();
   cy.contains('Featured Charts').should('be.visible');
+
+  // Refresh existing Repositories
+  cy.get('.icon.icon-lg.icon-refresh').click();
+  cy.get('.icon.icon-lg.icon-checkmark', { timeout: 60000 }).should('be.visible');
+
   cy.contains(chartName, { timeout: 60000 }).click();
   cy.contains('Charts: ' + chartName);
 


### PR DESCRIPTION
### What does this PR do?
Sometimes happens that no Application is displayed on `Featured Chart` page, esp. on vsphere clusters (maybe due to its geo location?) so the entire test is failing on installing `Monitoring` app. This PR should resolve that by refreshing all existing app repos prior installing.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #124 

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions (if applicable) https://github.com/rancher/rancher-turtles-e2e/actions/runs/13700030722 (passed twice in a row)

### Special notes for your reviewer:
