### PR TITLE
Use Cluster Identities for Clusterclass tests

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -405,19 +405,19 @@ jobs:
             e2e/unit_tests/capd_rke2_cluster.spec.ts
             e2e/unit_tests/capd_ui_clusterclass.spec.ts
             e2e/unit_tests/capv_rke2_cluster.spec.ts
+            e2e/unit_tests/capa_eks_cluster.spec.ts
+            e2e/unit_tests/capa_rke2_cluster.spec.ts
+            e2e/unit_tests/capa_kubeadm_cluster.spec.ts
+            e2e/unit_tests/capz_aks_cluster.spec.ts
+            e2e/unit_tests/capz_rke2_v2prov_cluster.spec.ts
+            e2e/unit_tests/capg_gke_cluster.spec.ts
             e2e/unit_tests/capv_rke2_clusterclass.spec.ts
             e2e/unit_tests/capv_kubeadm_clusterclass.spec.ts
-            e2e/unit_tests/capa_eks_cluster.spec.ts
-            e2e/unit_tests/capa_kubeadm_cluster.spec.ts
-            e2e/unit_tests/capa_kubeadm_clusterclass.spec.ts
-            e2e/unit_tests/capa_rke2_cluster.spec.ts
             e2e/unit_tests/capa_rke2_clusterclass.spec.ts
-            e2e/unit_tests/capz_aks_cluster.spec.ts
+            e2e/unit_tests/capa_kubeadm_clusterclass.spec.ts
             e2e/unit_tests/capz_aks_clusterclass.spec.ts
             e2e/unit_tests/capz_rke2_clusterclass.spec.ts
             e2e/unit_tests/capz_kubeadm_clusterclass.spec.ts
-            e2e/unit_tests/capz_rke2_v2prov_cluster.spec.ts
-            e2e/unit_tests/capg_gke_cluster.spec.ts
           UI_ACCOUNT: ${{ inputs.ui_account }}
           UPGRADE_OS_CHANNEL: ${{ inputs.upgrade_os_channel }}
         run: |

--- a/tests/assets/rancher-turtles-fleet-example/capa/kubeadm/class-clusters/templates/cluster.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capa/kubeadm/class-clusters/templates/cluster.yaml
@@ -7,6 +7,7 @@ metadata:
     cni: calico
     cloud-provider: aws
     csi: aws-ebs-csi-driver
+    cluster-api.cattle.io/rancher-auto-import: "true"
   name: {{ $cluster_name }}
 spec:
   clusterNetwork:
@@ -27,6 +28,8 @@ spec:
       value: {{ .Values.machine_type }}
     - name: workerMachineType
       value: {{ .Values.machine_type }}
+    - name: awsClusterIdentityName
+      value: cluster-identity
     - name: amiID
       value: {{ .Values.ami_id }}
     version: {{ .Values.version }}

--- a/tests/assets/rancher-turtles-fleet-example/capa/rke2/class-clusters/templates/cluster.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capa/rke2/class-clusters/templates/cluster.yaml
@@ -7,6 +7,7 @@ metadata:
     cni: calico
     cloud-provider: aws
     csi: aws-ebs-csi-driver
+    cluster-api.cattle.io/rancher-auto-import: "true"
   name: {{ $cluster_name }}
 spec:
   clusterNetwork:
@@ -31,6 +32,8 @@ spec:
       value: {{ .Values.ami_id }}
     - name: cni
       value: none
+    - name: awsClusterIdentityName
+      value: cluster-identity
     version: {{ .Values.version }}
     workers:
       machineDeployments:

--- a/tests/assets/rancher-turtles-fleet-example/capz/aks/class-clusters/templates/cluster.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capz/aks/class-clusters/templates/cluster.yaml
@@ -5,6 +5,7 @@ kind: Cluster
 metadata:
   labels:
     owner: turtles-qa
+    cluster-api.cattle.io/rancher-auto-import: "true"
   name: {{ $cluster_name }}
 spec:
   clusterNetwork:

--- a/tests/assets/rancher-turtles-fleet-example/capz/kubeadm/class-clusters/templates/cluster.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capz/kubeadm/class-clusters/templates/cluster.yaml
@@ -7,6 +7,7 @@ metadata:
     owner: turtles-qa
     cloud-provider: azure
     cni: calico
+    cluster-api.cattle.io/rancher-auto-import: "true"
   name: {{ $cluster_name }}
 spec:
   clusterNetwork:

--- a/tests/assets/rancher-turtles-fleet-example/capz/rke2/class-clusters/templates/cluster.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capz/rke2/class-clusters/templates/cluster.yaml
@@ -7,6 +7,7 @@ metadata:
     owner: turtles-qa
     cloud-provider: azure
     cni: calico
+    cluster-api.cattle.io/rancher-auto-import: "true"
   name: {{ $cluster_name }}
 spec:
   clusterNetwork:

--- a/tests/cypress/latest/e2e/unit_tests/capa_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capa_kubeadm_clusterclass.spec.ts
@@ -15,6 +15,9 @@ describe('Import CAPA Kubeadm Class-Cluster', { tags: '@full' }, () => {
   const turtlesRepoUrl = 'https://github.com/rancher/turtles'
   const classesPath = 'examples/clusterclasses/aws/kubeadm'
   const clusterClassRepoName = 'aws-kb-clusterclass'
+  const providerName = 'aws'
+  const accessKey = Cypress.env('aws_access_key')
+  const secretKey = Cypress.env('aws_secret_key')
 
   beforeEach(() => {
     cy.login();
@@ -22,7 +25,15 @@ describe('Import CAPA Kubeadm Class-Cluster', { tags: '@full' }, () => {
   });
 
   it('Setup the namespace for importing', () => {
-    cy.namespaceAutoImport('Enable');
+    cy.namespaceAutoImport('Disable');
+  })
+
+  // TODO: Create Provider via UI, ref: capi-ui-extension/issues/128
+  it('Create AWS CAPIProvider & AWSClusterStaticIdentity', () => {
+    cy.removeCAPIResource('Providers', providerName);
+    cy.createCAPIProvider(providerName);
+    cy.checkCAPIProvider(providerName);
+    cy.createAWSClusterStaticIdentity(accessKey, secretKey);
   })
 
   qase(129,
@@ -114,6 +125,10 @@ describe('Import CAPA Kubeadm Class-Cluster', { tags: '@full' }, () => {
 
         // Remove the clusterclass repo
         cy.removeFleetGitRepo(clusterClassRepoName);
+
+        // Delete secret and AWSClusterStaticIdentity
+        cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], 'cluster-identity', 'capa-system')
+        cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'AWSClusterStaticIdentities'], 'cluster-identity')
       })
     );
   }

--- a/tests/cypress/latest/e2e/unit_tests/capa_rke2_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capa_rke2_clusterclass.spec.ts
@@ -15,6 +15,9 @@ describe('Import CAPA RKE2 Class-Cluster', { tags: '@full' }, () => {
   const turtlesRepoUrl = 'https://github.com/rancher/turtles'
   const classesPath = 'examples/clusterclasses/aws/rke2'
   const clusterClassRepoName = 'aws-rke2-clusterclass'
+  const providerName = 'aws'
+  const accessKey = Cypress.env('aws_access_key')
+  const secretKey = Cypress.env('aws_secret_key')
 
   beforeEach(() => {
     cy.login();
@@ -22,7 +25,15 @@ describe('Import CAPA RKE2 Class-Cluster', { tags: '@full' }, () => {
   });
 
   it('Setup the namespace for importing', () => {
-    cy.namespaceAutoImport('Enable');
+    cy.namespaceAutoImport('Disable');
+  })
+
+  // TODO: Create Provider via UI, ref: capi-ui-extension/issues/128
+  it('Create AWS CAPIProvider & AWSClusterStaticIdentity', () => {
+    cy.removeCAPIResource('Providers', providerName);
+    cy.createCAPIProvider(providerName);
+    cy.checkCAPIProvider(providerName);
+    cy.createAWSClusterStaticIdentity(accessKey, secretKey);
   })
 
   qase(116,
@@ -114,6 +125,10 @@ describe('Import CAPA RKE2 Class-Cluster', { tags: '@full' }, () => {
 
         // Remove the clusterclass repo
         cy.removeFleetGitRepo(clusterClassRepoName);
+
+        // Delete secret and AWSClusterStaticIdentity
+        cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], 'cluster-identity', 'capa-system')
+        cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'AWSClusterStaticIdentities'], 'cluster-identity')
       })
     );
   }

--- a/tests/cypress/latest/e2e/unit_tests/capv_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capv_kubeadm_clusterclass.spec.ts
@@ -16,6 +16,7 @@ describe('Import CAPV Kubeadm Class-Cluster', { tags: '@vsphere' }, () => {
   const classesPath = 'examples/clusterclasses/vsphere/kubeadm'
   const vsphere_secrets_json_base64 = Cypress.env("vsphere_secrets_json_base64")
   const namespace = 'capv-system'
+  const providerName = 'vsphere'
 
   // Decode the base64 encoded secrets and make json object
   const vsphere_secrets_json = JSON.parse(Buffer.from(vsphere_secrets_json_base64, 'base64').toString('utf-8'))
@@ -69,7 +70,12 @@ describe('Import CAPV Kubeadm Class-Cluster', { tags: '@vsphere' }, () => {
     cy.clickButton('Close');
   })
 
-  it('Create VSphereClusterIdentity', () => {
+  // TODO: Create Provider via UI, ref: capi-ui-extension/issues/128
+  it('Create VSphere CAPIProvider & VSphereClusterIdentity', () => {
+    cy.removeCAPIResource('Providers', providerName);
+    cy.createCAPIProvider(providerName);
+    cy.checkCAPIProvider(providerName);
+
     const vsphere_username = JSON.stringify(vsphere_secrets_json.vsphere_username).replace(/\"/g, "")
     const vsphere_password = JSON.stringify(vsphere_secrets_json.vsphere_password).replace(/\"/g, "")
     cy.createVSphereClusterIdentity(vsphere_username, vsphere_password)
@@ -149,8 +155,8 @@ describe('Import CAPV Kubeadm Class-Cluster', { tags: '@vsphere' }, () => {
       cy.removeFleetGitRepo(classRepoName);
 
       // Delete secret and VSphereClusterIdentity
-      cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'VSphereClusterIdentities'], 'cluster-identity', 'capi-clusters')
-      cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], "capv-helm-values", namespace)
+      cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'VSphereClusterIdentities'], 'cluster-identity');
+      cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], 'capv-helm-values', namespace);
     })
   }
 });

--- a/tests/cypress/latest/e2e/unit_tests/capv_rke2_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capv_rke2_clusterclass.spec.ts
@@ -16,6 +16,7 @@ describe('Import CAPV RKE2 Class-Cluster', { tags: '@vsphere' }, () => {
   const classesPath = 'examples/clusterclasses/vsphere/rke2'
   const vsphere_secrets_json_base64 = Cypress.env("vsphere_secrets_json_base64")
   const namespace = 'capv-system'
+  const providerName = 'vsphere'
 
   // Decode the base64 encoded secrets and make json object
   const vsphere_secrets_json = JSON.parse(Buffer.from(vsphere_secrets_json_base64, 'base64').toString('utf-8'))
@@ -75,7 +76,12 @@ describe('Import CAPV RKE2 Class-Cluster', { tags: '@vsphere' }, () => {
     cy.clickButton('Close');
   })
 
-  it('Create VSphereClusterIdentity', () => {
+  // TODO: Create Provider via UI, ref: capi-ui-extension/issues/128
+  it('Create VSphere CAPIProvider & VSphereClusterIdentity', () => {
+    cy.removeCAPIResource('Providers', providerName);
+    cy.createCAPIProvider(providerName);
+    cy.checkCAPIProvider(providerName);
+
     const vsphere_username = JSON.stringify(vsphere_secrets_json.vsphere_username).replace(/\"/g, "")
     const vsphere_password = JSON.stringify(vsphere_secrets_json.vsphere_password).replace(/\"/g, "")
     cy.createVSphereClusterIdentity(vsphere_username, vsphere_password)
@@ -156,8 +162,8 @@ describe('Import CAPV RKE2 Class-Cluster', { tags: '@vsphere' }, () => {
       cy.removeFleetGitRepo(classRepoName);
 
       // Delete secret and VSphereClusterIdentity
-      cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'VSphereClusterIdentities'], 'cluster-identity', 'capi-clusters')
-      cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], "capv-helm-values", namespace)
+      cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'VSphereClusterIdentities'], 'cluster-identity');
+      cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], 'capv-helm-values', namespace);
     })
   }
 });

--- a/tests/cypress/latest/e2e/unit_tests/capz_aks_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capz_aks_cluster.spec.ts
@@ -100,7 +100,7 @@ describe('Import CAPZ AKS Cluster', { tags: '@full' }, () => {
     );
 
     it('Delete the secrets', () => {
-      ["azure-creds-secret", "cluster-identity-secret"].forEach((resourceName) => {
+      ['azure-creds-secret', 'cluster-identity'].forEach((resourceName) => {
         cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], resourceName, namespace)
       })
     })

--- a/tests/cypress/latest/e2e/unit_tests/capz_aks_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capz_aks_clusterclass.spec.ts
@@ -21,6 +21,7 @@ describe('Import/Create CAPZ AKS Class-Cluster', { tags: '@full' }, () => {
   const turtlesRepoUrl = 'https://github.com/rancher/turtles'
   const classesPath = 'examples/clusterclasses/azure/aks'
   const clusterClassRepoName = "azure-aks-clusterclass"
+  const providerName = 'azure'
 
   const clientID = Cypress.env("azure_client_id")
   const clientSecret = btoa(Cypress.env("azure_client_secret"))
@@ -32,8 +33,15 @@ describe('Import/Create CAPZ AKS Class-Cluster', { tags: '@full' }, () => {
     cy.burgerMenuOperate('open')
   });
 
+  // TODO: Create Provider via UI, ref: capi-ui-extension/issues/128
+  it('Create Azure CAPIProvider', () => {
+    cy.removeCAPIResource('Providers', providerName);
+    cy.createCAPIProvider(providerName);
+    cy.checkCAPIProvider(providerName);
+  })
+
   it('Setup the namespace for importing', () => {
-    cy.namespaceAutoImport('Enable');
+    cy.namespaceAutoImport('Disable');
   })
 
   it('Create values.yaml Secret', () => {
@@ -114,6 +122,7 @@ describe('Import/Create CAPZ AKS Class-Cluster', { tags: '@full' }, () => {
     cy.contains(new RegExp('Provisioned.*' + clusterName), { timeout: timeout });
 
     // Check child cluster is auto-imported
+    cy.clusterAutoImport(clusterName, 'Enable');
     cy.searchCluster(clusterName);
     cy.contains(new RegExp('Active.*' + clusterName), { timeout: timeout });
   })
@@ -148,9 +157,9 @@ describe('Import/Create CAPZ AKS Class-Cluster', { tags: '@full' }, () => {
       cy.removeFleetGitRepo(clusterClassRepoName);
 
       // Delete secret and AzureClusterIdentity
-      cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], "azure-creds-secret", namespace)
+      cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], 'azure-creds-secret', namespace)
       cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'AzureClusterIdentities'], 'cluster-identity', 'capi-clusters')
-      cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], "cluster-identity-secret", namespace)
+      cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], 'cluster-identity', namespace)
     })
   }
 

--- a/tests/cypress/latest/e2e/unit_tests/capz_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capz_kubeadm_clusterclass.spec.ts
@@ -15,6 +15,7 @@ describe('Import CAPZ Kubeadm Class-Cluster', { tags: '@full' }, () => {
     const turtlesRepoUrl = 'https://github.com/rancher/turtles'
     const classesPath = 'examples/clusterclasses/azure/kubeadm'
     const clusterClassRepoName = "azure-kubeadm-clusterclass"
+    const providerName = 'azure'
 
     const clientID = Cypress.env("azure_client_id")
     const clientSecret = btoa(Cypress.env("azure_client_secret"))
@@ -26,8 +27,15 @@ describe('Import CAPZ Kubeadm Class-Cluster', { tags: '@full' }, () => {
         cy.burgerMenuOperate('open')
     });
 
+    // TODO: Create Provider via UI, ref: capi-ui-extension/issues/128
+    it('Create Azure CAPIProvider', () => {
+      cy.removeCAPIResource('Providers', providerName);
+      cy.createCAPIProvider(providerName);
+      cy.checkCAPIProvider(providerName);
+    })
+
     it('Setup the namespace for importing', () => {
-        cy.namespaceAutoImport('Enable');
+        cy.namespaceAutoImport('Disable');
     })
 
     it('Create values.yaml Secret', () => {
@@ -116,9 +124,9 @@ describe('Import CAPZ Kubeadm Class-Cluster', { tags: '@full' }, () => {
             cy.removeFleetGitRepo(clusterClassRepoName);
 
             // Delete secret and AzureClusterIdentity
-            cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], "azure-creds-secret", namespace)
+            cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], 'azure-creds-secret', namespace)
             cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'AzureClusterIdentities'], 'cluster-identity', 'capi-clusters')
-            cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], "cluster-identity-secret", namespace)
+            cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], 'cluster-identity', namespace)
         });
     }
 

--- a/tests/cypress/latest/e2e/unit_tests/capz_rke2_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capz_rke2_clusterclass.spec.ts
@@ -15,6 +15,7 @@ describe('Import CAPZ RKE2 Class-Cluster', { tags: '@full' }, () => {
     const turtlesRepoUrl = 'https://github.com/rancher/turtles'
     const classesPath = 'examples/clusterclasses/azure/rke2'
     const clusterClassRepoName = "azure-rke2-clusterclass"
+    const providerName = 'azure'
 
     const clientID = Cypress.env("azure_client_id")
     const clientSecret = btoa(Cypress.env("azure_client_secret"))
@@ -26,8 +27,15 @@ describe('Import CAPZ RKE2 Class-Cluster', { tags: '@full' }, () => {
         cy.burgerMenuOperate('open')
     });
 
+    // TODO: Create Provider via UI, ref: capi-ui-extension/issues/128
+    it('Create Azure CAPIProvider', () => {
+      cy.removeCAPIResource('Providers', providerName);
+      cy.createCAPIProvider(providerName);
+      cy.checkCAPIProvider(providerName);
+    })
+
     it('Setup the namespace for importing', () => {
-        cy.namespaceAutoImport('Enable');
+        cy.namespaceAutoImport('Disable');
     })
 
     it('Create values.yaml Secret', () => {
@@ -121,9 +129,9 @@ describe('Import CAPZ RKE2 Class-Cluster', { tags: '@full' }, () => {
             cy.removeFleetGitRepo(clusterClassRepoName);
 
             // Delete secret and AzureClusterIdentity
-            cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], "azure-creds-secret", namespace)
+            cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], 'azure-creds-secret', namespace)
             cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'AzureClusterIdentities'], 'cluster-identity', 'capi-clusters')
-            cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], "cluster-identity-secret", namespace)
+            cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], 'cluster-identity', namespace)
         })
         );
     }

--- a/tests/cypress/latest/fixtures/capa-aws-cluster-identity.yaml
+++ b/tests/cypress/latest/fixtures/capa-aws-cluster-identity.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-identity
+  namespace: capa-system
+type: Opaque
+stringData:
+  AccessKeyID: replace_access_key_id
+  SecretAccessKey: replace_secret_access_key
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSClusterStaticIdentity
+metadata:
+  name: cluster-identity
+spec:
+  secretRef: cluster-identity
+  allowedNamespaces: {}

--- a/tests/cypress/latest/fixtures/capi-aws-provider.yaml
+++ b/tests/cypress/latest/fixtures/capi-aws-provider.yaml
@@ -1,0 +1,9 @@
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
+metadata:
+  name: aws
+  namespace: capa-system
+spec:
+  type: infrastructure
+  variables:
+    AWS_B64ENCODED_CREDENTIALS: ""

--- a/tests/cypress/latest/fixtures/capi-azure-provider.yaml
+++ b/tests/cypress/latest/fixtures/capi-azure-provider.yaml
@@ -1,0 +1,8 @@
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
+metadata:
+  name: azure
+  namespace: capz-system
+spec:
+  type: infrastructure
+  name: azure

--- a/tests/cypress/latest/fixtures/capi-vsphere-provider.yaml
+++ b/tests/cypress/latest/fixtures/capi-vsphere-provider.yaml
@@ -1,0 +1,10 @@
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
+metadata:
+  name: vsphere
+  namespace: capv-system
+spec:
+  type: infrastructure
+  variables:
+    VSPHERE_USERNAME: ""
+    VSPHERE_PASSWORD: ""

--- a/tests/cypress/latest/fixtures/capz-azure-cluster-identity.yaml
+++ b/tests/cypress/latest/fixtures/capz-azure-cluster-identity.yaml
@@ -4,14 +4,12 @@ data:
   clientSecret: replace_client_secret
 kind: Secret
 metadata:
-  name: cluster-identity-secret
+  name: cluster-identity
   namespace: capz-system
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureClusterIdentity
 metadata:
-  annotations:
-    "helm.sh/resource-policy": keep
   labels:
     clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
   name: cluster-identity
@@ -20,7 +18,7 @@ spec:
   allowedNamespaces: {}
   clientID: replace_client_id
   clientSecret:
-    name: cluster-identity-secret
+    name: cluster-identity
     namespace: capz-system
   tenantID: replace_tenant_id
   type: ServicePrincipal

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -793,6 +793,8 @@ Cypress.Commands.add('exploreCluster', (clusterName: string) => {
 
 // Create VSphereClusterIdentity
 Cypress.Commands.add('createVSphereClusterIdentity', (vsphere_username, vsphere_password) => {
+  cy.goToHome();
+  cy.burgerMenuOperate('open');
   cy.contains('local')
       .click();
   cy.get('.header-buttons > :nth-child(1) > .icon')
@@ -809,4 +811,54 @@ Cypress.Commands.add('createVSphereClusterIdentity', (vsphere_username, vsphere_
   });
   cy.clickButton('Import');
   cy.clickButton('Close');
+});
+
+// Create AWSClusterStaticIdentity
+Cypress.Commands.add('createAWSClusterStaticIdentity', (accessKey, secretKey) => {
+  cy.goToHome();
+  cy.burgerMenuOperate('open');
+  cy.contains('local')
+      .click();
+  cy.get('.header-buttons > :nth-child(1) > .icon')
+      .click();
+  cy.contains('Import YAML');
+
+  cy.readFile('./fixtures/capa-aws-cluster-identity.yaml').then((data) => {
+      cy.get('.CodeMirror')
+          .then((editor) => {
+              data = data.replace(/replace_access_key_id/g, accessKey)
+              data = data.replace(/replace_secret_access_key/g, secretKey)
+              editor[0].CodeMirror.setValue(data);
+          })
+  });
+  cy.clickButton('Import');
+  cy.clickButton('Close');
+});
+
+// Create CAPIProvider using YAML
+Cypress.Commands.add('createCAPIProvider', (providerName) => {
+  cy.goToHome();
+  cy.burgerMenuOperate('open');
+  cy.contains('local')
+    .click();
+  cy.get('.header-buttons > :nth-child(1) > .icon')
+    .click();
+  cy.contains('Import YAML');
+  cy.readFile('./fixtures/capi-' + providerName + '-provider.yaml').then((data) => {
+    cy.get('.CodeMirror')
+        .then((editor) => {
+            editor[0].CodeMirror.setValue(data);
+        })
+  });
+  cy.clickButton('Import');
+  cy.clickButton('Close');
+});
+
+// Check CAPIProvider ready status
+Cypress.Commands.add('checkCAPIProvider', (providerName) => {
+  // Navigate to providers Menu
+  cy.checkCAPIMenu();
+  cy.contains('Providers').click();
+  cy.typeInFilter(providerName);
+  cy.waitForAllRowsInState('Ready');
 });

--- a/tests/cypress/latest/support/e2e.ts
+++ b/tests/cypress/latest/support/e2e.ts
@@ -61,6 +61,9 @@ declare global {
       patchYamlResource(clusterName: string, namespace: string, resourceKind: string, resourceName: string, patch: object): Chainable<Element>;
       exploreCluster(clusterName: string): Chainable<Element>;
       createVSphereClusterIdentity(vsphere_username: string, vsphere_password: string): Chainable<Element>;
+      createAWSClusterStaticIdentity(accessKey: string, secretKey: string): Chainable<Element>;
+      createCAPIProvider(providerName: string): Chainable<Element>;
+      checkCAPIProvider(providerName: string): Chainable<Element>;
       // Functions declared in capz_support.js
       createCAPZValuesSecret(clientID: string, tenantID: string, subscriptionID: string): Chainable<Element>;
       createAzureClusterIdentity(clientID: string, tenantID: string, clientSecret: string ): Chainable<Element>;


### PR DESCRIPTION
### What does this PR do?
- Use managed Cluster Identities for Clusterclass tests
- Create CAPIProviders using YAML for above tests with blank credentials
- Change run order of the specs: Clusters > Class-Clusters tests
- Use cluster auto-import label for Clusterclass tests
- Add relevant functions in commands.ts

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #202 , #205 

### Checklist:
- [x] GitHub Actions:
:green_circle:  [@full](https://github.com/rancher/rancher-turtles-e2e/actions/runs/15860366728), [@vsphere](https://github.com/rancher/rancher-turtles-e2e/actions/runs/15860362451), [@short](https://github.com/rancher/rancher-turtles-e2e/actions/runs/15854246652)
