### PR TITLE
Provider versions bump after release v0.19.0-rc.1

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/providers_setup.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/providers_setup.spec.ts
@@ -32,8 +32,8 @@ describe('Enable CAPI Providers', () => {
   const vsphereProvider = 'vsphere'
 
   // Expected provider versions
-  const kubeadmProviderVersion = 'v1.9.5'
-  const fleetProviderVersion = 'v0.7.4'
+  const kubeadmProviderVersion = 'v1.10.0'
+  const fleetProviderVersion = 'v0.8.1'
   const vsphereProviderVersion = 'v1.12.0'
   const amazonProviderVersion = 'v2.8.1'
   const googleProviderVersion = 'v1.9.0'


### PR DESCRIPTION
### What does this PR do?
Just provider versions bump

Testrun on `0.19.0-rc.1`: https://github.com/rancher/rancher-turtles-e2e/actions/runs/14668083102

