### PR TITLE
Non-default namespace for CAPI resources

### DIFF
--- a/.github/workflows/janitor.yaml
+++ b/.github/workflows/janitor.yaml
@@ -36,7 +36,7 @@ jobs:
         continue-on-error: true
         run: |
           # Get the GKE clusters by prefix
-          for cl in $(gcloud container clusters list --location asia-south2 --filter="name:turtles-qa-capg-gke" --format json | jq -r ".[] | .name" 2> /dev/null); do
+          for cl in $(gcloud container clusters list --location asia-south2 --filter="name:turtles-qa-gcp-gke" --format json | jq -r ".[] | .name" 2> /dev/null); do
            echo "Deleting GKE cluster: $cl"
            gcloud container clusters delete --location asia-south2 $cl --async --quiet
           done

--- a/tests/assets/rancher-turtles-fleet-example/capa/eks/clusters/fleet.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capa/eks/clusters/fleet.yaml
@@ -1,4 +1,4 @@
-namespace: default
+namespace: capi-clusters
 
 helm:
   values:

--- a/tests/assets/rancher-turtles-fleet-example/capa/kubeadm/clusters/fleet.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capa/kubeadm/clusters/fleet.yaml
@@ -1,4 +1,4 @@
-namespace: default
+namespace: capi-clusters
 
 helm:
   values:
@@ -6,7 +6,7 @@ helm:
     region: ap-south-2
     sshKeyName: turtles-qa-rke2
     version: v1.31.0
-    # Private copy of ami-0988c3c36e3080c43 from eu-west-2 capa-ami-ubuntu-24.04-v1.31.0-1739348996
-    ami_id: ami-032636c1e5ad6d9ae
+    # Private copy of ami-012e88f0aa221423a from eu-west-2 capa-ami-ubuntu-24.04-v1.31.5 -1738233293
+    ami_id: ami-0af073946d0fe5c39
     cp_machine_count: 1 # Todo: 3, turtles/issues/1402
     worker_machine_count: 1

--- a/tests/assets/rancher-turtles-fleet-example/capa/rke2/class-clusters/fleet.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capa/rke2/class-clusters/fleet.yaml
@@ -1,4 +1,4 @@
-namespace: default
+namespace: capi-clusters
 
 helm:
   values:
@@ -7,7 +7,8 @@ helm:
     region: ap-south-2
     sshKeyName: turtles-qa-rke2
     version: v1.31.7+rke2r1
-    ami_id: ami-063222db4f3a22666
+    # Private copy of ami-012e88f0aa221423a from eu-west-2 capa-ami-ubuntu-24.04-v1.31.5 -1738233293
+    ami_id: ami-0af073946d0fe5c39
     machine_type: t3.2xlarge
     cp_machine_count: 3
     worker_machine_count: 1

--- a/tests/assets/rancher-turtles-fleet-example/capa/rke2/class-clusters/templates/cluster.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capa/rke2/class-clusters/templates/cluster.yaml
@@ -15,6 +15,7 @@ spec:
       - 192.168.0.0/16
   topology:
     class: {{ .Values.className }}
+    classNamespace: capi-classes
     controlPlane:
       replicas: {{ .Values.cp_machine_count }}
     variables:

--- a/tests/assets/rancher-turtles-fleet-example/capa/rke2/clusters/fleet.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capa/rke2/clusters/fleet.yaml
@@ -1,4 +1,4 @@
-namespace: default
+namespace: capi-clusters
 
 helm:
   values:
@@ -6,6 +6,7 @@ helm:
     region: ap-south-2
     sshKeyName: turtles-qa-rke2
     version: v1.31.7+rke2r1
-    ami_id: ami-063222db4f3a22666
+    # Private copy of ami-012e88f0aa221423a from eu-west-2 capa-ami-ubuntu-24.04-v1.31.5 -1738233293
+    ami_id: ami-0af073946d0fe5c39
     cp_machine_count: 3
     worker_machine_count: 1

--- a/tests/assets/rancher-turtles-fleet-example/capa/rke2/clusters/templates/cluster.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capa/rke2/clusters/templates/cluster.yaml
@@ -29,7 +29,7 @@ metadata:
   name: {{ $cluster_name }}
 spec:
   bastion:
-    enabled: true
+    enabled: false
   controlPlaneLoadBalancer:
     additionalListeners:
     - port: 9345

--- a/tests/assets/rancher-turtles-fleet-example/capd/kubeadm/class-clusters/fleet.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capd/kubeadm/class-clusters/fleet.yaml
@@ -1,4 +1,4 @@
-namespace: default
+namespace: capi-clusters
 
 helm:
   values:

--- a/tests/assets/rancher-turtles-fleet-example/capd/kubeadm/class-clusters/templates/cluster.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capd/kubeadm/class-clusters/templates/cluster.yaml
@@ -18,7 +18,7 @@ spec:
       - 10.128.0.0/12
   topology:
     class: docker-kubeadm-example
-    classNamespace: default
+    classNamespace: capi-classes
     controlPlane:
       metadata: {}
       replicas: 3

--- a/tests/assets/rancher-turtles-fleet-example/capd/kubeadm/clusters/fleet.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capd/kubeadm/clusters/fleet.yaml
@@ -1,4 +1,4 @@
-namespace: default
+namespace: capi-clusters
 
 helm:
   values:
@@ -8,6 +8,6 @@ diff:
   comparePatches:
   - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: DockerCluster
-    namespace: default
+    namespace: capi-clusters
     jsonPointers:
     - "/spec/failureDomains" 

--- a/tests/assets/rancher-turtles-fleet-example/capd/rke2/class-clusters/fleet.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capd/rke2/class-clusters/fleet.yaml
@@ -1,4 +1,4 @@
-namespace: default
+namespace: capi-clusters
 
 helm:
   values:

--- a/tests/assets/rancher-turtles-fleet-example/capd/rke2/class-clusters/templates/cluster.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capd/rke2/class-clusters/templates/cluster.yaml
@@ -20,7 +20,7 @@ spec:
     serviceDomain: cluster.local
   topology:
     class: docker-rke2-example
-    classNamespace: default
+    classNamespace: capi-classes
     controlPlane:
       replicas: 3
     variables:

--- a/tests/assets/rancher-turtles-fleet-example/capd/rke2/clusters/fleet.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capd/rke2/clusters/fleet.yaml
@@ -1,4 +1,4 @@
-namespace: default
+namespace: capi-clusters
 
 helm:
   values:
@@ -8,6 +8,6 @@ diff:
   comparePatches:
   - apiVersion: cluster.x-k8s.io/v1beta1
     kind: MachineDeployment
-    namespace: default
+    namespace: capi-clusters
     jsonPointers:
     - "/spec/selector"

--- a/tests/assets/rancher-turtles-fleet-example/capg/gke/clusters/fleet.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capg/gke/clusters/fleet.yaml
@@ -1,4 +1,4 @@
-namespace: default
+namespace: capi-clusters
 
 helm:
   valuesFrom:

--- a/tests/assets/rancher-turtles-fleet-example/capv/kubeadm/class-clusters/fleet.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capv/kubeadm/class-clusters/fleet.yaml
@@ -1,8 +1,8 @@
-namespace: default
+namespace: capi-clusters
 
 helm:
   valuesFrom:
     - secretKeyRef:
         name: capv-helm-values
-        namespace: default
+        namespace: capv-system
         key: values.yaml

--- a/tests/assets/rancher-turtles-fleet-example/capv/kubeadm/class-clusters/templates/cluster.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capv/kubeadm/class-clusters/templates/cluster.yaml
@@ -15,7 +15,7 @@ spec:
       - 192.168.0.0/16
   topology:
     class: vsphere-kubeadm-example
-    classNamespace: {{ .Values.cluster.namespace }}
+    classNamespace: capi-classes
     version: {{ .Values.cluster.version }}
     controlPlane:
       replicas: {{ .Values.cluster.control_plane_machine_count }}

--- a/tests/assets/rancher-turtles-fleet-example/capv/kubeadm/class-clusters/values.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capv/kubeadm/class-clusters/values.yaml
@@ -14,7 +14,7 @@ vsphere:
 
 cluster:
   name: turtles-qa-capv-kb-example
-  namespace: default
+  namespace: capi-clusters
   version: v1.31.4
   control_plane_machine_count: 1 # Todo: 3, turtles/issues/1402
   worker_machine_count: 1

--- a/tests/assets/rancher-turtles-fleet-example/capv/rke2/class-clusters/fleet.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capv/rke2/class-clusters/fleet.yaml
@@ -1,8 +1,8 @@
-namespace: default
+namespace: capi-clusters
 
 helm:
   valuesFrom:
     - secretKeyRef:
         name: capv-helm-values
-        namespace: default
+        namespace: capv-system
         key: values.yaml

--- a/tests/assets/rancher-turtles-fleet-example/capv/rke2/class-clusters/templates/cluster.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capv/rke2/class-clusters/templates/cluster.yaml
@@ -15,7 +15,7 @@ spec:
       - 192.168.0.0/16
   topology:
     class: vsphere-rke2-example
-    classNamespace: {{ .Values.cluster.namespace }}
+    classNamespace: capi-classes
     version: {{ .Values.cluster.rke2_version }}
     controlPlane:
       replicas: {{ .Values.cluster.control_plane_machine_count }}

--- a/tests/assets/rancher-turtles-fleet-example/capv/rke2/class-clusters/values.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capv/rke2/class-clusters/values.yaml
@@ -14,7 +14,7 @@ vsphere:
 
 cluster:
   name: turtles-qa-capv-rke2-example
-  namespace: default
+  namespace: capi-clusters
   rke2_version: v1.31.7+rke2r1
   control_plane_machine_count: 1
   worker_machine_count: 1

--- a/tests/assets/rancher-turtles-fleet-example/capv/rke2/clusters/fleet.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capv/rke2/clusters/fleet.yaml
@@ -1,8 +1,8 @@
-namespace: default
+namespace: capi-clusters
 
 helm:
   valuesFrom:
     - secretKeyRef:
         name: capv-helm-values
-        namespace: default
+        namespace: capv-system
         key: values.yaml

--- a/tests/assets/rancher-turtles-fleet-example/capv/rke2/clusters/values.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capv/rke2/clusters/values.yaml
@@ -14,7 +14,7 @@ vsphere:
 
 cluster:
   name: turtles-qa-capv-rke2
-  namespace: default
+  namespace: capi-clusters
   rke2_version: v1.31.7+rke2r1
   control_plane_machine_count: 1
   worker_machine_count: 1

--- a/tests/assets/rancher-turtles-fleet-example/capz/aks/class-clusters/fleet.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capz/aks/class-clusters/fleet.yaml
@@ -1,4 +1,4 @@
-namespace: default
+namespace: capi-clusters
 
 helm:
   valuesFrom:

--- a/tests/assets/rancher-turtles-fleet-example/capz/aks/class-clusters/templates/cluster.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capz/aks/class-clusters/templates/cluster.yaml
@@ -13,6 +13,7 @@ spec:
       - 192.168.0.0/16
   topology:
     class: {{ .Values.className }}
+    classNamespace: capi-clusters # TODO: Change to capi-classes (capi-ui-extension/issues/111)
     variables:
     - name: subscriptionID
       value: "{{ .Values.azure.subscriptionID }}"

--- a/tests/assets/rancher-turtles-fleet-example/capz/aks/clusters/fleet.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capz/aks/clusters/fleet.yaml
@@ -1,4 +1,4 @@
-namespace: default
+namespace: capi-clusters
 
 helm:
   valuesFrom:

--- a/tests/assets/rancher-turtles-fleet-example/capz/kubeadm/class-clusters/fleet.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capz/kubeadm/class-clusters/fleet.yaml
@@ -1,4 +1,4 @@
-namespace: default
+namespace: capi-clusters
 
 helm:
   valuesFrom:

--- a/tests/assets/rancher-turtles-fleet-example/capz/kubeadm/class-clusters/templates/cluster.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capz/kubeadm/class-clusters/templates/cluster.yaml
@@ -15,6 +15,7 @@ spec:
       - 192.168.0.0/16
   topology:
     class: {{ .Values.className }}
+    classNamespace: capi-classes
     controlPlane:
       replicas: {{ .Values.cp_machine_count }}
     variables:

--- a/tests/assets/rancher-turtles-fleet-example/capz/rke2/class-clusters/fleet.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capz/rke2/class-clusters/fleet.yaml
@@ -1,4 +1,4 @@
-namespace: default
+namespace: capi-clusters
 
 helm:
   valuesFrom:

--- a/tests/assets/rancher-turtles-fleet-example/capz/rke2/class-clusters/templates/cluster.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capz/rke2/class-clusters/templates/cluster.yaml
@@ -15,6 +15,7 @@ spec:
       - 192.168.0.0/16
   topology:
     class: {{ .Values.className }}
+    classNamespace: capi-classes
     controlPlane:
       replicas: {{ .Values.cp_machine_count }}
     variables:

--- a/tests/cypress/latest/e2e/unit_tests/capa_kubeadm_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capa_kubeadm_cluster.spec.ts
@@ -12,9 +12,6 @@ describe('Import CAPA Kubeadm Cluster', { tags: '@full' }, () => {
   const branch = 'main'
   const path = '/tests/assets/rancher-turtles-fleet-example/capa/kubeadm/clusters'
   const repoUrl = 'https://github.com/rancher/rancher-turtles-e2e.git'
-  const turtlesRepoUrl = 'https://github.com/rancher/turtles'
-  const examplesPath = ['examples/applications/cni/aws/calico', 'examples/applications/ccm/aws', 'examples/applications/csi/aws']
-  const awsAppsRepoName = 'aws-kubeadm-apps'
 
   beforeEach(() => {
     cy.login();
@@ -25,16 +22,14 @@ describe('Import CAPA Kubeadm Cluster', { tags: '@full' }, () => {
     cy.namespaceAutoImport('Enable');
   })
 
-  it('Add CAPA Kubeadm Applications Fleet Repo', () => {
-    cy.addFleetGitRepo(awsAppsRepoName, turtlesRepoUrl, 'main', examplesPath)
-
+  it('Check CAPA Kubeadm Applications', () => {
     // Navigate to `local` cluster, More Resources > Fleet > Helm Apps and ensure the charts are active.
     cy.burgerMenuOperate('open');
     cy.contains('local').click();
     cy.accesMenuSelection(['More Resources', 'Fleet', 'HelmApps']);
     ['aws-ccm', 'aws-csi-driver', 'calico-cni-aws'].forEach((app) => {
         cy.typeInFilter(app);
-        cy.waitForAllRowsInState('Active');
+        cy.getBySel('sortable-cell-0-1').should('exist');
     })
   })
 
@@ -107,9 +102,6 @@ describe('Import CAPA Kubeadm Cluster', { tags: '@full' }, () => {
         // Wait until the following returns no clusters found
         // This is checked by ensuring the cluster is not available in CAPI menu
         cy.checkCAPIClusterDeleted(clusterName, timeout);
-
-        // Remove the apps repo
-        cy.removeFleetGitRepo(awsAppsRepoName);
       })
     );
   }

--- a/tests/cypress/latest/e2e/unit_tests/capa_rke2_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capa_rke2_cluster.spec.ts
@@ -12,9 +12,6 @@ describe('Import CAPA RKE2 Cluster', { tags: '@full' }, () => {
   const branch = 'main'
   const path = '/tests/assets/rancher-turtles-fleet-example/capa/rke2/clusters'
   const repoUrl = 'https://github.com/rancher/rancher-turtles-e2e.git'
-  const turtlesRepoUrl = 'https://github.com/rancher/turtles'
-  const examplesPath = ['examples/applications/cni/aws/calico', 'examples/applications/ccm/aws', 'examples/applications/csi/aws']
-  const awsAppsRepoName = 'aws-rke2-apps'
 
   beforeEach(() => {
     cy.login();
@@ -25,16 +22,14 @@ describe('Import CAPA RKE2 Cluster', { tags: '@full' }, () => {
     cy.namespaceAutoImport('Enable');
   })
 
-  it('Add CAPA RKE2 Applications Fleet Repo', () => {
-    cy.addFleetGitRepo(awsAppsRepoName, turtlesRepoUrl, 'main', examplesPath)
-
+  it('Check CAPA RKE2 Applications', () => {
     // Navigate to `local` cluster, More Resources > Fleet > Helm Apps and ensure the charts are active.
     cy.burgerMenuOperate('open');
     cy.contains('local').click();
     cy.accesMenuSelection(['More Resources', 'Fleet', 'HelmApps']);
     ['aws-ccm', 'aws-csi-driver'].forEach((app) => {
         cy.typeInFilter(app);
-        cy.waitForAllRowsInState('Active');
+        cy.getBySel('sortable-cell-0-1').should('exist');
     })
   })
 
@@ -107,9 +102,6 @@ describe('Import CAPA RKE2 Cluster', { tags: '@full' }, () => {
         // Wait until the following returns no clusters found
         // This is checked by ensuring the cluster is not available in CAPI menu
         cy.checkCAPIClusterDeleted(clusterName, timeout);
-
-        // Remove the apps repo
-        cy.removeFleetGitRepo(awsAppsRepoName);
       })
     );
   }

--- a/tests/cypress/latest/e2e/unit_tests/capa_rke2_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capa_rke2_clusterclass.spec.ts
@@ -13,7 +13,7 @@ describe('Import CAPA RKE2 Class-Cluster', { tags: '@full' }, () => {
   const path = '/tests/assets/rancher-turtles-fleet-example/capa/rke2/class-clusters'
   const repoUrl = 'https://github.com/rancher/rancher-turtles-e2e.git'
   const turtlesRepoUrl = 'https://github.com/rancher/turtles'
-  const examplesPath = ['examples/clusterclasses/aws/rke2', 'examples/applications/cni/aws/calico', 'examples/applications/ccm/aws', 'examples/applications/csi/aws']
+  const classesPath = 'examples/clusterclasses/aws/rke2'
   const clusterClassRepoName = 'aws-rke2-clusterclass'
 
   beforeEach(() => {
@@ -26,8 +26,8 @@ describe('Import CAPA RKE2 Class-Cluster', { tags: '@full' }, () => {
   })
 
   qase(116,
-    it('Add CAPA RKE2 ClusterClass and Applications Fleet Repo', () => {
-      cy.addFleetGitRepo(clusterClassRepoName, turtlesRepoUrl, 'main', examplesPath)
+    it('Add CAPA RKE2 ClusterClass Fleet Repo and check Applications', () => {
+      cy.addFleetGitRepo(clusterClassRepoName, turtlesRepoUrl, 'main', classesPath, 'capi-classes')
       // Go to CAPI > ClusterClass to ensure the clusterclass is created
       cy.checkCAPIClusterClass(className);
 
@@ -37,7 +37,7 @@ describe('Import CAPA RKE2 Class-Cluster', { tags: '@full' }, () => {
       cy.accesMenuSelection(['More Resources', 'Fleet', 'HelmApps']);
       ['aws-ccm', 'aws-csi-driver'].forEach((app) => {
           cy.typeInFilter(app);
-          cy.waitForAllRowsInState('Active');
+          cy.getBySel('sortable-cell-0-1').should('exist');
       })
     })
   );

--- a/tests/cypress/latest/e2e/unit_tests/capd_kubeadm_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capd_kubeadm_cluster.spec.ts
@@ -40,7 +40,7 @@ describe('Import CAPD Kubeadm', { tags: '@short' }, () => {
 
   qase(92,
     it('Add CAPD Kubeadm ClusterClass using fleet', () => {
-      cy.addFleetGitRepo(clusterClassRepoName, turtlesRepoUrl, 'main', classesPath)
+      cy.addFleetGitRepo(clusterClassRepoName, turtlesRepoUrl, 'main', classesPath, 'capi-classes')
       // Go to CAPI > ClusterClass to ensure the clusterclass is created
       cy.checkCAPIClusterClass(className);
     })

--- a/tests/cypress/latest/e2e/unit_tests/capd_rke2_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capd_rke2_cluster.spec.ts
@@ -32,7 +32,7 @@ describe('Import CAPD RKE2', { tags: '@short' }, () => {
   const questions = [{ menuEntry: 'Rancher Turtles Features Settings', inputBoxTitle: 'Kubectl Image', inputBoxValue: 'registry.k8s.io/kubernetes/kubectl:v1.31.0' }];
 
   const turtlesRepoUrl = 'https://github.com/rancher/turtles'
-  const examplesPath = ['examples/clusterclasses/docker/rke2', 'examples/applications/lb/docker']
+  const classesPath = 'examples/clusterclasses/docker/rke2'
   const clusterClassRepoName = "docker-rke2-clusterclass"
 
   beforeEach(() => {
@@ -41,8 +41,8 @@ describe('Import CAPD RKE2', { tags: '@short' }, () => {
   });
 
   qase(91,
-    it('Add CAPD RKE2 ClusterClass and LB Fleet Repo', () => {
-      cy.addFleetGitRepo(clusterClassRepoName, turtlesRepoUrl, 'main', examplesPath)
+    it('Add CAPD RKE2 ClusterClass Fleet Repo', () => {
+      cy.addFleetGitRepo(clusterClassRepoName, turtlesRepoUrl, 'main', classesPath, 'capi-classes')
       // Go to CAPI > ClusterClass to ensure the clusterclass is created
       cy.checkCAPIClusterClass(className);
     })

--- a/tests/cypress/latest/e2e/unit_tests/capd_ui_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capd_ui_clusterclass.spec.ts
@@ -24,6 +24,7 @@ describe('Create CAPD', { tags: '@short' }, () => {
   const clusterName = clusterNamePrefix + randomstring.generate({ length: 4, capitalization: "lowercase" })
   const k8sVersion = 'v1.31.4'
   const pathNames = ['kubeadm'] // TODO: Add rke2 path (capi-ui-extension/issues/121)
+  const namespace = 'capi-classes' // TODO: Change to capi-clusters (capi-ui-extension/issues/111)
 
   beforeEach(() => {
     cy.login();
@@ -40,6 +41,8 @@ describe('Create CAPD', { tags: '@short' }, () => {
       cy.contains('local').click();
       cy.getBySel('header-action-import-yaml').click();
       cy.contains('Import YAML');
+      cy.get('.vs__selected-options').click();
+      cy.contains(namespace).click();
 
       cy.readFile('./fixtures/kindnet.yaml').then((data) => {
         cy.get('.CodeMirror')
@@ -95,8 +98,8 @@ describe('Create CAPD', { tags: '@short' }, () => {
       })
 
       it('Delete the Kindnet Config Map', () => {
-        cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'ConfigMaps'], "cni-docker-kubeadm-example-crs-0", 'default');
-        cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'ClusterResourceSets'], "docker-kubeadm-example-crs-0", 'default');
+        cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'ConfigMaps'], "cni-docker-kubeadm-example-crs-0", namespace);
+        cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'ClusterResourceSets'], "docker-kubeadm-example-crs-0", namespace);
       })
     }
   })

--- a/tests/cypress/latest/e2e/unit_tests/capg_gke_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capg_gke_cluster.spec.ts
@@ -35,7 +35,6 @@ describe('Import CAPG GKE Cluster', { tags: '@full' }, () => {
     });
     cy.clickButton('Import');
     cy.clickButton('Close');
-
   })
 
   it('Setup the namespace for importing', () => {

--- a/tests/cypress/latest/e2e/unit_tests/capv_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capv_kubeadm_clusterclass.spec.ts
@@ -13,8 +13,9 @@ describe('Import CAPV Kubeadm Class-Cluster', { tags: '@vsphere' }, () => {
   const path = '/tests/assets/rancher-turtles-fleet-example/capv/kubeadm/class-clusters'
   const repoUrl = 'https://github.com/rancher/rancher-turtles-e2e.git'
   const turtlesRepoUrl = 'https://github.com/rancher/turtles'
-  const examplesPath = ['examples/clusterclasses/vsphere/kubeadm', 'examples/applications/ccm/vsphere', 'examples/applications/csi/vsphere']
+  const classesPath = 'examples/clusterclasses/vsphere/kubeadm'
   const vsphere_secrets_json_base64 = Cypress.env("vsphere_secrets_json_base64")
+  const namespace = 'capv-system'
 
   // Decode the base64 encoded secrets and make json object
   const vsphere_secrets_json = JSON.parse(Buffer.from(vsphere_secrets_json_base64, 'base64').toString('utf-8'))
@@ -34,6 +35,7 @@ describe('Import CAPV Kubeadm Class-Cluster', { tags: '@vsphere' }, () => {
     cy.get('.header-buttons > :nth-child(1) > .icon')
       .click();
     cy.contains('Import YAML');
+
     var encodedData = ''
     cy.readFile('./fixtures/capv-helm-values.yaml').then((data) => {
       data = data.replace(/replace_vsphere_server/g, JSON.stringify(vsphere_secrets_json.vsphere_server))
@@ -73,8 +75,8 @@ describe('Import CAPV Kubeadm Class-Cluster', { tags: '@vsphere' }, () => {
     cy.createVSphereClusterIdentity(vsphere_username, vsphere_password)
   })
 
-  it('Add CAPV Kubeadm ClusterClass and Applications Fleet Repo', () => {
-    cy.addFleetGitRepo(classRepoName, turtlesRepoUrl, 'main', examplesPath)
+  it('Add CAPV Kubeadm ClusterClass Fleet Repo and check Applications', () => {
+    cy.addFleetGitRepo(classRepoName, turtlesRepoUrl, 'main', classesPath, 'capi-classes')
     // Go to CAPI > ClusterClass to ensure the clusterclass is created
     cy.checkCAPIClusterClass(className);
 
@@ -83,7 +85,7 @@ describe('Import CAPV Kubeadm Class-Cluster', { tags: '@vsphere' }, () => {
     cy.contains('local').click();
     cy.accesMenuSelection(['More Resources', 'Fleet', 'HelmApps']);
     cy.typeInFilter('vsphere-ccm');
-    cy.waitForAllRowsInState('Active');
+    cy.getBySel('sortable-cell-0-1').should('exist');
   });
 
 
@@ -147,8 +149,8 @@ describe('Import CAPV Kubeadm Class-Cluster', { tags: '@vsphere' }, () => {
       cy.removeFleetGitRepo(classRepoName);
 
       // Delete secret and VSphereClusterIdentity
-      cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'VSphereClusterIdentities'], 'cluster-identity', 'default')
-      cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], "capv-helm-values", 'default')
+      cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'VSphereClusterIdentities'], 'cluster-identity', 'capi-clusters')
+      cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], "capv-helm-values", namespace)
     })
   }
 });

--- a/tests/cypress/latest/e2e/unit_tests/capv_rke2_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capv_rke2_cluster.spec.ts
@@ -11,6 +11,7 @@ describe('Import CAPV RKE2 Cluster', { tags: '@vsphere' }, () => {
   const path = '/tests/assets/rancher-turtles-fleet-example/capv/rke2/clusters'
   const repoUrl = "https://github.com/rancher/rancher-turtles-e2e.git"
   const vsphere_secrets_json_base64 = Cypress.env("vsphere_secrets_json_base64")
+  const namespace = 'capv-system'
 
   // The `vsphere_secrets_json_base64` environment variable must be stored in GitHub Actions Secrets and BASE64 encoded.
   // export VSPHERE_SECRETS_JSON_BASE64=$(echo '
@@ -49,6 +50,7 @@ describe('Import CAPV RKE2 Cluster', { tags: '@vsphere' }, () => {
     cy.get('.header-buttons > :nth-child(1) > .icon')
       .click();
     cy.contains('Import YAML');
+
     var encodedData = ''
     cy.readFile('./fixtures/capv-helm-values.yaml').then((data) => {
       data = data.replace(/replace_vsphere_server/g, JSON.stringify(vsphere_secrets_json.vsphere_server))
@@ -209,7 +211,7 @@ describe('Import CAPV RKE2 Cluster', { tags: '@vsphere' }, () => {
     })
 
     it('Delete the helm values secret', () => {
-      cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], "capv-helm-values", 'default')
+      cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], "capv-helm-values", namespace)
     })
   }
 });

--- a/tests/cypress/latest/e2e/unit_tests/capv_rke2_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capv_rke2_clusterclass.spec.ts
@@ -13,8 +13,9 @@ describe('Import CAPV RKE2 Class-Cluster', { tags: '@vsphere' }, () => {
   const path = '/tests/assets/rancher-turtles-fleet-example/capv/rke2/class-clusters'
   const repoUrl = 'https://github.com/rancher/rancher-turtles-e2e.git'
   const turtlesRepoUrl = 'https://github.com/rancher/turtles'
-  const examplesPath = ['examples/clusterclasses/vsphere/rke2', 'examples/applications/ccm/vsphere', 'examples/applications/csi/vsphere']
+  const classesPath = 'examples/clusterclasses/vsphere/rke2'
   const vsphere_secrets_json_base64 = Cypress.env("vsphere_secrets_json_base64")
+  const namespace = 'capv-system'
 
   // Decode the base64 encoded secrets and make json object
   const vsphere_secrets_json = JSON.parse(Buffer.from(vsphere_secrets_json_base64, 'base64').toString('utf-8'))
@@ -34,6 +35,7 @@ describe('Import CAPV RKE2 Class-Cluster', { tags: '@vsphere' }, () => {
     cy.get('.header-buttons > :nth-child(1) > .icon')
       .click();
     cy.contains('Import YAML');
+
     var encodedData = ''
     cy.readFile('./fixtures/capv-helm-values.yaml').then((data) => {
       data = data.replace(/replace_vsphere_server/g, JSON.stringify(vsphere_secrets_json.vsphere_server))
@@ -79,8 +81,8 @@ describe('Import CAPV RKE2 Class-Cluster', { tags: '@vsphere' }, () => {
     cy.createVSphereClusterIdentity(vsphere_username, vsphere_password)
   })
 
-  it('Add CAPV RKE2 ClusterClass and Applications Fleet Repo', () => {
-    cy.addFleetGitRepo(classRepoName, turtlesRepoUrl, 'main', examplesPath)
+  it('Add CAPV RKE2 ClusterClass Fleet Repo and check Applications', () => {
+    cy.addFleetGitRepo(classRepoName, turtlesRepoUrl, 'main', classesPath, 'capi-classes')
     // Go to CAPI > ClusterClass to ensure the clusterclass is created
     cy.checkCAPIClusterClass(className);
 
@@ -89,7 +91,7 @@ describe('Import CAPV RKE2 Class-Cluster', { tags: '@vsphere' }, () => {
     cy.contains('local').click();
     cy.accesMenuSelection(['More Resources', 'Fleet', 'HelmApps']);
     cy.typeInFilter('vsphere-ccm');
-    cy.waitForAllRowsInState('Active');
+    cy.getBySel('sortable-cell-0-1').should('exist');
   });
 
 
@@ -154,8 +156,8 @@ describe('Import CAPV RKE2 Class-Cluster', { tags: '@vsphere' }, () => {
       cy.removeFleetGitRepo(classRepoName);
 
       // Delete secret and VSphereClusterIdentity
-      cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'VSphereClusterIdentities'], 'cluster-identity', 'default')
-      cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], "capv-helm-values", 'default')
+      cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'VSphereClusterIdentities'], 'cluster-identity', 'capi-clusters')
+      cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], "capv-helm-values", namespace)
     })
   }
 });

--- a/tests/cypress/latest/e2e/unit_tests/capz_aks_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capz_aks_cluster.spec.ts
@@ -105,9 +105,8 @@ describe('Import CAPZ AKS Cluster', { tags: '@full' }, () => {
       })
     })
 
-    it('Delete AzureClusterIdentities resource', { retries: 1 }, () => {
-      // This test can be flaky, so it is in a separate test.
-      cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'AzureClusterIdentities'], 'cluster-identity', 'default')
+    it('Delete AzureClusterIdentities resource', () => {
+      cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'AzureClusterIdentities'], 'cluster-identity', 'capi-clusters')
     })
   }
 

--- a/tests/cypress/latest/e2e/unit_tests/capz_aks_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capz_aks_clusterclass.spec.ts
@@ -45,7 +45,7 @@ describe('Import/Create CAPZ AKS Class-Cluster', { tags: '@full' }, () => {
   })
 
   qase(84, it('Add CAPZ AKS ClusterClass using fleet', () => {
-    cy.addFleetGitRepo(clusterClassRepoName, turtlesRepoUrl, 'main', classesPath)
+    cy.addFleetGitRepo(clusterClassRepoName, turtlesRepoUrl, 'main', classesPath, 'capi-clusters')
     // Go to CAPI > ClusterClass to ensure the clusterclass is created
     cy.checkCAPIClusterClass(className);
   })
@@ -149,7 +149,7 @@ describe('Import/Create CAPZ AKS Class-Cluster', { tags: '@full' }, () => {
 
       // Delete secret and AzureClusterIdentity
       cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], "azure-creds-secret", namespace)
-      cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'AzureClusterIdentities'], 'cluster-identity', 'default')
+      cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'AzureClusterIdentities'], 'cluster-identity', 'capi-clusters')
       cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], "cluster-identity-secret", namespace)
     })
   }

--- a/tests/cypress/latest/e2e/unit_tests/capz_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capz_kubeadm_clusterclass.spec.ts
@@ -13,7 +13,7 @@ describe('Import CAPZ Kubeadm Class-Cluster', { tags: '@full' }, () => {
     const path = '/tests/assets/rancher-turtles-fleet-example/capz/kubeadm/class-clusters'
     const repoUrl = "https://github.com/rancher/rancher-turtles-e2e.git"
     const turtlesRepoUrl = 'https://github.com/rancher/turtles'
-    const examplesPath = ['examples/clusterclasses/azure/kubeadm', '/examples/applications/ccm/azure']
+    const classesPath = 'examples/clusterclasses/azure/kubeadm'
     const clusterClassRepoName = "azure-kubeadm-clusterclass"
 
     const clientID = Cypress.env("azure_client_id")
@@ -38,8 +38,8 @@ describe('Import CAPZ Kubeadm Class-Cluster', { tags: '@full' }, () => {
         cy.createAzureClusterIdentity(clientID, tenantID, clientSecret)
     })
 
-    it('Add CAPZ Kubeadm ClusterClass and Azure CCM Fleet Repo', () => {
-        cy.addFleetGitRepo(clusterClassRepoName, turtlesRepoUrl, 'main', examplesPath)
+    it('Add CAPZ Kubeadm ClusterClass Fleet Repo and check Azure CCM', () => {
+        cy.addFleetGitRepo(clusterClassRepoName, turtlesRepoUrl, 'main', classesPath, 'capi-classes')
         // Go to CAPI > ClusterClass to ensure the clusterclass is created
         cy.checkCAPIClusterClass(className);
 
@@ -49,7 +49,7 @@ describe('Import CAPZ Kubeadm Class-Cluster', { tags: '@full' }, () => {
         cy.accesMenuSelection(['More Resources', 'Fleet', 'HelmApps']);
         ["azure-ccm", "calico-cni"].forEach((app) => {
             cy.typeInFilter(app);
-            cy.waitForAllRowsInState('Active');
+            cy.getBySel('sortable-cell-0-1').should('exist');
         })
     });
 
@@ -83,7 +83,7 @@ describe('Import CAPZ Kubeadm Class-Cluster', { tags: '@full' }, () => {
         cy.checkCAPIClusterActive(clusterName, timeout);
     });
 
-    it('Install App on imported cluster', { retries: 1 }, () => {
+    it('Install App on imported cluster', () => {
         // Click on imported CAPZ cluster
         cy.contains(clusterName).click();
 
@@ -117,7 +117,7 @@ describe('Import CAPZ Kubeadm Class-Cluster', { tags: '@full' }, () => {
 
             // Delete secret and AzureClusterIdentity
             cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], "azure-creds-secret", namespace)
-            cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'AzureClusterIdentities'], 'cluster-identity', 'default')
+            cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'AzureClusterIdentities'], 'cluster-identity', 'capi-clusters')
             cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], "cluster-identity-secret", namespace)
         });
     }

--- a/tests/cypress/latest/e2e/unit_tests/capz_rke2_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capz_rke2_clusterclass.spec.ts
@@ -13,7 +13,7 @@ describe('Import CAPZ RKE2 Class-Cluster', { tags: '@full' }, () => {
     const path = '/tests/assets/rancher-turtles-fleet-example/capz/rke2/class-clusters'
     const repoUrl = "https://github.com/rancher/rancher-turtles-e2e.git"
     const turtlesRepoUrl = 'https://github.com/rancher/turtles'
-    const examplesPath = ['examples/clusterclasses/azure/rke2', '/examples/applications/ccm/azure']
+    const classesPath = 'examples/clusterclasses/azure/rke2'
     const clusterClassRepoName = "azure-rke2-clusterclass"
 
     const clientID = Cypress.env("azure_client_id")
@@ -38,8 +38,8 @@ describe('Import CAPZ RKE2 Class-Cluster', { tags: '@full' }, () => {
         cy.createAzureClusterIdentity(clientID, tenantID, clientSecret)
     })
 
-    qase(87, it('Add CAPZ RKE2 ClusterClass and Azure CCM Fleet Repo', () => {
-        cy.addFleetGitRepo(clusterClassRepoName, turtlesRepoUrl, 'main', examplesPath)
+    qase(87, it('Add CAPZ RKE2 ClusterClass Fleet Repo and check Azure CCM', () => {
+        cy.addFleetGitRepo(clusterClassRepoName, turtlesRepoUrl, 'main', classesPath, 'capi-classes')
         // Go to CAPI > ClusterClass to ensure the clusterclass is created
         cy.checkCAPIClusterClass(className);
 
@@ -49,7 +49,7 @@ describe('Import CAPZ RKE2 Class-Cluster', { tags: '@full' }, () => {
         cy.accesMenuSelection(['More Resources', 'Fleet', 'HelmApps']);
         ["azure-ccm", "calico-cni"].forEach((app) => {
             cy.typeInFilter(app);
-            cy.waitForAllRowsInState('Active');
+            cy.getBySel('sortable-cell-0-1').should('exist');
         })
     })
     );
@@ -122,7 +122,7 @@ describe('Import CAPZ RKE2 Class-Cluster', { tags: '@full' }, () => {
 
             // Delete secret and AzureClusterIdentity
             cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], "azure-creds-secret", namespace)
-            cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'AzureClusterIdentities'], 'cluster-identity', 'default')
+            cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'AzureClusterIdentities'], 'cluster-identity', 'capi-clusters')
             cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], "cluster-identity-secret", namespace)
         })
         );

--- a/tests/cypress/latest/e2e/unit_tests/providers_setup.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/providers_setup.spec.ts
@@ -39,6 +39,7 @@ describe('Enable CAPI Providers', () => {
 
   const kubeadmBaseURL = 'https://github.com/kubernetes-sigs/cluster-api/releases/'
   const kubeadmProviderTypes = ['bootstrap', 'control plane']
+  const capiNamespaces = ['capi-clusters', 'capi-classes']
   const localProviderNamespaces = ['capi-kubeadm-bootstrap-system', 'capi-kubeadm-control-plane-system', 'capd-system']
   const cloudProviderNamespaces = ['capa-system', 'capg-system', 'capz-system']
   const vsphereProviderNamespace = 'capv-system'
@@ -49,6 +50,12 @@ describe('Enable CAPI Providers', () => {
   });
 
   context('Local providers - @install', { tags: '@install' }, () => {
+    capiNamespaces.forEach(namespace => {
+      it('Create CAPI Namespaces - ' + namespace, () => {
+        cy.createNamespace(namespace);
+      })
+    })
+
     localProviderNamespaces.forEach(namespace => {
       it('Create CAPI Providers Namespaces - ' + namespace, () => {
         cy.createNamespace(namespace);
@@ -89,10 +96,10 @@ describe('Enable CAPI Providers', () => {
     );
 
     qase(90,
-      // CNI to be used across all specs
-      it('Add CNI fleet repo', () => {
-        // Add upstream cni repo
-        cy.addFleetGitRepo('cni-calico', turtlesRepoUrl, branch, 'examples/applications/cni/calico');
+      // HelmApps to be used across all specs
+      it('Add Applications fleet repo', () => {
+        // Add upstream apps repo
+        cy.addFleetGitRepo('helm-apps', turtlesRepoUrl, branch, 'examples/applications/', 'capi-clusters');
       })
     );
 

--- a/tests/cypress/latest/fixtures/capv-helm-values-secret.yaml
+++ b/tests/cypress/latest/fixtures/capv-helm-values-secret.yaml
@@ -5,4 +5,4 @@ data:
 kind: Secret
 metadata:
   name: capv-helm-values
-  namespace: default
+  namespace: capv-system

--- a/tests/cypress/latest/fixtures/capv-vsphere-cluster-identity.yaml
+++ b/tests/cypress/latest/fixtures/capv-vsphere-cluster-identity.yaml
@@ -12,6 +12,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereClusterIdentity
 metadata:
   name: cluster-identity
+  namespace: capi-clusters
 spec:
   secretName: cluster-identity
   allowedNamespaces:

--- a/tests/cypress/latest/fixtures/capz-azure-cluster-identity.yaml
+++ b/tests/cypress/latest/fixtures/capz-azure-cluster-identity.yaml
@@ -15,6 +15,7 @@ metadata:
   labels:
     clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
   name: cluster-identity
+  namespace: capi-clusters
 spec:
   allowedNamespaces: {}
   clientID: replace_client_id

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -23,11 +23,12 @@ import _ from 'lodash';
 // Go to specific Sub Menu from Access Menu
 Cypress.Commands.add('accesMenuSelection', (menuPaths: string[]) => {
   menuPaths.forEach((path) => {
+    cy.wait(1000);
     cypressLib.accesMenu(path);
   })
 });
 
-// Command to set CAPI Auto-import on default namespace
+// Command to set CAPI Auto-import on capi-clusters namespace
 Cypress.Commands.add('namespaceAutoImport', (mode) => {
   cy.contains('local')
     .click();
@@ -35,8 +36,8 @@ Cypress.Commands.add('namespaceAutoImport', (mode) => {
   cy.contains('Create Project')
     .should('be.visible');
 
-  // Select default namespace
-  cy.setNamespace('default');
+  // Select capi-clusters namespace
+  cy.setNamespace('capi-clusters');
   cy.setAutoImport(mode);
   cy.namespaceReset();
 });
@@ -619,7 +620,7 @@ Cypress.Commands.add('goToHome', () => {
 
 // Fleet commands
 // Command add Fleet Git Repository
-Cypress.Commands.add('addFleetGitRepo', (repoName, repoUrl, branch, paths, workspace, targetNamespace) => {
+Cypress.Commands.add('addFleetGitRepo', (repoName, repoUrl, branch, paths, targetNamespace, workspace) => {
   cy.accesMenuSelection(['Continuous Delivery', 'Git Repos']);
   cy.getBySel('masthead-create').should('be.visible');
   cy.contains('fleet-').click();
@@ -789,7 +790,6 @@ Cypress.Commands.add('exploreCluster', (clusterName: string) => {
   cy.accesMenuSelection([clusterName])
   cy.getBySel('header').get('.cluster-name').contains(clusterName);
 });
-
 
 // Create VSphereClusterIdentity
 Cypress.Commands.add('createVSphereClusterIdentity', (vsphere_username, vsphere_password) => {

--- a/tests/cypress/latest/support/e2e.ts
+++ b/tests/cypress/latest/support/e2e.ts
@@ -26,7 +26,7 @@ declare global {
       namespaceAutoImport(mode: string): Chainable<Element>;
       setAutoImport(mode: string): Chainable<Element>;
       clusterAutoImport(clusterName: string, mode: string): Chainable<Element>;
-      addFleetGitRepo(repoName: string, repoUrl: string, branch: string, paths: string | string[], workspace?: string, targetNamespace?: string): Chainable<Element>;
+      addFleetGitRepo(repoName: string, repoUrl: string, branch: string, paths: string | string[], targetNamespace?: string, workspace?: string): Chainable<Element>;
       removeFleetGitRepo(repoName: string, workspace?: string): Chainable<Element>;
       forceUpdateFleetGitRepo(repoName: string, workspace?: string): Chainable<Element>;
       checkFleetGitRepo(repoName: string, workspace?: string): Chainable<Element>;


### PR DESCRIPTION
### What does this PR do?
- Change namespace from `default` to `capi-clusters` and `capi-classes`
- Add Applications fleet repo commonly, to be used across all tests
- Use non-default ns for secrets, cluster identities 

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #167 

### Checklist:
- [x] GitHub Actions:
:green_circle: [@short](https://github.com/rancher/rancher-turtles-e2e/actions/runs/15568404305), [@full](https://github.com/rancher/rancher-turtles-e2e/actions/runs/15567193616), [@vsphere](https://github.com/rancher/rancher-turtles-e2e/actions/runs/15567188066)

