### PR TITLE
Always refresh repo after adding

### DIFF
--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -385,9 +385,14 @@ Cypress.Commands.add('addRepository', (repositoryName: string, repositoryURL: st
   }
   cy.clickButton('Create');
   // Make sure the repo is active before leaving
+  // Always press Refresh button as workaround for https://github.com/rancher/rancher/issues/49671
   cy.wait(1000);
   cy.typeInFilter(repositoryName);
-  cy.contains(new RegExp('Active.*' + repositoryName), { timeout: 150000 });
+  cy.getBySel('sortable-table-0-action-button').click();
+  cy.wait(1000);
+  cy.get('.icon.group-icon.icon-refresh').click();
+  cy.wait(1000);
+  cy.contains(new RegExp('Active.*' + repositoryName), { timeout: 60000 });
 });
 
 // Command to Install or Update App from Charts menu

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -392,7 +392,7 @@ Cypress.Commands.add('addRepository', (repositoryName: string, repositoryURL: st
   cy.wait(1000);
   cy.get('.icon.group-icon.icon-refresh').click();
   cy.wait(1000);
-  cy.contains(new RegExp('Active.*' + repositoryName), { timeout: 60000 });
+  cy.contains(new RegExp('Active.*' + repositoryName), { timeout: 150000 });
 });
 
 // Command to Install or Update App from Charts menu


### PR DESCRIPTION
### What does this PR do?
addRepository function will be always refreshing repositories after creating/adding the repo, workaround for https://github.com/rancher/rancher/issues/49671

### Checklist:
- [ ] `@install @short` GitHub Actions (if applicable)  https://github.com/rancher/rancher-turtles-e2e/actions/runs/14861920159 (failed but it should not be related to the changes)
- [ ] `@install` https://github.com/rancher/rancher-turtles-e2e/actions/runs/14863353533
