### PR TITLE
CAPV RKE2 kube-vip test

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -345,7 +345,7 @@ jobs:
       - name: Inject kube-vip controlplane IP for vsphere into capv-helm-values.yaml
         if: ${{ needs.create-runner.outputs.uuid == 'vsphere' }}
         run: |
-          # A round-robin distribution of 3 available control plane IPs
+          # A round-robin distribution of 3 available control plane IPs for kube-vip
           INDEX=$(((${{ github.run_number }} % 3) + 1))
           CP_ENDPOINT_IP=$(echo ${{ secrets.vsphere_endpoints_list }} | cut -d' ' -f${INDEX})
           sed -i "s/replace_cluster_control_plane_endpoint_ip/${CP_ENDPOINT_IP}/" tests/cypress/latest/fixtures/capv-helm-values.yaml

--- a/tests/assets/rancher-turtles-fleet-example/capv/rke2/class-clusters/templates/cluster.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capv/rke2/class-clusters/templates/cluster.yaml
@@ -53,6 +53,8 @@ spec:
       value: eth0
     - name: productKey
       value: {{ .Values.cluster.product_key | quote }}
+    - name: dockerAuthSecret
+      value: {{ .Values.cluster.docker_auth_token_secret_name }}
 ---
 kind: Bundle
 apiVersion: fleet.cattle.io/v1alpha1

--- a/tests/assets/rancher-turtles-fleet-example/capv/rke2/class-clusters/values.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capv/rke2/class-clusters/values.yaml
@@ -19,3 +19,4 @@ cluster:
   control_plane_machine_count: 1
   worker_machine_count: 1
   product_key: ""
+  docker_auth_token_secret_name: capv-docker-token

--- a/tests/cypress/latest/e2e/unit_tests/capv_rke2_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capv_rke2_cluster.spec.ts
@@ -7,7 +7,7 @@ describe('Import CAPV RKE2 Cluster', { tags: '@vsphere' }, () => {
   const timeout = 1200000
   const repoName = 'clusters-capv-rke2'
   const clusterName = "turtles-qa-capv-rke2"
-  const branch = 'main'
+  const branch = 'capv-kube-vip-test' // TODO: change to main when the branch is merged
   const path = '/tests/assets/rancher-turtles-fleet-example/capv/rke2/clusters'
   const repoUrl = "https://github.com/rancher/rancher-turtles-e2e.git"
   const vsphere_secrets_json_base64 = Cypress.env("vsphere_secrets_json_base64")
@@ -28,8 +28,10 @@ describe('Import CAPV RKE2 Cluster', { tags: '@vsphere' }, () => {
   //     "vsphere_kubeadm_template": "replace_vsphere_kubeadm_template",
   //     "vsphere_ssh_authorized_key": "replace_vsphere_ssh_authorized_key",
   //     "vsphere_tls_thumbprint": "replace_vsphere_tls_thumbprint",
-  //     "cluster_control_plane_endpoint_ip": "replace_cluster_control_plane_endpoint_ip"
-  //     "cluster_product_key": "replace_cluster_product_key"
+  //     "cluster_control_plane_endpoint_ip": "replace_cluster_control_plane_endpoint_ip",
+  //     "cluster_product_key": "replace_cluster_product_key",
+  //     "cluster_docker_auth_username": "replace_cluster_docker_auth_username",
+  //     "cluster_docker_auth_password": "replace_cluster_docker_auth_password"
   //   }' | jq | base64 -w0)
 
   // Decode the base64 encoded secrets and make json object
@@ -140,8 +142,8 @@ describe('Import CAPV RKE2 Cluster', { tags: '@vsphere' }, () => {
 
     var encodedData = ''
     cy.readFile('./fixtures/capv-helm-values.yaml').then((data) => {
-      data = data.replace(/control_plane_machine_count: 1/g, "control_plane_machine_count: 2")
-      data = data.replace(/worker_machine_count: 1/g, "worker_machine_count: 2")
+      data = data.replace(/control_plane_machine_count: 1/g, "control_plane_machine_count: 3")
+      data = data.replace(/worker_machine_count: 1/g, "worker_machine_count: 3")
 
       // workaround; these values need to be re-replaced before applying the scaling changes
       data = data.replace(/replace_vsphere_server/g, JSON.stringify(vsphere_secrets_json.vsphere_server))
@@ -159,7 +161,7 @@ describe('Import CAPV RKE2 Cluster', { tags: '@vsphere' }, () => {
       // This is not mandatory field, usable for SLE only
       if (vsphere_secrets_json.cluster_product_key) {
         const productKeyValue = vsphere_secrets_json.cluster_product_key
-        data = data.replace(/product_key: ""/, `product_key: "${productKeyValue}"`);
+        data = data.replace(/product_key:.*/, `product_key: "${productKeyValue}"`);
       }
       // Placeholder 'replace_cluster_control_plane_endpoint_ip' is already replaced at workflow level
       // Anyway it might be helpful for local runs when capv-helm-values.yaml is not modified by the workflow

--- a/tests/cypress/latest/fixtures/capv-docker-auth-token-secret.yaml
+++ b/tests/cypress/latest/fixtures/capv-docker-auth-token-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: capv-docker-token
+  namespace: capi-clusters
+type: Opaque
+data:
+  username: replace_cluster_docker_auth_username
+  password: replace_cluster_docker_auth_password

--- a/tests/cypress/latest/fixtures/capv-helm-values.yaml
+++ b/tests/cypress/latest/fixtures/capv-helm-values.yaml
@@ -15,3 +15,6 @@ vsphere:
 cluster:
   control_plane_endpoint_ip: replace_cluster_control_plane_endpoint_ip
   product_key: ""
+  control_plane_machine_count: 1
+  worker_machine_count: 1
+  docker_auth_token_secret_name: capv-docker-token

--- a/tests/cypress/latest/fixtures/capv-kube-vip-static-pod-toggle-job.yaml
+++ b/tests/cypress/latest/fixtures/capv-kube-vip-static-pod-toggle-job.yaml
@@ -1,0 +1,41 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kube-vip-toggle
+  namespace: kube-system
+spec:
+  ttlSecondsAfterFinished: 5
+  template:
+    spec:
+      restartPolicy: Never
+      # kubectl get leases.coordination.k8s.io plndr-cp-lock -n kube-system -ojsonpath='{.spec.holderIdentity}'
+      nodeName: replace_by_active_kubevip_leader_node_name
+      containers:
+      - name: kube-vip-toggle
+        image: registry.suse.com/bci/bci-busybox:16.0
+        command:
+        - sh
+        - -c
+        - |
+          set -e
+          cd /manifests
+          if [ -f "kube-vip.yaml" ]; then
+            echo "Renaming kube-vip.yaml -> .kube-vip.yaml-inactive"
+            mv kube-vip.yaml .kube-vip.yaml-inactive
+            exit 0
+          elif [ -f ".kube-vip.yaml-inactive" ]; then
+            echo "Renaming .kube-vip.yaml-inactive -> kube-vip.yaml"
+            mv .kube-vip.yaml-inactive kube-vip.yaml
+            exit 0
+          else
+            echo "Neither kube-vip.yaml nor .kube-vip.yaml-inactive found. Nothing to do."
+            exit 42
+          fi
+        volumeMounts:
+        - name: manifests
+          mountPath: /manifests
+      volumes:
+      - name: manifests
+        hostPath:
+          path: /var/lib/rancher/rke2/agent/pod-manifests
+          type: Directory

--- a/tests/cypress/latest/support/e2e.ts
+++ b/tests/cypress/latest/support/e2e.ts
@@ -59,6 +59,8 @@ declare global {
       typeInFilter(text: string): Chainable<Element>;
       goToHome(): Chainable<Element>;
       patchYamlResource(clusterName: string, namespace: string, resourceKind: string, resourceName: string, patch: object): Chainable<Element>;
+      importYaml(clusterName: string, yamlOrPath: string, namespace?: string): Chainable<Element>;
+      verifyResourceCount(clusterName: string, resourcePath: string[], resourceName: string, namespace: string, expectedCount: number, timeout?: number): Chainable<Element>;
       exploreCluster(clusterName: string): Chainable<Element>;
       createVSphereClusterIdentity(vsphere_username: string, vsphere_password: string): Chainable<Element>;
       createAWSClusterStaticIdentity(accessKey: string, secretKey: string): Chainable<Element>;


### PR DESCRIPTION
### What does this PR do?
Described in QASE RT case 131https://app.qase.io/project/RT?case=131&suite=18

In addition:
* capv rke2 clusterClass test now provisions HA cluster (3+3)
* new `cy.ImportYaml` function taken from fleet-e2e project - accepts files as well as variable with yaml
* new `cy.verifyResourceCount` for blocking until the resources are available
* capv rke2 clusterClass now uses dockerhub authentication - to preven Rate limit (not doable for simple/legacy rke2)
* Introduced `control_plane_machine_count` and ` worker_machine_count` keys in `capv-helm-values.yaml` - before this change defaults from chart's values.yaml were used.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #168 #208

### Checklist:
- [x] Squashed commits into logical changes
- [x] Documentation
- [x] GitHub Actions (if applicable): ~https://github.com/rancher/rancher-turtles-e2e/actions/runs/15710161605~
* ~new testrun (added namespace selection for importYaml + counting kub-vip pods + fleetaddon bump) https://github.com/rancher/rancher-turtles-e2e/actions/runs/15829662610~
* new testrun (using fixed docker auth): https://github.com/rancher/rancher-turtles-e2e/actions/runs/15998945174/job/45128875366

### Special notes for your reviewer:
