### PR TITLE
Add support for 2.11

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -181,7 +181,8 @@ jobs:
         run: |
           gcloud compute instances create ${{ steps.generator.outputs.runner }} \
             --source-instance-template ${{ inputs.runner_template }} \
-            --zone ${{ inputs.zone }}
+            --zone ${{ inputs.zone }} \
+            --labels=owner=${{ github.actor }},team=highlander-qa
       - name: Create GCP secrets
         if: ${{ needs.determine-runner.outputs.initial-runner != 'vsphere' }}
         run: |

--- a/tests/cypress/latest/e2e/unit_tests/capd_kubeadm_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capd_kubeadm_cluster.spec.ts
@@ -14,7 +14,6 @@ limitations under the License.
 import '~/support/commands';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
-import { isRancherManagerVersion } from '~/support/utils';
 
 Cypress.config();
 describe('Import CAPD Kubeadm', { tags: '@short' }, () => {

--- a/tests/cypress/latest/e2e/unit_tests/capd_kubeadm_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capd_kubeadm_cluster.spec.ts
@@ -84,8 +84,6 @@ describe('Import CAPD Kubeadm', { tags: '@short' }, () => {
           cy.contains('Dashboard').should('be.visible');
           cypressLib.accesMenu('Clusters');
           cy.fleetNamespaceToggle('fleet-default');
-          // To close the fleetNamespace dropdown, we click on the table
-          cy.get('table.sortable-table').click();
           // Verify the cluster is registered and Active
           const rowNumber = 0
           cy.verifyTableRow(rowNumber, 'Active', clusterName);

--- a/tests/cypress/latest/e2e/unit_tests/capd_kubeadm_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capd_kubeadm_cluster.spec.ts
@@ -14,7 +14,7 @@ limitations under the License.
 import '~/support/commands';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
-import { skipClusterDeletion } from '~/support/utils';
+import { isRancherManagerVersion } from '~/support/utils';
 
 Cypress.config();
 describe('Import CAPD Kubeadm', { tags: '@short' }, () => {
@@ -85,10 +85,13 @@ describe('Import CAPD Kubeadm', { tags: '@short' }, () => {
           cy.contains('Dashboard').should('be.visible');
           cypressLib.accesMenu('Clusters');
           cy.fleetNamespaceToggle('fleet-default');
+          // To close the fleetNamespace dropdown, we click on the table
+          cy.get('table.sortable-table').click();
           // Verify the cluster is registered and Active
-          cy.verifyTableRow(0, 'Active', clusterName);
+          const rowNumber = 0
+          cy.verifyTableRow(rowNumber, 'Active', clusterName);
           // Make sure there is only one registered cluster in fleet (there should be one table row)
-          cy.get('table.sortable-table').find('tbody tr').should('have.length', 1);
+          cy.get('table.sortable-table').find(`tbody tr[data-testid="sortable-table-${rowNumber}-row"]`).should('have.length', 1);
         })
       )
       qase(43,

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -45,7 +45,13 @@ Cypress.Commands.add('namespaceAutoImport', (mode) => {
 Cypress.Commands.add('setAutoImport', (mode) => {
   // If the desired mode is already in place, then simply reload the page.
   cy.getBySel('sortable-table-0-action-button').click();
-  cy.get('.list-unstyled.menu').then(($list) => {
+
+  var dropdownLabel = '.list-unstyled.menu'
+  if (isRancherManagerVersion("2.11")) {
+    dropdownLabel = '.popperContainer'
+  }
+
+  cy.get(dropdownLabel).then(($list) => {
     if ($list.text().includes(mode + ' CAPI Auto-Import')) {
       cy.contains(mode + ' CAPI Auto-Import').click();
     } else {

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -375,7 +375,7 @@ Cypress.Commands.add('checkChart', (operation, chartName, namespace, version, qu
   cy.clickButton(operation);
   // During update, Chart name changes to App name
   if (operation == "Install") {
-    cy.contains('.outer-container > .header', chartName);
+    cy.contains('.chart-header', chartName);
   }
   cy.clickButton('Next');
 

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -615,7 +615,7 @@ Cypress.Commands.add('checkFleetGitRepo', (repoName, workspace) => {
 
 // Fleet namespace toggle
 Cypress.Commands.add('fleetNamespaceToggle', (toggleOption = 'local') => {
-  cy.contains('fleet-').click();
+  cy.getBySel('workspace-switcher').click();
   cy.contains(toggleOption).should('be.visible').click();
 });
 

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -375,7 +375,7 @@ Cypress.Commands.add('checkChart', (operation, chartName, namespace, version, qu
   cy.clickButton(operation);
   // During update, Chart name changes to App name
   if (operation == "Install") {
-    cy.contains('.chart-header', chartName);
+    cy.contains('.header > .title', chartName)
   }
   cy.clickButton('Next');
 


### PR DESCRIPTION
### What does this PR do?
Fix turtles installation on 2.11. The new fix works for both 2.10 and 2.11.
### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #142 

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions (if applicable) - [2.11](https://github.com/rancher/rancher-turtles-e2e/actions/runs/14217376749), [2.10](https://github.com/rancher/rancher-turtles-e2e/actions/runs/14217372701)

### Special notes for your reviewer:
