### PR TITLE
Bump testhelpers to support new rancher head repos

### DIFF
--- a/.github/workflows/ui-e2e.yaml
+++ b/.github/workflows/ui-e2e.yaml
@@ -19,8 +19,8 @@ on:
         default: none
         type: string
       rancher_version:
-        description: Rancher Manager channel/version/head_version to use for installation
-        default: latest/devel/2.11
+        description: Rancher Manager channel/<version|head_version>[/head_version] to use for installation
+        default: head/2.11
         type: string
       turtles_operator_version:
         description: Rancher Turtles operator version to test (eg. 0.16.0)
@@ -72,7 +72,7 @@ jobs:
       cluster_name: cluster-k3s
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       capi_ui_version: ${{ inputs.capi_ui_version }}
-      rancher_version: ${{ inputs.rancher_version || 'latest/devel/2.11' }}
+      rancher_version: ${{ inputs.rancher_version || 'head/2.11' }}
       qase_run_id: ${{ inputs.qase_run_id || 'auto' }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag || (github.event.schedule == '0 3 * * *' && '@install @short') || (github.event.schedule == '0 4 * * *' && '@install @vsphere') || (github.event.schedule == '0 5 * * 6' && '@install @full') }}
       operator_dev_chart: ${{ inputs.operator_dev_chart == true || (github.event_name == 'schedule' && true) }}

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -7,7 +7,7 @@ toolchain go1.23.3
 require (
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.34.2
-	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20250415062725-efdf8e57c793
+	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20250711071119-c33617a1af7a
 	github.com/rancher-sandbox/qase-ginkgo v1.0.1
 	github.com/sirupsen/logrus v1.9.3
 )

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -127,8 +127,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/rancher-sandbox/ele-testhelpers v0.0.0-20250415062725-efdf8e57c793 h1:NIioaBqH1VA1NbAqWRG+SjxSW7z/EOU8jcEIFbDW8lc=
-github.com/rancher-sandbox/ele-testhelpers v0.0.0-20250415062725-efdf8e57c793/go.mod h1:Ex+a/ng4u2BvcGQdQjTHI48h88bQ6k2a7q8rnvU0XbQ=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20250711071119-c33617a1af7a h1:s/tYg69rbYbIa93r4oZcZKU445rfH4mbhHQM/jafm4w=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20250711071119-c33617a1af7a/go.mod h1:Ex+a/ng4u2BvcGQdQjTHI48h88bQ6k2a7q8rnvU0XbQ=
 github.com/rancher-sandbox/qase-ginkgo v1.0.1 h1:LB9ITLavX3PmcOe0hp0Y7rwQCjJ3WpL8kG8v1MxPadE=
 github.com/rancher-sandbox/qase-ginkgo v1.0.1/go.mod h1:sIF43xaLHtEzmPqADKlZZV6oatc66GHz1N6gpBNn6QY=
 github.com/rancher/qase-go/client v0.0.0-20231114201952-65195ec001fa h1:/qeYlQVfyvsO5yY0dZmm7mRTAsDm54jACiRDx3LAwsA=


### PR DESCRIPTION
### What does this PR do?
bump of testhelpers to support new "official" head repos & `RANCHER_VERSION` env updated in workflows

### Checklist:
- [ ] GitHub Actions (if applicable) https://github.com/rancher/rancher-turtles-e2e/actions/runs/16216571326
