### PR TITLE
Bump to cypress@14.5.0

### DIFF
--- a/tests/cypress/latest/package.json
+++ b/tests/cypress/latest/package.json
@@ -24,7 +24,6 @@
     "@cypress/grep": "^4.1.0",
     "@rancher-ecp-qa/cypress-library": "2.0.0",
     "cy-verify-downloads": "^0.1.8",
-    "cypress": "^14.2.1",
     "cypress-dark": "^1.8.3",
     "cypress-file-upload": "^5.0.8",
     "cypress-mochawesome-reporter": "^3.8.2",
@@ -41,6 +40,7 @@
     "@types/randomstring": "^1.3.0",
     "@typescript-eslint/eslint-plugin": "^6.2.0",
     "@typescript-eslint/parser": "^6.2.0",
+    "cypress": "^14.5.0",
     "eslint-plugin-cypress": "^2.13.0"
   }
 }


### PR DESCRIPTION
### What does this PR do?
Just a bump for cypress, I was experiencing test window crashes and seems there are no breaking changes, just bugfixes and few minor features so it should be safe.

Updated by performing: `npm install --save-dev cypress@14.5.0`

Testrun: https://github.com/rancher/rancher-turtles-e2e/actions/runs/16002703197