### PR TITLE
Switch capi-ui repo to https instead of git

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/turtles_extension.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/turtles_extension.spec.ts
@@ -25,7 +25,7 @@ describe('Install CAPI extension - @install', { tags: '@install' }, () => {
   });
 
   it('Add capi-ui repo', () => {
-    cy.addRepository('capi-ui', 'https://github.com/rancher/capi-ui-extension.git', 'git', 'gh-pages')
+    cy.addRepository('capi-ui', 'https://rancher.github.io/capi-ui-extension', 'http', 'none')
   })
 
   qase(3,

--- a/tests/cypress/latest/e2e/unit_tests/turtles_operator.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/turtles_operator.spec.ts
@@ -46,7 +46,7 @@ describe('Install Turtles Operator - @install', { tags: '@install' }, () => {
     } else {
       turtlesHelmRepo += ':8080'
     }
-    cy.addRepository('turtles-operator', turtlesHelmRepo, 'helm', 'none');
+    cy.addRepository('turtles-operator', turtlesHelmRepo, 'http', 'none');
   })
 
   qase([2, 11],


### PR DESCRIPTION
### What does this PR do?
Uses https for adding capi-ui repo instead of git, now it will be according to turtles documentation. 

This is also an attempt to fix problematic adding of the capi-ui git repo which might be affected by gh rate-limit - adding timeouted after 2mins.
![image](https://github.com/user-attachments/assets/15735682-e124-4113-bdab-53617fd773b2)


### Checklist:
- [x] GitHub Actions (if applicable) https://github.com/rancher/rancher-turtles-e2e/actions/runs/14398378301
