### PR TITLE
Skip test result checking when running outside CI

### DIFF
--- a/tests/cypress/latest/plugins/index.ts
+++ b/tests/cypress/latest/plugins/index.ts
@@ -56,5 +56,8 @@ module.exports = (on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions)
   config.env.grep = process.env.GREP;
   config.env.grepTags = process.env.GREPTAGS;
 
+  // To know if tests are running in a CI environment
+  config.env.ci = process.env.CI;
+
   return config;
 };

--- a/tests/scripts/start-cypress-tests
+++ b/tests/scripts/start-cypress-tests
@@ -46,6 +46,7 @@ docker run --init -v $PWD:/workdir -w /workdir \
     -e SKIP_CLUSTER_DELETE=$SKIP_CLUSTER_DELETE \
     -e "GREP=$GREP" \
     -e "GREPTAGS=$GREPTAGS" \
+    -e "CI=$CI" \
     --add-host host.docker.internal:host-gateway \
     --ipc=host \
     $CYPRESS_DOCKER \


### PR DESCRIPTION
### What does this PR do?
It prevents checking previous test result when running outside Github Actions by using GH internal variable CI. If you need this functionality in local runs just use `export CI=whatever` 

### Special notes for your reviewer:
Github Actions
![image](https://github.com/user-attachments/assets/1c82d1cb-6996-4fb1-b5d4-919db74284a4)

Outside Github Actions
![image](https://github.com/user-attachments/assets/699076a3-fca2-4e0d-a824-da62b972c1d2)
