### PR TITLE
Temporarily skip fleet-addon related tests

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/capd_rke2_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capd_rke2_cluster.spec.ts
@@ -109,7 +109,8 @@ describe('Import CAPD RKE2', { tags: '@short' }, () => {
       );
 
       qase(41,
-        it('Update chart and check cluster status', () => {
+        // turtles/issues/1219
+        xit('Update chart and check cluster status', () => {
           cy.contains('local').click();
           cy.checkChart('Update', 'Rancher Turtles', 'rancher-turtles-system', '', questions);
 

--- a/tests/cypress/latest/e2e/unit_tests/providers_setup.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/providers_setup.spec.ts
@@ -23,8 +23,8 @@ describe('Enable CAPI Providers', () => {
   const amazonProvider = 'aws'
   const googleProvider = 'gcp'
   const azureProvider = 'azure'
-  const fleetProvider = 'rancher-fleet'
-  const fleetProviderVersion = 'v0.7.1'
+  const fleetProvider = 'fleet'
+  const fleetProviderVersion = 'v0.7.2'
   const vsphereProvider = 'vsphere'
   const vsphereProviderVersion = 'v1.12.0'
   const kubeadmProviderVersion = 'v1.9.5'
@@ -78,7 +78,7 @@ describe('Enable CAPI Providers', () => {
       })
     );
 
-    it('Custom Fleet addon config', () => {
+    xit('Custom Fleet addon config', () => {
       // Allows Fleet addon to be installed on specific clusters only
 
       const clusterName = 'local';


### PR DESCRIPTION
### What does this PR do?
- Skips tests due to `turtles/issues/1219`
- Bumps fleet-addon version

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes - Nightly CI

### Checklist:
- [x] GitHub Actions:
https://github.com/rancher/rancher-turtles-e2e/actions/runs/14105940630

