### PR TITLE
Input for runner_template offers spot & standard templates

### DIFF
--- a/.github/workflows/ui-e2e.yaml
+++ b/.github/workflows/ui-e2e.yaml
@@ -45,6 +45,13 @@ on:
         description: Skip CAPI cluster and fleet repo deletion tests
         default: false
         type: boolean
+      runner_template:
+        description: Runner template to use
+        default: capi-e2e-ci-runner-spot-n2-highmem-16-template-v3
+        type: choice
+        options:
+          - capi-e2e-ci-runner-spot-n2-highmem-16-template-v3
+          - capi-e2e-ci-runner-standard-n2-highmem-4-template-v4
   schedule:
     - cron: '0 3 * * *' # @short
     - cron: '0 4 * * *' # @vsphere
@@ -78,3 +85,4 @@ jobs:
       operator_dev_chart: ${{ inputs.operator_dev_chart == true || (github.event_name == 'schedule' && true) }}
       turtles_operator_version: ${{ inputs.turtles_operator_version }}
       skip_cluster_delete: ${{ inputs.skip_cluster_delete || (github.event_name == 'schedule' && false) }}
+      runner_template: ${{ inputs.runner_template || 'capi-e2e-ci-runner-spot-n2-highmem-16-template-v3' }}


### PR DESCRIPTION
### What does this PR do?
Input for offering multiple instance templates for selection spot or standard where Spot is still default and also used for scheduled runs.

<img width="472" height="382" alt="image" src="https://github.com/user-attachments/assets/913de996-96a8-475d-b6e1-b9b4099a878d" />


### Checklist:
- [ ] GitHub Actions (if applicable)
* standard https://github.com/rancher/rancher-turtles-e2e/actions/runs/16267897977 
<img width="1568" height="976" alt="pasted_image_250714" src="https://github.com/user-attachments/assets/0b9e743a-da40-4093-af64-0a3c60f47e35" />
* spot https://github.com/rancher/rancher-turtles-e2e/actions/runs/16267914256 
<img width="1555" height="971" alt="pasted_image_250714-001" src="https://github.com/user-attachments/assets/f9e5df5b-0be3-4612-90da-27cd3463ba31" />
