### PR TITLE
Delete the GCP runner if the job has been cancelled

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -465,7 +465,7 @@ jobs:
 
   delete-runner:
     if: ${{ always() && needs.create-runner.result == 'success' && needs.create-runner.outputs.uuid != 'vsphere' }}
-    needs: [create-runner, e2e]
+    needs: [create-runner]
     runs-on: ubuntu-latest
     steps:
       # actions/checkout MUST come before auth

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -464,7 +464,7 @@ jobs:
           echo "K3s on Rancher Manager: ${{ env.INSTALL_K3S_VERSION }}" >> ${GITHUB_STEP_SUMMARY}
 
   delete-runner:
-    if: ${{ always() && needs.create-runner.result == 'success' && needs.create-runner.outputs.uuid != 'vsphere' }}
+    if: ${{ always() && needs.create-runner.outputs.uuid != 'vsphere' }}
     needs: [create-runner]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -465,7 +465,7 @@ jobs:
 
   delete-runner:
     if: ${{ always() && needs.create-runner.outputs.uuid != 'vsphere' }}
-    needs: [create-runner]
+    needs: [create-runner, e2e]
     runs-on: ubuntu-latest
     steps:
       # actions/checkout MUST come before auth


### PR DESCRIPTION
### What does this PR do?
This PR removes the need for create-runner job to succeed and the dependency on e2e job for delete runner to get triggered.

The runner must be removed if the job has been cancelled.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [X] GitHub Actions (if applicable) - [before](https://github.com/rancher/rancher-turtles-e2e/actions/runs/14082847756), [after](https://github.com/rancher/rancher-turtles-e2e/actions/runs/14083288978)

### Special notes for your reviewer:
