### PR TITLE
Add option not to delete cluster for Cloud Providers

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -110,6 +110,9 @@ on:
       turtles_operator_version:
         description: Turtles Operator Version; only to be used when dev chart is set to false; default - latest stable version
         type: string
+      skip_deletion_test:
+        description: Skip deletion tests to retain the clusters
+        type: boolean
 
 jobs:
   determine-runner:
@@ -390,6 +393,7 @@ jobs:
           QASE_RUN_ID: ${{ needs.pre-qase.outputs.qase_run_id }}
           GREPTAGS: ${{ inputs.grep_test_by_tag }}
           TURTLES_OPERATOR_VERSION: ${{inputs.turtles_operator_version}}
+          SKIP_DELETION_TEST: ${{ inputs.skip_deletion_test }}
           SPEC: |
             e2e/unit_tests/first_connection.spec.ts
             e2e/unit_tests/turtles_operator.spec.ts

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -110,8 +110,8 @@ on:
       turtles_operator_version:
         description: Turtles Operator Version; only to be used when dev chart is set to false; default - latest stable version
         type: string
-      skip_deletion_test:
-        description: Skip deletion tests to retain the clusters
+      skip_cluster_delete:
+        description: Skip CAPI cluster and fleet repo deletion tests
         type: boolean
 
 jobs:
@@ -393,7 +393,7 @@ jobs:
           QASE_RUN_ID: ${{ needs.pre-qase.outputs.qase_run_id }}
           GREPTAGS: ${{ inputs.grep_test_by_tag }}
           TURTLES_OPERATOR_VERSION: ${{inputs.turtles_operator_version}}
-          SKIP_DELETION_TEST: ${{ inputs.skip_deletion_test }}
+          SKIP_CLUSTER_DELETE: ${{ inputs.skip_cluster_delete }}
           SPEC: |
             e2e/unit_tests/first_connection.spec.ts
             e2e/unit_tests/turtles_operator.spec.ts

--- a/.github/workflows/ui-e2e.yaml
+++ b/.github/workflows/ui-e2e.yaml
@@ -28,7 +28,7 @@ on:
         description: Version of the capi-ui-extension to test (eg. 0.8.1)
         type: string
       grep_test_by_tag:
-        description: Test tags. For multiple selection separate with spaces. Keep always @install
+        description: Test tags. For multiple selection separate with spaces (Available options - @install, @short, @full, @vsphere). Keep always @install
         required: true
         type: string
         default: '@install @short'

--- a/.github/workflows/ui-e2e.yaml
+++ b/.github/workflows/ui-e2e.yaml
@@ -28,7 +28,7 @@ on:
         description: Version of the capi-ui-extension to test (eg. 0.8.1)
         type: string
       grep_test_by_tag:
-        description: Test tags. For multiple selection separate with spaces (Available options - @install, @short, @full, @vsphere). Keep always @install
+        description: Test tags. For multiple selection separate with spaces (Available options - @install [@short @full|@vsphere]). Keep always @install
         required: true
         type: string
         default: '@install @short'
@@ -40,8 +40,8 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      skip_deletion_test:
-        description: Skip Deletion tests to retain the clusters
+      skip_cluster_delete:
+        description: Skip CAPI cluster and fleet repo deletion tests
         default: false
         type: boolean
   schedule:
@@ -75,4 +75,4 @@ jobs:
       grep_test_by_tag: ${{ inputs.grep_test_by_tag || (github.event.schedule == '0 3 * * *' && '@install @short') || (github.event.schedule == '0 4 * * *' && '@install @vsphere') }}
       operator_dev_chart: ${{ inputs.operator_dev_chart == true || (github.event_name == 'schedule' && true) }}
       turtles_operator_version: ${{ inputs.turtles_operator_version }}
-      skip_deletion_test: ${{ inputs.skip_deletion_test }}
+      skip_cluster_delete: ${{ inputs.skip_cluster_delete }}

--- a/.github/workflows/ui-e2e.yaml
+++ b/.github/workflows/ui-e2e.yaml
@@ -40,6 +40,10 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
+      skip_deletion_test:
+        description: Skip Deletion tests to retain the clusters
+        default: false
+        type: boolean
   schedule:
     - cron: '0 3 * * *'
     - cron: '0 4 * * *'
@@ -71,3 +75,4 @@ jobs:
       grep_test_by_tag: ${{ inputs.grep_test_by_tag || (github.event.schedule == '0 3 * * *' && '@install @short') || (github.event.schedule == '0 4 * * *' && '@install @vsphere') }}
       operator_dev_chart: ${{ inputs.operator_dev_chart == true || (github.event_name == 'schedule' && true) }}
       turtles_operator_version: ${{ inputs.turtles_operator_version }}
+      skip_deletion_test: ${{ inputs.skip_deletion_test }}

--- a/tests/cypress/latest/e2e/unit_tests/capa_eks_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capa_eks_cluster.spec.ts
@@ -1,6 +1,7 @@
 import '~/support/commands';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
+import { skipDeletionTest } from '~/support/utils';
 
 Cypress.config();
 describe('Import CAPA EKS', { tags: '@full' }, () => {
@@ -62,28 +63,29 @@ describe('Import CAPA EKS', { tags: '@full' }, () => {
     })
   );
 
-  qase(15,
-    it('Remove imported CAPA cluster from Rancher Manager', { retries: 1 }, () => {
+  if (!skipDeletionTest) {
+    qase(15,
+      it('Remove imported CAPA cluster from Rancher Manager', { retries: 1 }, () => {
 
-      // Check cluster is not deleted after removal
-      cy.deleteCluster(clusterName);
-      cy.goToHome();
-      // kubectl get clusters.cluster.x-k8s.io
-      // This is checked by ensuring the cluster is not available in navigation menu
-      cy.contains(clusterName).should('not.exist');
-      cy.checkCAPIClusterProvisioned(clusterName);
-    })
-  );
+        // Check cluster is not deleted after removal
+        cy.deleteCluster(clusterName);
+        cy.goToHome();
+        // kubectl get clusters.cluster.x-k8s.io
+        // This is checked by ensuring the cluster is not available in navigation menu
+        cy.contains(clusterName).should('not.exist');
+        cy.checkCAPIClusterProvisioned(clusterName);
+      })
+    );
 
-  qase(16,
-    it('Delete the CAPA cluster fleet repo', () => {
+    qase(16,
+      it('Delete the CAPA cluster fleet repo', () => {
 
-      // Remove the fleet git repo
-      cy.removeFleetGitRepo(repoName, true);
-      // Wait until the following returns no clusters found
-      // This is checked by ensuring the cluster is not available in CAPI menu
-      cy.checkCAPIClusterDeleted(clusterName, timeout);
-    })
-  );
-
+        // Remove the fleet git repo
+        cy.removeFleetGitRepo(repoName, true);
+        // Wait until the following returns no clusters found
+        // This is checked by ensuring the cluster is not available in CAPI menu
+        cy.checkCAPIClusterDeleted(clusterName, timeout);
+      })
+    );
+  }
 });

--- a/tests/cypress/latest/e2e/unit_tests/capa_rke2_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capa_rke2_cluster.spec.ts
@@ -1,6 +1,7 @@
 import '~/support/commands';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
+import { skipDeletionTest } from '~/support/utils';
 
 Cypress.config();
 describe('Import CAPA RKE2', { tags: '@full' }, () => {
@@ -62,25 +63,27 @@ describe('Import CAPA RKE2', { tags: '@full' }, () => {
     })
   );
 
-  qase(15,
-    it('Remove imported CAPA cluster from Rancher Manager', { retries: 1 }, () => {
-      // Check cluster is not deleted after removal
-      cy.deleteCluster(clusterName);
-      cy.goToHome();
-      // kubectl get clusters.cluster.x-k8s.io
-      // This is checked by ensuring the cluster is not available in navigation menu
-      cy.contains(clusterName).should('not.exist');
-      cy.checkCAPIClusterProvisioned(clusterName);
-    })
-  );
+  if (!skipDeletionTest) {
+    qase(15,
+      it('Remove imported CAPA cluster from Rancher Manager', { retries: 1 }, () => {
+        // Check cluster is not deleted after removal
+        cy.deleteCluster(clusterName);
+        cy.goToHome();
+        // kubectl get clusters.cluster.x-k8s.io
+        // This is checked by ensuring the cluster is not available in navigation menu
+        cy.contains(clusterName).should('not.exist');
+        cy.checkCAPIClusterProvisioned(clusterName);
+      })
+    );
 
-  qase(16,
-    it('Delete the CAPA cluster fleet repo', () => {
-      // Remove the fleet git repo
-      cy.removeFleetGitRepo(repoName, true);
-      // Wait until the following returns no clusters found
-      // This is checked by ensuring the cluster is not available in CAPI menu
-      cy.checkCAPIClusterDeleted(clusterName, timeout);
-    })
-  );
+    qase(16,
+      it('Delete the CAPA cluster fleet repo', () => {
+        // Remove the fleet git repo
+        cy.removeFleetGitRepo(repoName, true);
+        // Wait until the following returns no clusters found
+        // This is checked by ensuring the cluster is not available in CAPI menu
+        cy.checkCAPIClusterDeleted(clusterName, timeout);
+      })
+    );
+  }
 });

--- a/tests/cypress/latest/e2e/unit_tests/capd_clusterclass_ui_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capd_clusterclass_ui_cluster.spec.ts
@@ -14,6 +14,7 @@ limitations under the License.
 import '~/support/commands';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
+import { skipDeletionTest } from '~/support/utils';
 
 Cypress.config();
 describe('Create CAPD', { tags: '@short' }, () => {
@@ -82,31 +83,31 @@ describe('Create CAPD', { tags: '@short' }, () => {
       cy.checkChart('Install', 'Monitoring', 'cattle-monitoring');
     })
 
-    it('Remove CAPD cluster from Rancher Manager', { retries: 1 }, () => {
-      // Check cluster is not deleted after removal
-      cy.deleteCluster(clusterName);
-      cy.goToHome();
-      // kubectl get clusters.cluster.x-k8s.io
-      // This is checked by ensuring the cluster is not available in navigation menu
-      cy.contains(clusterName).should('not.exist');
-      cy.checkCAPIClusterProvisioned(clusterName);
-    })
-
-
-    it('Delete the CAPI cluster and fleet repo', () => {
-      cy.removeCAPIResource('Clusters', clusterName, timeout);
-
-      // Remove the classes fleet repo
-      cypressLib.burgerMenuToggle();
-      cy.removeFleetGitRepo(classesRepo, true);
-          
-      // Ensure the cluster is not available in navigation menu
-      cy.getBySel('side-menu').then(($menu) => {
-        if ($menu.text().includes(clusterName)) {
-          cy.deleteCluster(clusterName);
-        }
+    if (!skipDeletionTest) {
+      it('Remove CAPD cluster from Rancher Manager', { retries: 1 }, () => {
+        // Check cluster is not deleted after removal
+        cy.deleteCluster(clusterName);
+        cy.goToHome();
+        // kubectl get clusters.cluster.x-k8s.io
+        // This is checked by ensuring the cluster is not available in navigation menu
+        cy.contains(clusterName).should('not.exist');
+        cy.checkCAPIClusterProvisioned(clusterName);
       })
-    })
 
+      it('Delete the CAPI cluster and fleet repo', () => {
+        cy.removeCAPIResource('Clusters', clusterName, timeout);
+
+        // Remove the classes fleet repo
+        cypressLib.burgerMenuToggle();
+        cy.removeFleetGitRepo(classesRepo, true);
+
+        // Ensure the cluster is not available in navigation menu
+        cy.getBySel('side-menu').then(($menu) => {
+          if ($menu.text().includes(clusterName)) {
+            cy.deleteCluster(clusterName);
+          }
+        })
+      })
+    }
   })
 });

--- a/tests/cypress/latest/e2e/unit_tests/capd_clusterclass_ui_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capd_clusterclass_ui_cluster.spec.ts
@@ -83,31 +83,30 @@ describe('Create CAPD', { tags: '@short' }, () => {
       cy.checkChart('Install', 'Monitoring', 'cattle-monitoring');
     })
 
-    if (!skipDeletionTest) {
-      it('Remove CAPD cluster from Rancher Manager', { retries: 1 }, () => {
-        // Check cluster is not deleted after removal
-        cy.deleteCluster(clusterName);
-        cy.goToHome();
-        // kubectl get clusters.cluster.x-k8s.io
-        // This is checked by ensuring the cluster is not available in navigation menu
-        cy.contains(clusterName).should('not.exist');
-        cy.checkCAPIClusterProvisioned(clusterName);
+    it('Remove CAPD cluster from Rancher Manager', { retries: 1 }, () => {
+      // Check cluster is not deleted after removal
+      cy.deleteCluster(clusterName);
+      cy.goToHome();
+      // kubectl get clusters.cluster.x-k8s.io
+      // This is checked by ensuring the cluster is not available in navigation menu
+      cy.contains(clusterName).should('not.exist');
+      cy.checkCAPIClusterProvisioned(clusterName);
+    })
+
+    it('Delete the CAPI cluster and fleet repo', () => {
+      cy.removeCAPIResource('Clusters', clusterName, timeout);
+
+      // Remove the classes fleet repo
+      cypressLib.burgerMenuToggle();
+      cy.removeFleetGitRepo(classesRepo, true);
+
+      // Ensure the cluster is not available in navigation menu
+      cy.getBySel('side-menu').then(($menu) => {
+        if ($menu.text().includes(clusterName)) {
+          cy.deleteCluster(clusterName);
+        }
       })
+    })
 
-      it('Delete the CAPI cluster and fleet repo', () => {
-        cy.removeCAPIResource('Clusters', clusterName, timeout);
-
-        // Remove the classes fleet repo
-        cypressLib.burgerMenuToggle();
-        cy.removeFleetGitRepo(classesRepo, true);
-
-        // Ensure the cluster is not available in navigation menu
-        cy.getBySel('side-menu').then(($menu) => {
-          if ($menu.text().includes(clusterName)) {
-            cy.deleteCluster(clusterName);
-          }
-        })
-      })
-    }
   })
 });

--- a/tests/cypress/latest/e2e/unit_tests/capd_kubeadm_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capd_kubeadm_cluster.spec.ts
@@ -140,52 +140,50 @@ describe('Import CAPD Kubeadm', { tags: '@short' }, () => {
       );
     }
 
-    if (!skipDeletionTest) {
-      qase(9,
-        it('Remove imported CAPD cluster from Rancher Manager', { retries: 1 }, () => {
-          // Check cluster is not deleted after removal
-          cy.deleteCluster(clusterName);
-          cy.goToHome();
-          // kubectl get clusters.cluster.x-k8s.io
-          // This is checked by ensuring the cluster is not available in navigation menu
-          cy.contains(clusterName).should('not.exist');
-          cy.checkCAPIClusterProvisioned(clusterName);
-        })
-      );
+    qase(9,
+      it('Remove imported CAPD cluster from Rancher Manager', { retries: 1 }, () => {
+        // Check cluster is not deleted after removal
+        cy.deleteCluster(clusterName);
+        cy.goToHome();
+        // kubectl get clusters.cluster.x-k8s.io
+        // This is checked by ensuring the cluster is not available in navigation menu
+        cy.contains(clusterName).should('not.exist');
+        cy.checkCAPIClusterProvisioned(clusterName);
+      })
+    );
 
-      qase(10,
-        it('Delete the CAPD cluster fleet repo(s) - ' + path, () => {
-          if (path.includes('clusterclass')) {
-            // Remove the cni fleet repo from fleet-default workspace
-            cy.removeFleetGitRepo('clusterclass-cni', true, 'fleet-default');
-            // Remove the classes fleet repo
-            cypressLib.burgerMenuToggle();
-            cy.removeFleetGitRepo(classesRepo, true);
-            // Remove the clusters fleet repo
-            cypressLib.burgerMenuToggle();
-            cy.removeFleetGitRepo(clustersRepo);
+    qase(10,
+      it('Delete the CAPD cluster fleet repo(s) - ' + path, () => {
+        if (path.includes('clusterclass')) {
+          // Remove the cni fleet repo from fleet-default workspace
+          cy.removeFleetGitRepo('clusterclass-cni', true, 'fleet-default');
+          // Remove the classes fleet repo
+          cypressLib.burgerMenuToggle();
+          cy.removeFleetGitRepo(classesRepo, true);
+          // Remove the clusters fleet repo
+          cypressLib.burgerMenuToggle();
+          cy.removeFleetGitRepo(clustersRepo);
 
-            // Wait until the following returns no clusters found
-            cy.checkCAPIClusterDeleted(clusterName, timeout);
-            // Remove the clusterclass
-            cy.removeCAPIResource('Cluster Classes', className);
-          } else {
-            // Remove the clusters fleet repo
-            cy.removeFleetGitRepo(clustersRepo);
+          // Wait until the following returns no clusters found
+          cy.checkCAPIClusterDeleted(clusterName, timeout);
+          // Remove the clusterclass
+          cy.removeCAPIResource('Cluster Classes', className);
+        } else {
+          // Remove the clusters fleet repo
+          cy.removeFleetGitRepo(clustersRepo);
 
-            // Wait until the following returns no clusters found
-            // This is checked by ensuring the cluster is not available in CAPI menu
-            cy.checkCAPIClusterDeleted(clusterName, timeout);
+          // Wait until the following returns no clusters found
+          // This is checked by ensuring the cluster is not available in CAPI menu
+          cy.checkCAPIClusterDeleted(clusterName, timeout);
+        }
+
+        // Ensure the cluster is not available in navigation menu
+        cy.getBySel('side-menu').then(($menu) => {
+          if ($menu.text().includes(clusterName)) {
+            cy.deleteCluster(clusterName);
           }
-
-          // Ensure the cluster is not available in navigation menu
-          cy.getBySel('side-menu').then(($menu) => {
-            if ($menu.text().includes(clusterName)) {
-              cy.deleteCluster(clusterName);
-            }
-          })
         })
-      );
-    }
+      })
+    );
   })
 });

--- a/tests/cypress/latest/e2e/unit_tests/capd_rke2_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capd_rke2_cluster.spec.ts
@@ -14,6 +14,7 @@ limitations under the License.
 import '~/support/commands';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
+import { skipDeletionTest } from '~/support/utils';
 
 Cypress.config();
 describe('Import CAPD RKE2', { tags: '@short' }, () => {
@@ -119,48 +120,49 @@ describe('Import CAPD RKE2', { tags: '@short' }, () => {
       );
     }
 
-    qase(9,
-      it('Remove imported CAPD cluster from Rancher Manager', { retries: 1 }, () => {
-        // Check cluster is not deleted after removal
-        cy.deleteCluster(clusterName);
-        cy.goToHome();
-        // kubectl get clusters.cluster.x-k8s.io
-        // This is checked by ensuring the cluster is not available in navigation menu
-        cy.contains(clusterName).should('not.exist');
-        cy.checkCAPIClusterProvisioned(clusterName);
-      })
-    );
-
-    qase(10,
-      it('Delete the CAPD cluster fleet repo(s) - ' + path, () => {
-        if (path.includes('clusterclass')) {
-          // Remove the classes fleet repo
-          cy.removeFleetGitRepo(classesRepo, true);
-          // Remove the clusters fleet repo
-          cypressLib.burgerMenuToggle();
-          cy.removeFleetGitRepo(clustersRepo);
-
-          // Wait until the following returns no clusters found
-          cy.checkCAPIClusterDeleted(clusterName, timeout);
-          // Remove the clusterclass
-          cy.removeCAPIResource('Cluster Classes', className);
-        } else {
-          // Remove the clusters fleet repo
-          cy.removeFleetGitRepo(clustersRepo);
-
-          // Wait until the following returns no clusters found
-          // This is checked by ensuring the cluster is not available in CAPI menu
-          cy.checkCAPIClusterDeleted(clusterName, timeout);
-        }
-        
-        // Ensure the cluster is not available in navigation menu
-        cy.getBySel('side-menu').then(($menu) => {
-          if ($menu.text().includes(clusterName)) {
-            cy.deleteCluster(clusterName);
-          }
+    if (!skipDeletionTest) {
+      qase(9,
+        it('Remove imported CAPD cluster from Rancher Manager', { retries: 1 }, () => {
+          // Check cluster is not deleted after removal
+          cy.deleteCluster(clusterName);
+          cy.goToHome();
+          // kubectl get clusters.cluster.x-k8s.io
+          // This is checked by ensuring the cluster is not available in navigation menu
+          cy.contains(clusterName).should('not.exist');
+          cy.checkCAPIClusterProvisioned(clusterName);
         })
-      })
-    );
+      );
 
+      qase(10,
+        it('Delete the CAPD cluster fleet repo(s) - ' + path, () => {
+          if (path.includes('clusterclass')) {
+            // Remove the classes fleet repo
+            cy.removeFleetGitRepo(classesRepo, true);
+            // Remove the clusters fleet repo
+            cypressLib.burgerMenuToggle();
+            cy.removeFleetGitRepo(clustersRepo);
+
+            // Wait until the following returns no clusters found
+            cy.checkCAPIClusterDeleted(clusterName, timeout);
+            // Remove the clusterclass
+            cy.removeCAPIResource('Cluster Classes', className);
+          } else {
+            // Remove the clusters fleet repo
+            cy.removeFleetGitRepo(clustersRepo);
+
+            // Wait until the following returns no clusters found
+            // This is checked by ensuring the cluster is not available in CAPI menu
+            cy.checkCAPIClusterDeleted(clusterName, timeout);
+          }
+
+          // Ensure the cluster is not available in navigation menu
+          cy.getBySel('side-menu').then(($menu) => {
+            if ($menu.text().includes(clusterName)) {
+              cy.deleteCluster(clusterName);
+            }
+          })
+        })
+      );
+    }
   })
 });

--- a/tests/cypress/latest/e2e/unit_tests/capd_rke2_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capd_rke2_cluster.spec.ts
@@ -120,49 +120,47 @@ describe('Import CAPD RKE2', { tags: '@short' }, () => {
       );
     }
 
-    if (!skipDeletionTest) {
-      qase(9,
-        it('Remove imported CAPD cluster from Rancher Manager', { retries: 1 }, () => {
-          // Check cluster is not deleted after removal
-          cy.deleteCluster(clusterName);
-          cy.goToHome();
-          // kubectl get clusters.cluster.x-k8s.io
-          // This is checked by ensuring the cluster is not available in navigation menu
-          cy.contains(clusterName).should('not.exist');
-          cy.checkCAPIClusterProvisioned(clusterName);
-        })
-      );
+    qase(9,
+      it('Remove imported CAPD cluster from Rancher Manager', { retries: 1 }, () => {
+        // Check cluster is not deleted after removal
+        cy.deleteCluster(clusterName);
+        cy.goToHome();
+        // kubectl get clusters.cluster.x-k8s.io
+        // This is checked by ensuring the cluster is not available in navigation menu
+        cy.contains(clusterName).should('not.exist');
+        cy.checkCAPIClusterProvisioned(clusterName);
+      })
+    );
 
-      qase(10,
-        it('Delete the CAPD cluster fleet repo(s) - ' + path, () => {
-          if (path.includes('clusterclass')) {
-            // Remove the classes fleet repo
-            cy.removeFleetGitRepo(classesRepo, true);
-            // Remove the clusters fleet repo
-            cypressLib.burgerMenuToggle();
-            cy.removeFleetGitRepo(clustersRepo);
+    qase(10,
+      it('Delete the CAPD cluster fleet repo(s) - ' + path, () => {
+        if (path.includes('clusterclass')) {
+          // Remove the classes fleet repo
+          cy.removeFleetGitRepo(classesRepo, true);
+          // Remove the clusters fleet repo
+          cypressLib.burgerMenuToggle();
+          cy.removeFleetGitRepo(clustersRepo);
 
-            // Wait until the following returns no clusters found
-            cy.checkCAPIClusterDeleted(clusterName, timeout);
-            // Remove the clusterclass
-            cy.removeCAPIResource('Cluster Classes', className);
-          } else {
-            // Remove the clusters fleet repo
-            cy.removeFleetGitRepo(clustersRepo);
+          // Wait until the following returns no clusters found
+          cy.checkCAPIClusterDeleted(clusterName, timeout);
+          // Remove the clusterclass
+          cy.removeCAPIResource('Cluster Classes', className);
+        } else {
+          // Remove the clusters fleet repo
+          cy.removeFleetGitRepo(clustersRepo);
 
-            // Wait until the following returns no clusters found
-            // This is checked by ensuring the cluster is not available in CAPI menu
-            cy.checkCAPIClusterDeleted(clusterName, timeout);
+          // Wait until the following returns no clusters found
+          // This is checked by ensuring the cluster is not available in CAPI menu
+          cy.checkCAPIClusterDeleted(clusterName, timeout);
+        }
+
+        // Ensure the cluster is not available in navigation menu
+        cy.getBySel('side-menu').then(($menu) => {
+          if ($menu.text().includes(clusterName)) {
+            cy.deleteCluster(clusterName);
           }
-
-          // Ensure the cluster is not available in navigation menu
-          cy.getBySel('side-menu').then(($menu) => {
-            if ($menu.text().includes(clusterName)) {
-              cy.deleteCluster(clusterName);
-            }
-          })
         })
-      );
-    }
+      })
+    );
   })
 });

--- a/tests/cypress/latest/e2e/unit_tests/capg_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capg_cluster.spec.ts
@@ -1,6 +1,7 @@
 import '~/support/commands';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
+import { skipDeletionTest } from '~/support/utils';
 
 Cypress.config();
 describe('Import CAPG GKE', { tags: '@full' }, () => {
@@ -64,28 +65,29 @@ describe('Import CAPG GKE', { tags: '@full' }, () => {
     })
   );
 
-  qase(38,
-    it('Remove imported CAPG cluster from Rancher Manager', { retries: 1 }, () => {
+  if (!skipDeletionTest) {
+    qase(38,
+      it('Remove imported CAPG cluster from Rancher Manager', { retries: 1 }, () => {
 
-      // Check cluster is not deleted after removal
-      cy.deleteCluster(clusterName);
-      cy.goToHome();
-      // kubectl get clusters.cluster.x-k8s.io
-      // This is checked by ensuring the cluster is not available in navigation menu
-      cy.contains(clusterName).should('not.exist');
-      cy.checkCAPIClusterProvisioned(clusterName);
-    })
-  );
+        // Check cluster is not deleted after removal
+        cy.deleteCluster(clusterName);
+        cy.goToHome();
+        // kubectl get clusters.cluster.x-k8s.io
+        // This is checked by ensuring the cluster is not available in navigation menu
+        cy.contains(clusterName).should('not.exist');
+        cy.checkCAPIClusterProvisioned(clusterName);
+      })
+    );
 
-  qase(39,
-    it('Delete the CAPG cluster fleet repo', () => {
+    qase(39,
+      it('Delete the CAPG cluster fleet repo', () => {
 
-      // Remove the fleet git repo
-      cy.removeFleetGitRepo(repoName, true);
-      // Wait until the following returns no clusters found
-      // This is checked by ensuring the cluster is not available in CAPI menu
-      cy.checkCAPIClusterDeleted(clusterName, timeout);
-    })
-  );
-
+        // Remove the fleet git repo
+        cy.removeFleetGitRepo(repoName, true);
+        // Wait until the following returns no clusters found
+        // This is checked by ensuring the cluster is not available in CAPI menu
+        cy.checkCAPIClusterDeleted(clusterName, timeout);
+      })
+    );
+  }
 });

--- a/tests/cypress/latest/e2e/unit_tests/capv_rke2_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capv_rke2_cluster.spec.ts
@@ -1,6 +1,7 @@
 import '~/support/commands';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
+import { skipDeletionTest } from '~/support/utils';
 
 Cypress.config();
 describe('Import CAPV', { tags: '@vsphere' }, () => {
@@ -166,21 +167,23 @@ describe('Import CAPV', { tags: '@vsphere' }, () => {
     cy.contains(new RegExp('Provisioned.*' + clusterName), { timeout: timeout });
   })
 
-  it('Remove imported CAPV cluster from Rancher Manager', { retries: 1 }, () => {
-    // Check cluster is not deleted after removal
-    cy.deleteCluster(clusterName);
-    cy.goToHome();
-    // kubectl get clusters.cluster.x-k8s.io
-    // This is checked by ensuring the cluster is not available in navigation menu
-    cy.contains(clusterName).should('not.exist');
-    cy.checkCAPIClusterProvisioned(clusterName);
-  })
+  if (!skipDeletionTest) {
+    it('Remove imported CAPV cluster from Rancher Manager', { retries: 1 }, () => {
+      // Check cluster is not deleted after removal
+      cy.deleteCluster(clusterName);
+      cy.goToHome();
+      // kubectl get clusters.cluster.x-k8s.io
+      // This is checked by ensuring the cluster is not available in navigation menu
+      cy.contains(clusterName).should('not.exist');
+      cy.checkCAPIClusterProvisioned(clusterName);
+    })
 
-  it('Delete the CAPV cluster fleet repo', () => {
-    // Remove the fleet git repo
-    cy.removeFleetGitRepo(repoName)
-    // Wait until the following returns no clusters found
-    // This is checked by ensuring the cluster is not available in CAPI menu
-    cy.checkCAPIClusterDeleted(clusterName, timeout);
-  })
+    it('Delete the CAPV cluster fleet repo', () => {
+      // Remove the fleet git repo
+      cy.removeFleetGitRepo(repoName)
+      // Wait until the following returns no clusters found
+      // This is checked by ensuring the cluster is not available in CAPI menu
+      cy.checkCAPIClusterDeleted(clusterName, timeout);
+    })
+  }
 });

--- a/tests/cypress/latest/e2e/unit_tests/capz_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capz_cluster.spec.ts
@@ -1,6 +1,7 @@
 import '~/support/commands';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
+import { skipDeletionTest } from '~/support/utils';
 
 Cypress.config();
 describe('Import/Create CAPZ', { tags: '@full' }, () => {
@@ -194,16 +195,18 @@ describe('Import/Create CAPZ', { tags: '@full' }, () => {
   })
   );
 
-  qase(26, it('Delete the CAPZ cluster fleet repo', () => {
+  if (!skipDeletionTest) {
+    qase(26, it('Delete the CAPZ cluster fleet repo', () => {
 
-    // Remove the fleet git repo
-    cy.removeFleetGitRepo(repoName, true);
-    // Wait until the following returns no clusters found
-    // This is checked by ensuring the cluster is not available in CAPI menu
-    cy.checkCAPIClusterDeleted(clusterName, timeout);
-    // Remove the clusterclass
-    cy.removeCAPIResource('Cluster Classes', className);
-  })
-  );
+      // Remove the fleet git repo
+      cy.removeFleetGitRepo(repoName, true);
+      // Wait until the following returns no clusters found
+      // This is checked by ensuring the cluster is not available in CAPI menu
+      cy.checkCAPIClusterDeleted(clusterName, timeout);
+      // Remove the clusterclass
+      cy.removeCAPIResource('Cluster Classes', className);
+    })
+    );
+  }
 
 });

--- a/tests/cypress/latest/e2e/unit_tests/providers_setup.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/providers_setup.spec.ts
@@ -30,7 +30,8 @@ describe('Enable CAPI Providers', () => {
   const kubeadmProviderVersion = 'v1.9.5'
   const kubeadmBaseURL = 'https://github.com/kubernetes-sigs/cluster-api/releases/'
   const kubeadmProviderTypes = ['bootstrap', 'control plane']
-  const providerNamespaces = ['capi-kubeadm-bootstrap-system', 'capi-kubeadm-control-plane-system', 'capd-system', 'capa-system', 'capg-system', 'capz-system']
+  const providerNamespaces = ['capi-kubeadm-bootstrap-system', 'capi-kubeadm-control-plane-system', 'capd-system']
+  const cloudProviderNamespaces = ['capa-system', 'capg-system', 'capz-system']
   const vsphereProviderNamespace = 'capv-system'
 
   beforeEach(() => {
@@ -126,6 +127,13 @@ describe('Enable CAPI Providers', () => {
   })
 
   context('Cloud Providers', { tags: '@full' }, () => {
+
+    cloudProviderNamespaces.forEach(namespace => {
+      it('Create CAPI Cloud Providers Namespaces - ' + namespace, () => {
+        cy.createNamespace(namespace);
+      })
+    })
+
     qase(13,
       it('Create CAPA provider', () => {
         // Create AWS Infrastructure provider

--- a/tests/cypress/latest/e2e/unit_tests/providers_setup.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/providers_setup.spec.ts
@@ -50,11 +50,13 @@ describe('Enable CAPI Providers', () => {
         it('Create Kubeadm Providers', () => {
           // Create CAPI Kubeadm providers
           if (providerType == 'control plane') {
+            // https://github.com/kubernetes-sigs/cluster-api/releases/v1.9.5/control-plane-components.yaml
             const providerURL = kubeadmBaseURL + kubeadmProviderVersion + '/' + 'control-plane' + '-components.yaml'
             const providerName = kubeadmProvider + '-' + 'control-plane'
             const namespace = 'capi-kubeadm-control-plane-system'
             cy.addCustomProvider(providerName, namespace, kubeadmProvider, providerType, kubeadmProviderVersion, providerURL);
           } else {
+            // https://github.com/kubernetes-sigs/cluster-api/releases/v1.9.5/bootstrap-components.yaml
             const providerURL = kubeadmBaseURL + kubeadmProviderVersion + '/' + providerType + '-components.yaml'
             const providerName = kubeadmProvider + '-' + providerType
             const namespace = 'capi-kubeadm-bootstrap-system'
@@ -97,7 +99,7 @@ describe('Enable CAPI Providers', () => {
     });
   });
 
-context('vSphere provider', { tags: '@vsphere' }, () => {
+  context('vSphere provider', { tags: '@vsphere' }, () => {
     it('Create CAPI Providers Namespace - ' + vsphereProviderNamespace, () => {
       cy.createNamespace(vsphereProviderNamespace);
     })

--- a/tests/cypress/latest/plugins/index.ts
+++ b/tests/cypress/latest/plugins/index.ts
@@ -48,6 +48,7 @@ module.exports = (on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions)
   config.env.azure_client_secret = process.env.AZURE_CLIENT_SECRET
   config.env.azure_subscription_id = process.env.AZURE_SUBSCRIPTION_ID
   config.env.azure_location = process.env.AZURE_LOCATION
+  config.env.skip_deletion_test = process.env.SKIP_DELETION_TEST
   // VMware vSphere
   config.env.vsphere_secrets_json_base64 = process.env.VSPHERE_SECRETS_JSON_BASE64
 

--- a/tests/cypress/latest/plugins/index.ts
+++ b/tests/cypress/latest/plugins/index.ts
@@ -48,7 +48,7 @@ module.exports = (on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions)
   config.env.azure_client_secret = process.env.AZURE_CLIENT_SECRET
   config.env.azure_subscription_id = process.env.AZURE_SUBSCRIPTION_ID
   config.env.azure_location = process.env.AZURE_LOCATION
-  config.env.skip_deletion_test = process.env.SKIP_DELETION_TEST
+  config.env.skip_cluster_delete = process.env.SKIP_CLUSTER_DELETE
   // VMware vSphere
   config.env.vsphere_secrets_json_base64 = process.env.VSPHERE_SECRETS_JSON_BASE64
 

--- a/tests/cypress/latest/support/utils.ts
+++ b/tests/cypress/latest/support/utils.ts
@@ -19,3 +19,7 @@ export const isRancherManagerVersion = (version: string) => {
 export const isUIVersion = (version: string) => {
   return (new RegExp(version)).test(Cypress.env("capi_ui_version"));
 }
+
+export const skipDeletionTest = () => {
+  return Boolean(Cypress.env("skip_deletion_test"));
+}

--- a/tests/cypress/latest/support/utils.ts
+++ b/tests/cypress/latest/support/utils.ts
@@ -21,5 +21,5 @@ export const isUIVersion = (version: string) => {
 }
 
 export const skipDeletionTest = () => {
-  return Boolean(Cypress.env("skip_deletion_test"));
+  return Boolean(Cypress.env("skip_cluster_delete"));
 }

--- a/tests/scripts/start-cypress-tests
+++ b/tests/scripts/start-cypress-tests
@@ -42,6 +42,7 @@ docker run --init -v $PWD:/workdir -w /workdir \
     -e QASE_API_TOKEN=$QASE_API_TOKEN \
     -e QASE_RUN_ID=$QASE_RUN_ID \
     -e QASE_REPORT=$QASE_REPORT \
+    -e SKIP_DELETION_TEST=$SKIP_DELETION_TEST \
     -e "GREP=$GREP" \
     -e "GREPTAGS=$GREPTAGS" \
     --add-host host.docker.internal:host-gateway \

--- a/tests/scripts/start-cypress-tests
+++ b/tests/scripts/start-cypress-tests
@@ -42,7 +42,7 @@ docker run --init -v $PWD:/workdir -w /workdir \
     -e QASE_API_TOKEN=$QASE_API_TOKEN \
     -e QASE_RUN_ID=$QASE_RUN_ID \
     -e QASE_REPORT=$QASE_REPORT \
-    -e SKIP_DELETION_TEST=$SKIP_DELETION_TEST \
+    -e SKIP_CLUSTER_DELETE=$SKIP_CLUSTER_DELETE \
     -e "GREP=$GREP" \
     -e "GREPTAGS=$GREPTAGS" \
     --add-host host.docker.internal:host-gateway \


### PR DESCRIPTION
### What does this PR do?
1. This PR attempts to skip cluster deletion for cloud providers. This fix will be implemented for CAPD after #130 is done.
2. Separate cloud provider namespace creation so that they are created with proper tags. (Earlier when I tried to run CI job with `@install @full` tags, cloud provider namespaces were not created and the subsequent tests failed).

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #94 

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [X] GitHub Actions (if applicable) - https://github.com/rancher/rancher-turtles-e2e/actions/runs/13968186526

### Special notes for your reviewer:
