### PR TITLE
Stop tests on first failure in @install

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -378,7 +378,7 @@ jobs:
       - name: Cypress tests
         env:
           BROWSER: chrome
-          CYPRESS_DOCKER: 'cypress/included:13.6.4'
+          CYPRESS_DOCKER: 'cypress/included:14.2.1'
           CAPI_UI_VERSION: ${{ inputs.capi_ui_version }}
           K8S_UPSTREAM_VERSION: ${{ inputs.upstream_cluster_version }}
           RANCHER_VERSION: ${{ steps.component.outputs.rm_version }}

--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ What tests are doing:
 4. Test the Turtles menu, namespaces import features
 5. Perform CAPI setup prerequisites
 6. Create & Import CAPI cluster using fleet by cluster, namespace annotation
-7. Install App on imported CAPI cluster
-8. Scale the imported CAPI cluster
-9. Remove & Delete the imported CAPI cluster
+7. Create & Import CAPI cluster using ClusterClass UI
+8. Install App on imported CAPI cluster
+9. Scale the imported CAPI cluster
+10. Remove & Delete the imported CAPI cluster
 
 
 ## Running the tests locally
@@ -19,7 +20,7 @@ What tests are doing:
 ### Pre-requisites
 1. Install Rancher.
 2. Install Rancher Turtles operator.
-3. Install CAPI UI Extensions.
+3. Install CAPI UI Extension.
 
 ### Running the test
 1. `cd tests/cypress/latest`
@@ -38,7 +39,7 @@ The Cypress GUI should now be visible.
 # Test structure
 We categorize our tests using tags such as `short`, `full`, `vsphere`, and `install`. 
 Tests tagged with `short` are local (docker-based) tests, while those tagged with `vsphere` are specific to vSphere.
-Tests tagged with `full` are cloud provider-based tests. The `install` tag is used for initial setup tests.
+Tests tagged with `full` are cloud provider-based tests. The `install` tag is used for initial setup tests ('install' tag is also to be included in setup tests title).
 
 # Running tests using Cypress grep
 We have implemented tags for more precise selection of tests using a Cypress plugin called [cypress-grep](https://github.com/cypress-io/cypress/tree/develop/npm/grep)

--- a/tests/cypress/latest/e2e/unit_tests/capa_eks_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capa_eks_cluster.spec.ts
@@ -81,7 +81,7 @@ describe('Import CAPA EKS', { tags: '@full' }, () => {
       it('Delete the CAPA cluster fleet repo', () => {
 
         // Remove the fleet git repo
-        cy.removeFleetGitRepo(repoName, true);
+        cy.removeFleetGitRepo(repoName);
         // Wait until the following returns no clusters found
         // This is checked by ensuring the cluster is not available in CAPI menu
         cy.checkCAPIClusterDeleted(clusterName, timeout);

--- a/tests/cypress/latest/e2e/unit_tests/capa_rke2_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capa_rke2_cluster.spec.ts
@@ -79,7 +79,7 @@ describe('Import CAPA RKE2', { tags: '@full' }, () => {
     qase(16,
       it('Delete the CAPA cluster fleet repo', () => {
         // Remove the fleet git repo
-        cy.removeFleetGitRepo(repoName, true);
+        cy.removeFleetGitRepo(repoName);
         // Wait until the following returns no clusters found
         // This is checked by ensuring the cluster is not available in CAPI menu
         cy.checkCAPIClusterDeleted(clusterName, timeout);

--- a/tests/cypress/latest/e2e/unit_tests/capd_clusterclass_ui_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capd_clusterclass_ui_cluster.spec.ts
@@ -104,7 +104,7 @@ describe('Create CAPD', { tags: '@short' }, () => {
 
         // Remove the classes fleet repo
         cypressLib.burgerMenuToggle();
-        cy.removeFleetGitRepo(className, true);
+        cy.removeFleetGitRepo(className);
 
         // Ensure the cluster is not available in navigation menu
         cy.getBySel('side-menu').then(($menu) => {

--- a/tests/cypress/latest/e2e/unit_tests/capd_kubeadm_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capd_kubeadm_cluster.spec.ts
@@ -177,10 +177,10 @@ describe('Import CAPD Kubeadm', { tags: '@short' }, () => {
         it('Delete the CAPD cluster fleet repo(s) - ' + path, () => {
           if (path.includes('clusterclass')) {
             // Remove the cni fleet repo from fleet-default workspace
-            cy.removeFleetGitRepo(classesRepoName+'-cni', true, 'fleet-default');
+            cy.removeFleetGitRepo(classesRepoName+'-cni', 'fleet-default');
             // Remove the classes fleet repo
             cypressLib.burgerMenuToggle();
-            cy.removeFleetGitRepo(classesRepoName, true);
+            cy.removeFleetGitRepo(classesRepoName);
             // Remove the clusters fleet repo
             cypressLib.burgerMenuToggle();
             cy.removeFleetGitRepo(clustersRepoName);

--- a/tests/cypress/latest/e2e/unit_tests/capd_rke2_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capd_rke2_cluster.spec.ts
@@ -155,7 +155,7 @@ describe('Import CAPD RKE2', { tags: '@short' }, () => {
         it('Delete the CAPD cluster fleet repo(s) - ' + path, () => {
           if (path.includes('clusterclass')) {
             // Remove the classes fleet repo
-            cy.removeFleetGitRepo(classesRepoName, true);
+            cy.removeFleetGitRepo(classesRepoName);
             // Remove the clusters fleet repo
             cypressLib.burgerMenuToggle();
             cy.removeFleetGitRepo(clustersRepoName);

--- a/tests/cypress/latest/e2e/unit_tests/capg_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capg_cluster.spec.ts
@@ -109,7 +109,7 @@ describe('Import CAPG GKE', { tags: '@full' }, () => {
       it('Delete the CAPG cluster fleet repo', () => {
 
         // Remove the fleet git repo
-        cy.removeFleetGitRepo(repoName, true);
+        cy.removeFleetGitRepo(repoName);
         // Wait until the following returns no clusters found
         // This is checked by ensuring the cluster is not available in CAPI menu
         cy.checkCAPIClusterDeleted(clusterName, timeout);

--- a/tests/cypress/latest/e2e/unit_tests/capz_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capz_cluster.spec.ts
@@ -199,7 +199,7 @@ describe('Import/Create CAPZ', { tags: '@full' }, () => {
     qase(26, it('Delete the CAPZ cluster fleet repo', () => {
 
       // Remove the fleet git repo
-      cy.removeFleetGitRepo(repoName, true);
+      cy.removeFleetGitRepo(repoName);
       // Wait until the following returns no clusters found
       // This is checked by ensuring the cluster is not available in CAPI menu
       cy.checkCAPIClusterDeleted(clusterName, timeout);

--- a/tests/cypress/latest/e2e/unit_tests/first_connection.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/first_connection.spec.ts
@@ -15,7 +15,7 @@ limitations under the License.
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 
 Cypress.config();
-describe('First login on Rancher', { tags: '@install' }, () => {
+describe('First login on Rancher - @install', { tags: '@install' }, () => {
   const password = 'rancherpassword'
 
   it('Log in and accept terms and conditions',

--- a/tests/cypress/latest/e2e/unit_tests/menu.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/menu.spec.ts
@@ -16,7 +16,7 @@ import '~/support/commands';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 
 Cypress.config();
-describe('Menu testing', { tags: '@install' }, () => {
+describe('Menu testing - @install', { tags: '@install' }, () => {
   beforeEach(() => {
     cy.login();
     cypressLib.burgerMenuToggle();

--- a/tests/cypress/latest/e2e/unit_tests/turtles_extension.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/turtles_extension.spec.ts
@@ -15,10 +15,9 @@ limitations under the License.
 import '~/support/commands';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
-import { timers } from 'cypress/types/jquery';
 
 Cypress.config();
-describe('Install CAPI extension', { tags: '@install' }, () => {
+describe('Install CAPI extension - @install', { tags: '@install' }, () => {
 
   beforeEach(() => {
     cy.login();

--- a/tests/cypress/latest/e2e/unit_tests/turtles_operator.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/turtles_operator.spec.ts
@@ -17,7 +17,7 @@ import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import { qase } from 'cypress-qase-reporter/dist/mocha';
 
 Cypress.config();
-describe('Install Turtles Operator', { tags: '@install' }, () => {
+describe('Install Turtles Operator - @install', { tags: '@install' }, () => {
 
   beforeEach(() => {
     cy.login();

--- a/tests/cypress/latest/fixtures/runtime_test_result.yaml
+++ b/tests/cypress/latest/fixtures/runtime_test_result.yaml
@@ -1,0 +1,1 @@
+test_result: passed

--- a/tests/cypress/latest/package.json
+++ b/tests/cypress/latest/package.json
@@ -25,7 +25,7 @@
     "@rancher-ecp-qa/cypress-library": "2.0.0",
     "cy-verify-downloads": "^0.1.8",
     "randomstring": "^1.3.0",
-    "cypress": "^13.6.4",
+    "cypress": "^14.2.1",
     "cypress-dark": "^1.8.3",
     "cypress-file-upload": "^5.0.8",
     "cypress-mochawesome-reporter": "^3.8.2",

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -210,8 +210,12 @@ Cypress.Commands.add('addCustomProvider', (name, namespace, providerName, provid
   cy.getBySel('name-ns-description-namespace').type(namespace + '{enter}');
   cy.typeValue('Name', name);
   cy.typeValue('Provider', providerName);
-  cy.typeValue('Version', version);
-  cy.typeValue('URL', url);
+  if (version != undefined) {
+    cy.typeValue('Version', version);
+  }
+  if (url != undefined) {
+    cy.typeValue('URL', url);
+  }
   cy.clickButton('Create');
   cy.contains('Providers').should('be.visible');
 });
@@ -573,17 +577,13 @@ Cypress.Commands.add('addFleetGitRepo', (repoName, repoUrl, branch, path, worksp
 })
 
 // Command remove Fleet Git Repository
-Cypress.Commands.add('removeFleetGitRepo', (repoName, noRepoCheck, workspace) => {
+Cypress.Commands.add('removeFleetGitRepo', (repoName, workspace) => {
   cy.checkFleetGitRepo(repoName, workspace);
   // Click on the actions menu and select 'Delete' from the menu
   cy.get('.actions .btn.actions').click();
   cy.get('.icon.group-icon.icon-trash').click();
   cypressLib.confirmDelete();
-  if (noRepoCheck == true) {
-    cy.contains(repoName).should('not.exist');
-  } else {
-    cy.contains('No repositories have been added').should('be.visible');
-  }
+  cy.contains(repoName).should('not.exist');
 })
 
 // Command forcefully update Fleet Git Repository

--- a/tests/cypress/latest/support/e2e.ts
+++ b/tests/cypress/latest/support/e2e.ts
@@ -13,6 +13,7 @@ limitations under the License.
 */
 
 import './commands';
+import yaml from 'js-yaml';
 
 declare global {
   // In Cypress functions should be declared with 'namespace'
@@ -24,7 +25,7 @@ declare global {
       setAutoImport(mode: string): Chainable<Element>;
       clusterAutoImport(clusterName: string, mode: string): Chainable<Element>;
       addFleetGitRepo(repoName: string, repoUrl: string, branch: string, path: string, workspace?: string): Chainable<Element>;
-      removeFleetGitRepo(repoName: string, noRepoCheck?: boolean, workspace?: string): Chainable<Element>;
+      removeFleetGitRepo(repoName: string, workspace?: string): Chainable<Element>;
       forceUpdateFleetGitRepo(repoName: string, workspace?: string): Chainable<Element>;
       checkFleetGitRepo(repoName: string, workspace?: string): Chainable<Element>;
       fleetNamespaceToggle(toggleOption: string): Chainable<Element>;
@@ -85,3 +86,25 @@ require('@rancher-ecp-qa/cypress-library');
 // @ts-ignore
 import registerCypressGrep from '@cypress/grep'
 registerCypressGrep()
+
+// Abort on first failure in @install tests
+const resultFile = './fixtures/runtime_test_result.yaml'
+beforeEach(() => {
+  cy.readFile(resultFile).then((data) => {
+    const content = yaml.load(data)
+    const result = content['test_result']
+    cy.log('Previous Test Result: ' + result);
+    if (result == 'failed') {
+      cy.log('Stopping test run - previous test(s) have failed')
+      Cypress.stop()
+    }
+  });
+});
+
+afterEach(function () {
+  if (this.currentTest?.state == 'failed' && this.currentTest?.fullTitle?.().includes('@install')) {
+    const result = { test_result: this.currentTest?.state };
+    const data = yaml.dump(result);
+    cy.writeFile(resultFile, data);
+  }
+})


### PR DESCRIPTION
### What does this PR do?
- Skip tests run on first failure in `@install` using Cypress.Stop()
- Bump Cypress to latest version
- Refactors `providers_setup.spec.ts`
- Remove redundant check in `removeFleetGitRepo`, since repo names are now unique

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #25 

### Checklist:
- [x] GitHub Actions:

`@install @short` nightly - :green_circle: https://github.com/rancher/rancher-turtles-e2e/actions/runs/14360018165

Tests not skipped if `@short` failure:
`@install @short` - https://github.com/rancher/rancher-turtles-e2e/actions/runs/14360035519

Tests skipped if `@install` failure:
`@install` - https://github.com/rancher/rancher-turtles-e2e/actions/runs/14360856892
`@install @short` - https://github.com/rancher/rancher-turtles-e2e/actions/runs/14360874340
