### PR TITLE
Use ubuntu-latest for independent steps

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -211,8 +211,7 @@ jobs:
           fi
 
   pre-qase:
-    needs: determine-runner
-    runs-on: ${{ needs.determine-runner.outputs.initial-runner }}
+    runs-on: ubuntu-latest
     env:
       QASE_API_TOKEN: ${{ secrets.QASE_API_TOKEN }}
       QASE_PROJECT_CODE: RT
@@ -484,8 +483,8 @@ jobs:
 
   post-qase:
     if: ${{ always() && needs.pre-qase.outputs.qase_run_id != '' }}
-    needs: [determine-runner, e2e, pre-qase]
-    runs-on: ${{ needs.determine-runner.outputs.initial-runner }}
+    needs: [e2e, pre-qase]
+    runs-on: ubuntu-latest
     env:
       QASE_API_TOKEN: ${{ secrets.qase_api_token }}
       QASE_PROJECT_CODE: RT
@@ -520,8 +519,8 @@ jobs:
   # Just to signify that something has been cancelled and it's not useful to check the test
   declare-cancelled:
     if: ${{ always() && contains(needs.e2e.result, 'cancelled') }}
-    needs: [create-runner, e2e]
-    runs-on: ${{ needs.create-runner.outputs.uuid }}
+    needs: e2e
+    runs-on: ubuntu-latest
     steps:
       - name: Specify in summary if something has been cancelled
         run: echo "# TEST CANCELLED!" >> ${GITHUB_STEP_SUMMARY}


### PR DESCRIPTION
### What does this PR do?
using `ubuntu-latest` runners for `post/pre-qase` and `declare-canceled` jobs to simplify

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #127 

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [ ] GitHub Actions (if applicable) vsphere:
* vsphere (qase_id=auto and cancelled) https://github.com/rancher/rancher-turtles-e2e/actions/runs/13718061397
* short (qase_id=auto and cancelled) https://github.com/rancher/rancher-turtles-e2e/actions/runs/13718038999

### Special notes for your reviewer:
for deleting qase_run_id after cancel in qase we probably don't have needed permissions:
![image](https://github.com/user-attachments/assets/9606b369-248b-4f44-bf4c-1cb67369f735)

