### PR TITLE
Testhelpers bump 210

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -7,7 +7,7 @@ toolchain go1.23.3
 require (
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.34.2
-	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20241114104736-0d5b41ca9158
+	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20250415062725-efdf8e57c793
 	github.com/rancher-sandbox/qase-ginkgo v1.0.1
 	github.com/sirupsen/logrus v1.9.3
 )

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -127,8 +127,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/rancher-sandbox/ele-testhelpers v0.0.0-20241114104736-0d5b41ca9158 h1:qQjjaS+nhifw5iPLIvMmLqDpxr39DPWJRFOskw0AJlg=
-github.com/rancher-sandbox/ele-testhelpers v0.0.0-20241114104736-0d5b41ca9158/go.mod h1:Ex+a/ng4u2BvcGQdQjTHI48h88bQ6k2a7q8rnvU0XbQ=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20250415062725-efdf8e57c793 h1:NIioaBqH1VA1NbAqWRG+SjxSW7z/EOU8jcEIFbDW8lc=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20250415062725-efdf8e57c793/go.mod h1:Ex+a/ng4u2BvcGQdQjTHI48h88bQ6k2a7q8rnvU0XbQ=
 github.com/rancher-sandbox/qase-ginkgo v1.0.1 h1:LB9ITLavX3PmcOe0hp0Y7rwQCjJ3WpL8kG8v1MxPadE=
 github.com/rancher-sandbox/qase-ginkgo v1.0.1/go.mod h1:sIF43xaLHtEzmPqADKlZZV6oatc66GHz1N6gpBNn6QY=
 github.com/rancher/qase-go/client v0.0.0-20231114201952-65195ec001fa h1:/qeYlQVfyvsO5yY0dZmm7mRTAsDm54jACiRDx3LAwsA=


### PR DESCRIPTION
### What does this PR do?
rancher/rancher:v2.10-head is not being released on dockerhub anymore but on stgregistry.

### Checklist:
- [ ] GitHub Actions (if applicable) https://github.com/rancher/rancher-turtles-e2e/actions/runs/14487984852