### PR TITLE
Support for different provider versions for dev

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/providers_setup.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/providers_setup.spec.ts
@@ -30,12 +30,35 @@ describe('Enable CAPI Providers', () => {
   const vsphereProvider = 'vsphere'
 
   // Expected provider versions
-  const kubeadmProviderVersion = 'v1.9.5'
-  const fleetProviderVersion = 'v0.11.0'
-  const vsphereProviderVersion = 'v1.12.0'
-  const amazonProviderVersion = 'v2.8.1'
-  const googleProviderVersion = 'v1.10.0'
-  const azureProviderVersion = 'v1.19.1'
+  const providerVersions = {
+    prod: {
+      kubeadm: 'v1.9.5',
+      fleet: 'v0.11.0',
+      vsphere: 'v1.12.0',
+      amazon: 'v2.8.1',
+      google: 'v1.10.0',
+      azure: 'v1.19.1'
+    },
+    dev: {
+      kubeadm: 'v1.9.5',
+      fleet: 'v0.11.0',
+      vsphere: 'v1.12.0',
+      amazon: 'v2.8.1',
+      google: 'v1.10.0',
+      azure: 'v1.19.1'
+    }
+  }
+
+  // Set the provider versions based on the environment
+  const buildType = Cypress.env('chartmuseum_repo') ? 'dev' : 'prod';
+
+  // Assign the provider versions based on the build type
+  const kubeadmProviderVersion = providerVersions[buildType].kubeadm
+  const fleetProviderVersion = providerVersions[buildType].fleet
+  const vsphereProviderVersion = providerVersions[buildType].vsphere
+  const amazonProviderVersion = providerVersions[buildType].amazon
+  const googleProviderVersion = providerVersions[buildType].google
+  const azureProviderVersion = providerVersions[buildType].azure
 
   const kubeadmBaseURL = 'https://github.com/kubernetes-sigs/cluster-api/releases/'
   const kubeadmProviderTypes = ['bootstrap', 'control plane']


### PR DESCRIPTION
### What does this PR do?
The goal is to have two sets of provider versions, one for dev builds and another for production builds. 

Currently both build types are using the same versions.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes https://github.com/rancher/rancher-turtles-e2e/issues/207

### Checklist:
- [x] GitHub Actions (if applicable)
* dev (failed on purpose, when all the provider versions were set to `0`) https://github.com/rancher/rancher-turtles-e2e/actions/runs/16053549710
* prod (correct versions) https://github.com/rancher/rancher-turtles-e2e/actions/runs/16055258585
