### PR TITLE
Fix force update gitRepo on 2.11

### DIFF
--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -621,7 +621,7 @@ Cypress.Commands.add('removeFleetGitRepo', (repoName, workspace) => {
 // Command forcefully update Fleet Git Repository
 Cypress.Commands.add('forceUpdateFleetGitRepo', (repoName, workspace) => {
   cy.checkFleetGitRepo(repoName, workspace);
-  // Click on the actions menu and select 'Delete' from the menu
+  // Click on the actions menu and select 'Force Update' from the menu
   cy.get('.actions .btn.actions').click();
   cy.get('.icon.group-icon.icon-refresh').click();
   if (isRancherManagerVersion("2.11")) {


### PR DESCRIPTION
### What does this PR do?
Fixes force update of gitRepo in Fleet for eg when scaling nodes on capv.

New modal with Force Update confirmation present on 2.11
![image](https://github.com/user-attachments/assets/dc0a8163-7586-4e90-8dc2-14566b59f186)


### Checklist:
- [x] GitHub Actions (if applicable) https://github.com/rancher/rancher-turtles-e2e/actions/runs/14380389755

