### PR TITLE
Add and remove clusterclass fleet repo for all the capd tests

### DIFF
--- a/tests/cypress/latest/e2e/capd_kubeadm_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/capd_kubeadm_cluster.spec.ts
@@ -38,15 +38,15 @@ describe('Import CAPD Kubeadm', { tags: '@short' }, () => {
     cy.burgerMenuOperate('open');
   });
 
-  qase(92,
-    it('Add CAPD Kubeadm ClusterClass using fleet', () => {
-      cy.addFleetGitRepo(clusterClassRepoName, turtlesRepoUrl, 'main', classesPath, 'capi-classes')
-      // Go to CAPI > ClusterClass to ensure the clusterclass is created
-      cy.checkCAPIClusterClass(className);
-    })
-  );
-
   pathNames.forEach((path) => {
+    qase(92,
+      it('Add CAPD Kubeadm ClusterClass using fleet', () => {
+        cy.addFleetGitRepo(clusterClassRepoName, turtlesRepoUrl, 'main', classesPath, 'capi-classes')
+        // Go to CAPI > ClusterClass to ensure the clusterclass is created
+        cy.checkCAPIClusterClass(className);
+      })
+    );
+
     const clustersRepoName = path + namePrefix
 
     it('Setup the namespace for importing', () => {

--- a/tests/cypress/latest/e2e/capd_kubeadm_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/capd_kubeadm_cluster.spec.ts
@@ -199,6 +199,10 @@ describe('Import CAPD Kubeadm', { tags: '@short' }, () => {
           })
         })
       );
+
+      it('Remove the CAPD Kubeadm ClusterClass fleet repo', () => {
+        cy.removeFleetGitRepo(clusterClassRepoName)
+      })
     }
   })
 });

--- a/tests/cypress/latest/e2e/capd_kubeadm_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/capd_kubeadm_cluster.spec.ts
@@ -38,15 +38,15 @@ describe('Import CAPD Kubeadm', { tags: '@short' }, () => {
     cy.burgerMenuOperate('open');
   });
 
-  pathNames.forEach((path) => {
-    qase(92,
-      it('Add CAPD Kubeadm ClusterClass using fleet', () => {
-        cy.addFleetGitRepo(clusterClassRepoName, turtlesRepoUrl, 'main', classesPath, 'capi-classes')
-        // Go to CAPI > ClusterClass to ensure the clusterclass is created
-        cy.checkCAPIClusterClass(className);
-      })
-    );
+  qase(92,
+    it('Add CAPD Kubeadm ClusterClass using fleet', () => {
+      cy.addFleetGitRepo(clusterClassRepoName, turtlesRepoUrl, 'main', classesPath, 'capi-classes')
+      // Go to CAPI > ClusterClass to ensure the clusterclass is created
+      cy.checkCAPIClusterClass(className);
+    })
+  );
 
+  pathNames.forEach((path) => {
     const clustersRepoName = path + namePrefix
 
     it('Setup the namespace for importing', () => {
@@ -200,9 +200,12 @@ describe('Import CAPD Kubeadm', { tags: '@short' }, () => {
         })
       );
 
-      it('Remove the CAPD Kubeadm ClusterClass fleet repo', () => {
-        cy.removeFleetGitRepo(clusterClassRepoName)
-      })
     }
   })
+
+  if (skipClusterDeletion) {
+    it('Remove the CAPD Kubeadm ClusterClass fleet repo', () => {
+      cy.removeFleetGitRepo(clusterClassRepoName)
+    })
+  }
 });

--- a/tests/cypress/latest/e2e/capd_rke2_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/capd_rke2_cluster.spec.ts
@@ -40,15 +40,15 @@ describe('Import CAPD RKE2', { tags: '@short' }, () => {
     cy.burgerMenuOperate('open');
   });
 
-  pathNames.forEach((path) => {
-    qase(91,
-      it('Add CAPD RKE2 ClusterClass Fleet Repo', () => {
-        cy.addFleetGitRepo(clusterClassRepoName, turtlesRepoUrl, 'main', classesPath, 'capi-classes')
-        // Go to CAPI > ClusterClass to ensure the clusterclass is created
-        cy.checkCAPIClusterClass(className);
-      })
-    );
+  qase(91,
+    it('Add CAPD RKE2 ClusterClass Fleet Repo', () => {
+      cy.addFleetGitRepo(clusterClassRepoName, turtlesRepoUrl, 'main', classesPath, 'capi-classes')
+      // Go to CAPI > ClusterClass to ensure the clusterclass is created
+      cy.checkCAPIClusterClass(className);
+    })
+  );
 
+  pathNames.forEach((path) => {
     const clustersRepoName = path + namePrefix
 
     it('Setup the namespace for importing', () => {
@@ -184,9 +184,12 @@ describe('Import CAPD RKE2', { tags: '@short' }, () => {
         })
       );
 
-      it('Remove CAPD RKE2 ClusterClass Fleet Repo', () => {
-        cy.removeFleetGitRepo(clusterClassRepoName)
-      })
     }
-  })
+  });
+
+  if (skipClusterDeletion) {
+    it('Remove CAPD RKE2 ClusterClass Fleet Repo', () => {
+      cy.removeFleetGitRepo(clusterClassRepoName)
+    })
+  }
 });

--- a/tests/cypress/latest/e2e/capd_rke2_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/capd_rke2_cluster.spec.ts
@@ -40,15 +40,15 @@ describe('Import CAPD RKE2', { tags: '@short' }, () => {
     cy.burgerMenuOperate('open');
   });
 
-  qase(91,
-    it('Add CAPD RKE2 ClusterClass Fleet Repo', () => {
-      cy.addFleetGitRepo(clusterClassRepoName, turtlesRepoUrl, 'main', classesPath, 'capi-classes')
-      // Go to CAPI > ClusterClass to ensure the clusterclass is created
-      cy.checkCAPIClusterClass(className);
-    })
-  );
-
   pathNames.forEach((path) => {
+    qase(91,
+      it('Add CAPD RKE2 ClusterClass Fleet Repo', () => {
+        cy.addFleetGitRepo(clusterClassRepoName, turtlesRepoUrl, 'main', classesPath, 'capi-classes')
+        // Go to CAPI > ClusterClass to ensure the clusterclass is created
+        cy.checkCAPIClusterClass(className);
+      })
+    );
+
     const clustersRepoName = path + namePrefix
 
     it('Setup the namespace for importing', () => {

--- a/tests/cypress/latest/e2e/capd_rke2_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/capd_rke2_cluster.spec.ts
@@ -183,6 +183,10 @@ describe('Import CAPD RKE2', { tags: '@short' }, () => {
           })
         })
       );
+
+      it('Remove CAPD RKE2 ClusterClass Fleet Repo', () => {
+        cy.removeFleetGitRepo(clusterClassRepoName)
+      })
     }
   })
 });

--- a/tests/cypress/latest/e2e/capd_ui_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capd_ui_clusterclass.spec.ts
@@ -26,8 +26,8 @@ describe('Create CAPD', { tags: '@short' }, () => {
   const pathNames = ['kubeadm'] // TODO: Add rke2 path (capi-ui-extension/issues/121)
   const namespace = 'capi-classes' // TODO: Change to capi-clusters (capi-ui-extension/issues/111)
   const turtlesRepoUrl = 'https://github.com/rancher/turtles'
-  const classesPath = 'examples/clusterclasses/docker/kubeadm'
-  const clusterClassRepoName = "docker-kb-clusterclass"
+  const classesPath = 'examples/clusterclasses/docker/'
+  const clusterClassRepoName = "docker-ui-clusterclass"
 
   beforeEach(() => {
     cy.login();
@@ -44,8 +44,8 @@ describe('Create CAPD', { tags: '@short' }, () => {
       cy.importYAML('fixtures/kindnet.yaml', namespace);
     })
 
-    it('Add CAPD Kubeadm ClusterClass using fleet', () => {
-      cy.addFleetGitRepo(clusterClassRepoName, turtlesRepoUrl, 'main', classesPath, namespace)
+    it('Add CAPD ClusterClass fleet repo', () => {
+      cy.addFleetGitRepo(clusterClassRepoName, turtlesRepoUrl, 'main', classesPath + path, namespace)
       // Go to CAPI > ClusterClass to ensure the clusterclass is created
       cy.checkCAPIClusterClass(className);
     })
@@ -98,7 +98,7 @@ describe('Create CAPD', { tags: '@short' }, () => {
         cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'ClusterResourceSets'], "docker-kubeadm-example-crs-0", namespace);
       })
 
-      it('Remove the CAPD Kubeadm ClusterClass fleet repo', () => {
+      it('Remove the CAPD ClusterClass fleet repo', () => {
         cy.removeFleetGitRepo(clusterClassRepoName)
       })
     }

--- a/tests/cypress/latest/e2e/capd_ui_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capd_ui_clusterclass.spec.ts
@@ -25,6 +25,9 @@ describe('Create CAPD', { tags: '@short' }, () => {
   const k8sVersion = 'v1.31.4'
   const pathNames = ['kubeadm'] // TODO: Add rke2 path (capi-ui-extension/issues/121)
   const namespace = 'capi-classes' // TODO: Change to capi-clusters (capi-ui-extension/issues/111)
+  const turtlesRepoUrl = 'https://github.com/rancher/turtles'
+  const classesPath = 'examples/clusterclasses/docker/kubeadm'
+  const clusterClassRepoName = "docker-kb-clusterclass"
 
   beforeEach(() => {
     cy.login();
@@ -39,6 +42,12 @@ describe('Create CAPD', { tags: '@short' }, () => {
 
     it('Create Kindnet configmap', () => {
       cy.importYAML('fixtures/kindnet.yaml', namespace);
+    })
+
+    it('Add CAPD Kubeadm ClusterClass using fleet', () => {
+      cy.addFleetGitRepo(clusterClassRepoName, turtlesRepoUrl, 'main', classesPath, namespace)
+      // Go to CAPI > ClusterClass to ensure the clusterclass is created
+      cy.checkCAPIClusterClass(className);
     })
 
     qase(44,
@@ -87,6 +96,10 @@ describe('Create CAPD', { tags: '@short' }, () => {
       it('Delete the Kindnet Config Map', () => {
         cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'ConfigMaps'], "cni-docker-kubeadm-example-crs-0", namespace);
         cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'ClusterResourceSets'], "docker-kubeadm-example-crs-0", namespace);
+      })
+
+      it('Remove the CAPD Kubeadm ClusterClass fleet repo', () => {
+        cy.removeFleetGitRepo(clusterClassRepoName)
       })
     }
   })

--- a/tests/cypress/latest/e2e/capz_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capz_kubeadm_clusterclass.spec.ts
@@ -4,130 +4,130 @@ import { skipClusterDeletion } from '~/support/utils';
 
 Cypress.config();
 describe('Import CAPZ Kubeadm Class-Cluster', { tags: '@full' }, () => {
-    var clusterName: string;
-    const timeout = 1200000
-    const namespace = 'capz-system'
-    const repoName = 'class-clusters-azure-kubeadm'
-    const className = 'azure-kubeadm-example'
-    const branch = 'main'
-    const path = '/tests/assets/rancher-turtles-fleet-example/capz/kubeadm/class-clusters'
-    const repoUrl = "https://github.com/rancher/rancher-turtles-e2e.git"
-    const turtlesRepoUrl = 'https://github.com/rancher/turtles'
-    const classesPath = 'examples/clusterclasses/azure/kubeadm'
-    const clusterClassRepoName = "azure-kubeadm-clusterclass"
-    const providerName = 'azure'
+  var clusterName: string;
+  const timeout = 1200000
+  const namespace = 'capz-system'
+  const repoName = 'class-clusters-azure-kubeadm'
+  const className = 'azure-kubeadm-example'
+  const branch = 'main'
+  const path = '/tests/assets/rancher-turtles-fleet-example/capz/kubeadm/class-clusters'
+  const repoUrl = "https://github.com/rancher/rancher-turtles-e2e.git"
+  const turtlesRepoUrl = 'https://github.com/rancher/turtles'
+  const classesPath = 'examples/clusterclasses/azure/kubeadm'
+  const clusterClassRepoName = "azure-kubeadm-clusterclass"
+  const providerName = 'azure'
 
-    const clientID = Cypress.env("azure_client_id")
-    const clientSecret = btoa(Cypress.env("azure_client_secret"))
-    const subscriptionID = Cypress.env("azure_subscription_id")
-    const tenantID = Cypress.env("azure_tenant_id")
+  const clientID = Cypress.env("azure_client_id")
+  const clientSecret = btoa(Cypress.env("azure_client_secret"))
+  const subscriptionID = Cypress.env("azure_subscription_id")
+  const tenantID = Cypress.env("azure_tenant_id")
 
-    beforeEach(() => {
-        cy.login();
-        cy.burgerMenuOperate('open')
-    });
+  beforeEach(() => {
+    cy.login();
+    cy.burgerMenuOperate('open')
+  });
 
-    // TODO: Create Provider via UI, ref: capi-ui-extension/issues/128
-    it('Create Azure CAPIProvider', () => {
-        cy.removeCAPIResource('Providers', providerName);
-        cy.createCAPIProvider(providerName);
-        cy.checkCAPIProvider(providerName);
+  // TODO: Create Provider via UI, ref: capi-ui-extension/issues/128
+  it('Create Azure CAPIProvider', () => {
+    cy.removeCAPIResource('Providers', providerName);
+    cy.createCAPIProvider(providerName);
+    cy.checkCAPIProvider(providerName);
+  })
+
+  it('Setup the namespace for importing', () => {
+    cy.namespaceAutoImport('Disable');
+  })
+
+  it('Create values.yaml Secret', () => {
+    cy.createCAPZValuesSecret(clientID, tenantID, subscriptionID);
+  })
+
+  it('Create AzureClusterIdentity', () => {
+    cy.createAzureClusterIdentity(clientID, tenantID, clientSecret)
+  })
+
+  it('Add CAPZ Kubeadm ClusterClass Fleet Repo and check Azure CCM', () => {
+    cy.addFleetGitRepo(clusterClassRepoName, turtlesRepoUrl, 'main', classesPath, 'capi-classes')
+    // Go to CAPI > ClusterClass to ensure the clusterclass is created
+    cy.checkCAPIClusterClass(className);
+
+    // Navigate to `local` cluster, More Resources > Fleet > Helm Apps and ensure the charts are active.
+    cy.burgerMenuOperate('open');
+    cy.contains('local').click();
+    cy.accesMenuSelection(['More Resources', 'Fleet', 'HelmApps']);
+    ["azure-ccm", "calico-cni"].forEach((app) => {
+      cy.typeInFilter(app);
+      cy.getBySel('sortable-cell-0-1').should('exist');
     })
+  });
 
-    it('Setup the namespace for importing', () => {
-        cy.namespaceAutoImport('Disable');
-    })
+  it('Add GitRepo for class-cluster and get cluster name', () => {
+    cy.addFleetGitRepo(repoName, repoUrl, branch, path);
+    // Check CAPI cluster using its name prefix i.e. className
+    cy.checkCAPICluster(className);
 
-    it('Create values.yaml Secret', () => {
-        cy.createCAPZValuesSecret(clientID, tenantID, subscriptionID);
-    })
+    // Get the cluster name by its prefix and use it across the test
+    cy.getBySel('sortable-cell-0-1').then(($cell) => {
+      clusterName = $cell.text();
+      cy.log('CAPI Cluster Name:', clusterName);
+    });
+  });
 
-    it('Create AzureClusterIdentity', () => {
-        cy.createAzureClusterIdentity(clientID, tenantID, clientSecret)
-    })
+  it('Auto import child CAPZ Kubeadm cluster', () => {
+    // Go to Cluster Management > CAPI > Clusters and check if the cluster has provisioned
+    cy.checkCAPIClusterProvisioned(clusterName, timeout);
 
-    it('Add CAPZ Kubeadm ClusterClass Fleet Repo and check Azure CCM', () => {
-        cy.addFleetGitRepo(clusterClassRepoName, turtlesRepoUrl, 'main', classesPath, 'capi-classes')
-        // Go to CAPI > ClusterClass to ensure the clusterclass is created
-        cy.checkCAPIClusterClass(className);
+    // Check child cluster is created and auto-imported
+    // This is checked by ensuring the cluster is available in navigation menu
+    cy.goToHome();
+    cy.contains(clusterName).should('exist');
 
-        // Navigate to `local` cluster, More Resources > Fleet > Helm Apps and ensure the charts are active.
-        cy.burgerMenuOperate('open');
-        cy.contains('local').click();
-        cy.accesMenuSelection(['More Resources', 'Fleet', 'HelmApps']);
-        ["azure-ccm", "calico-cni"].forEach((app) => {
-            cy.typeInFilter(app);
-            cy.getBySel('sortable-cell-0-1').should('exist');
-        })
+    // Check cluster is Active
+    cy.searchCluster(clusterName);
+    cy.contains(new RegExp('Active.*' + clusterName), { timeout: timeout });
+
+    // Go to Cluster Management > CAPI > Clusters and check if the cluster has provisioned
+    // Ensuring cluster is provisioned also ensures all the Cluster Management > Advanced > Machines for the given cluster are Active.
+    cy.checkCAPIClusterActive(clusterName, timeout);
+  });
+
+  it('Install App on imported cluster', () => {
+    // Click on imported CAPZ cluster
+    cy.contains(clusterName).click();
+
+    // Install Chart
+    // We install Logging chart instead of Monitoring, since this is relatively lightweight.
+    cy.checkChart('Install', 'Logging', 'cattle-logging-system');
+  });
+
+
+  if (skipClusterDeletion) {
+    it('Remove imported CAPZ cluster from Rancher Manager', { retries: 1 }, () => {
+      // Check cluster is not deleted after removal
+      cy.deleteCluster(clusterName);
+      cy.goToHome();
+      // kubectl get clusters.cluster.x-k8s.io
+      // This is checked by ensuring the cluster is not available in navigation menu
+      cy.contains(clusterName).should('not.exist');
+      cy.checkCAPIClusterProvisioned(clusterName);
     });
 
-    it('Add GitRepo for class-cluster and get cluster name', () => {
-        cy.addFleetGitRepo(repoName, repoUrl, branch, path);
-        // Check CAPI cluster using its name prefix i.e. className
-        cy.checkCAPICluster(className);
+    it('Delete the CAPZ cluster and clusterclasses fleet repo and other resources', () => {
 
-        // Get the cluster name by its prefix and use it across the test
-        cy.getBySel('sortable-cell-0-1').then(($cell) => {
-            clusterName = $cell.text();
-            cy.log('CAPI Cluster Name:', clusterName);
-        });
+      // Remove the fleet git repo
+      cy.removeFleetGitRepo(repoName);
+      // Wait until the following returns no clusters found
+      // This is checked by ensuring the cluster is not available in CAPI menu
+      cy.checkCAPIClusterDeleted(clusterName, timeout);
+
+      // Remove the clusterclass repo
+      cy.removeFleetGitRepo(clusterClassRepoName);
+
+      // Delete secret and AzureClusterIdentity
+      cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], 'azure-creds-secret', namespace)
+      cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'AzureClusterIdentities'], 'cluster-identity', 'capi-clusters')
+      cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], 'cluster-identity', namespace)
     });
-
-    it('Auto import child CAPZ Kubeadm cluster', () => {
-        // Go to Cluster Management > CAPI > Clusters and check if the cluster has provisioned
-        cy.checkCAPIClusterProvisioned(clusterName, timeout);
-
-        // Check child cluster is created and auto-imported
-        // This is checked by ensuring the cluster is available in navigation menu
-        cy.goToHome();
-        cy.contains(clusterName).should('exist');
-
-        // Check cluster is Active
-        cy.searchCluster(clusterName);
-        cy.contains(new RegExp('Active.*' + clusterName), { timeout: timeout });
-
-        // Go to Cluster Management > CAPI > Clusters and check if the cluster has provisioned
-        // Ensuring cluster is provisioned also ensures all the Cluster Management > Advanced > Machines for the given cluster are Active.
-        cy.checkCAPIClusterActive(clusterName, timeout);
-    });
-
-    it('Install App on imported cluster', () => {
-        // Click on imported CAPZ cluster
-        cy.contains(clusterName).click();
-
-        // Install Chart
-        // We install Logging chart instead of Monitoring, since this is relatively lightweight.
-        cy.checkChart('Install', 'Logging', 'cattle-logging-system');
-    });
-
-
-    if (skipClusterDeletion) {
-        it('Remove imported CAPZ cluster from Rancher Manager', { retries: 1 }, () => {
-            // Check cluster is not deleted after removal
-            cy.deleteCluster(clusterName);
-            cy.goToHome();
-            // kubectl get clusters.cluster.x-k8s.io
-            // This is checked by ensuring the cluster is not available in navigation menu
-            cy.contains(clusterName).should('not.exist');
-            cy.checkCAPIClusterProvisioned(clusterName);
-        });
-
-        it('Delete the CAPZ cluster and clusterclasses fleet repo and other resources', () => {
-
-            // Remove the fleet git repo
-            cy.removeFleetGitRepo(repoName);
-            // Wait until the following returns no clusters found
-            // This is checked by ensuring the cluster is not available in CAPI menu
-            cy.checkCAPIClusterDeleted(clusterName, timeout);
-
-            // Remove the clusterclass repo
-            cy.removeFleetGitRepo(clusterClassRepoName);
-
-            // Delete secret and AzureClusterIdentity
-            cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], 'azure-creds-secret', namespace)
-            cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'AzureClusterIdentities'], 'cluster-identity', 'capi-clusters')
-            cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], 'cluster-identity', namespace)
-        });
-    }
+  }
 
 });

--- a/tests/cypress/latest/e2e/capz_rke2_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capz_rke2_clusterclass.spec.ts
@@ -4,136 +4,136 @@ import { skipClusterDeletion } from '~/support/utils';
 
 Cypress.config();
 describe('Import CAPZ RKE2 Class-Cluster', { tags: '@full' }, () => {
-    var clusterName: string;
-    const timeout = 1200000
-    const namespace = 'capz-system'
-    const repoName = 'class-clusters-azure-rke2'
-    const className = 'azure-rke2-example'
-    const branch = 'main'
-    const path = '/tests/assets/rancher-turtles-fleet-example/capz/rke2/class-clusters'
-    const repoUrl = "https://github.com/rancher/rancher-turtles-e2e.git"
-    const turtlesRepoUrl = 'https://github.com/rancher/turtles'
-    const classesPath = 'examples/clusterclasses/azure/rke2'
-    const clusterClassRepoName = "azure-rke2-clusterclass"
-    const providerName = 'azure'
+  var clusterName: string;
+  const timeout = 1200000
+  const namespace = 'capz-system'
+  const repoName = 'class-clusters-azure-rke2'
+  const className = 'azure-rke2-example'
+  const branch = 'main'
+  const path = '/tests/assets/rancher-turtles-fleet-example/capz/rke2/class-clusters'
+  const repoUrl = "https://github.com/rancher/rancher-turtles-e2e.git"
+  const turtlesRepoUrl = 'https://github.com/rancher/turtles'
+  const classesPath = 'examples/clusterclasses/azure/rke2'
+  const clusterClassRepoName = "azure-rke2-clusterclass"
+  const providerName = 'azure'
 
-    const clientID = Cypress.env("azure_client_id")
-    const clientSecret = btoa(Cypress.env("azure_client_secret"))
-    const subscriptionID = Cypress.env("azure_subscription_id")
-    const tenantID = Cypress.env("azure_tenant_id")
+  const clientID = Cypress.env("azure_client_id")
+  const clientSecret = btoa(Cypress.env("azure_client_secret"))
+  const subscriptionID = Cypress.env("azure_subscription_id")
+  const tenantID = Cypress.env("azure_tenant_id")
 
-    beforeEach(() => {
-        cy.login();
-        cy.burgerMenuOperate('open')
+  beforeEach(() => {
+    cy.login();
+    cy.burgerMenuOperate('open')
+  });
+
+  // TODO: Create Provider via UI, ref: capi-ui-extension/issues/128
+  it('Create Azure CAPIProvider', () => {
+    cy.removeCAPIResource('Providers', providerName);
+    cy.createCAPIProvider(providerName);
+    cy.checkCAPIProvider(providerName);
+  })
+
+  it('Setup the namespace for importing', () => {
+    cy.namespaceAutoImport('Disable');
+  })
+
+  it('Create values.yaml Secret', () => {
+    cy.createCAPZValuesSecret(clientID, tenantID, subscriptionID);
+  })
+
+  it('Create AzureClusterIdentity', () => {
+    cy.createAzureClusterIdentity(clientID, tenantID, clientSecret)
+  })
+
+  qase(87, it('Add CAPZ RKE2 ClusterClass Fleet Repo and check Azure CCM', () => {
+    cy.addFleetGitRepo(clusterClassRepoName, turtlesRepoUrl, 'main', classesPath, 'capi-classes')
+    // Go to CAPI > ClusterClass to ensure the clusterclass is created
+    cy.checkCAPIClusterClass(className);
+
+    // Navigate to `local` cluster, More Resources > Fleet > Helm Apps and ensure the charts are active.
+    cy.burgerMenuOperate('open');
+    cy.contains('local').click();
+    cy.accesMenuSelection(['More Resources', 'Fleet', 'HelmApps']);
+    ["azure-ccm", "calico-cni"].forEach((app) => {
+      cy.typeInFilter(app);
+      cy.getBySel('sortable-cell-0-1').should('exist');
+    })
+  })
+  );
+
+  qase(78, it('Add GitRepo for class-cluster and get cluster name', () => {
+    cy.addFleetGitRepo(repoName, repoUrl, branch, path);
+    // Check CAPI cluster using its name prefix i.e. className
+    cy.checkCAPICluster(className);
+
+    // Get the cluster name by its prefix and use it across the test
+    cy.getBySel('sortable-cell-0-1').then(($cell) => {
+      clusterName = $cell.text();
+      cy.log('CAPI Cluster Name:', clusterName);
     });
+  })
+  );
 
-    // TODO: Create Provider via UI, ref: capi-ui-extension/issues/128
-    it('Create Azure CAPIProvider', () => {
-      cy.removeCAPIResource('Providers', providerName);
-      cy.createCAPIProvider(providerName);
-      cy.checkCAPIProvider(providerName);
-    })
+  qase(79, it('Auto import child CAPZ RKE2 cluster', () => {
+    // Go to Cluster Management > CAPI > Clusters and check if the cluster has provisioned
+    cy.checkCAPIClusterProvisioned(clusterName, timeout);
 
-    it('Setup the namespace for importing', () => {
-        cy.namespaceAutoImport('Disable');
-    })
+    // Check child cluster is created and auto-imported
+    // This is checked by ensuring the cluster is available in navigation menu
+    cy.goToHome();
+    cy.contains(clusterName).should('exist');
 
-    it('Create values.yaml Secret', () => {
-        cy.createCAPZValuesSecret(clientID, tenantID, subscriptionID);
-    })
+    // Check cluster is Active
+    cy.searchCluster(clusterName);
+    cy.contains(new RegExp('Active.*' + clusterName), { timeout: timeout });
 
-    it('Create AzureClusterIdentity', () => {
-        cy.createAzureClusterIdentity(clientID, tenantID, clientSecret)
-    })
+    // Go to Cluster Management > CAPI > Clusters and check if the cluster has provisioned
+    // Ensuring cluster is provisioned also ensures all the Cluster Management > Advanced > Machines for the given cluster are Active.
+    cy.checkCAPIClusterActive(clusterName, timeout);
+  })
+  );
 
-    qase(87, it('Add CAPZ RKE2 ClusterClass Fleet Repo and check Azure CCM', () => {
-        cy.addFleetGitRepo(clusterClassRepoName, turtlesRepoUrl, 'main', classesPath, 'capi-classes')
-        // Go to CAPI > ClusterClass to ensure the clusterclass is created
-        cy.checkCAPIClusterClass(className);
+  qase(80, it('Install App on imported cluster', () => {
+    // Click on imported CAPZ cluster
+    cy.contains(clusterName).click();
 
-        // Navigate to `local` cluster, More Resources > Fleet > Helm Apps and ensure the charts are active.
-        cy.burgerMenuOperate('open');
-        cy.contains('local').click();
-        cy.accesMenuSelection(['More Resources', 'Fleet', 'HelmApps']);
-        ["azure-ccm", "calico-cni"].forEach((app) => {
-            cy.typeInFilter(app);
-            cy.getBySel('sortable-cell-0-1').should('exist');
-        })
-    })
-    );
+    // Install Chart
+    // We install Logging chart instead of Monitoring, since this is relatively lightweight.
+    cy.checkChart('Install', 'Logging', 'cattle-logging-system');
+  })
+  );
 
-    qase(78, it('Add GitRepo for class-cluster and get cluster name', () => {
-        cy.addFleetGitRepo(repoName, repoUrl, branch, path);
-        // Check CAPI cluster using its name prefix i.e. className
-        cy.checkCAPICluster(className);
 
-        // Get the cluster name by its prefix and use it across the test
-        cy.getBySel('sortable-cell-0-1').then(($cell) => {
-            clusterName = $cell.text();
-            cy.log('CAPI Cluster Name:', clusterName);
-        });
-    })
-    );
-
-    qase(79, it('Auto import child CAPZ RKE2 cluster', () => {
-      // Go to Cluster Management > CAPI > Clusters and check if the cluster has provisioned
-      cy.checkCAPIClusterProvisioned(clusterName, timeout);
-
-      // Check child cluster is created and auto-imported
-      // This is checked by ensuring the cluster is available in navigation menu
+  if (skipClusterDeletion) {
+    qase(82, it('Remove imported CAPZ cluster from Rancher Manager', { retries: 1 }, () => {
+      // Check cluster is not deleted after removal
+      cy.deleteCluster(clusterName);
       cy.goToHome();
-      cy.contains(clusterName).should('exist');
-
-      // Check cluster is Active
-      cy.searchCluster(clusterName);
-      cy.contains(new RegExp('Active.*' + clusterName), { timeout: timeout });
-
-      // Go to Cluster Management > CAPI > Clusters and check if the cluster has provisioned
-      // Ensuring cluster is provisioned also ensures all the Cluster Management > Advanced > Machines for the given cluster are Active.
-      cy.checkCAPIClusterActive(clusterName, timeout);
+      // kubectl get clusters.cluster.x-k8s.io
+      // This is checked by ensuring the cluster is not available in navigation menu
+      cy.contains(clusterName).should('not.exist');
+      cy.checkCAPIClusterProvisioned(clusterName);
     })
     );
 
-    qase(80, it('Install App on imported cluster', () => {
-        // Click on imported CAPZ cluster
-        cy.contains(clusterName).click();
+    qase(83, it('Delete the CAPZ cluster and clusterclasses fleet repo and other resources', () => {
 
-        // Install Chart
-        // We install Logging chart instead of Monitoring, since this is relatively lightweight.
-        cy.checkChart('Install', 'Logging', 'cattle-logging-system');
+      // Remove the fleet git repo
+      cy.removeFleetGitRepo(repoName);
+      // Wait until the following returns no clusters found
+      // This is checked by ensuring the cluster is not available in CAPI menu
+      cy.checkCAPIClusterDeleted(clusterName, timeout);
+
+      // Remove the clusterclass repo
+      cy.removeFleetGitRepo(clusterClassRepoName);
+
+      // Delete secret and AzureClusterIdentity
+      cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], 'azure-creds-secret', namespace)
+      cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'AzureClusterIdentities'], 'cluster-identity', 'capi-clusters')
+      cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], 'cluster-identity', namespace)
     })
     );
-
-
-    if (skipClusterDeletion) {
-        qase(82, it('Remove imported CAPZ cluster from Rancher Manager', { retries: 1 }, () => {
-            // Check cluster is not deleted after removal
-            cy.deleteCluster(clusterName);
-            cy.goToHome();
-            // kubectl get clusters.cluster.x-k8s.io
-            // This is checked by ensuring the cluster is not available in navigation menu
-            cy.contains(clusterName).should('not.exist');
-            cy.checkCAPIClusterProvisioned(clusterName);
-        })
-        );
-
-        qase(83, it('Delete the CAPZ cluster and clusterclasses fleet repo and other resources', () => {
-
-            // Remove the fleet git repo
-            cy.removeFleetGitRepo(repoName);
-            // Wait until the following returns no clusters found
-            // This is checked by ensuring the cluster is not available in CAPI menu
-            cy.checkCAPIClusterDeleted(clusterName, timeout);
-
-            // Remove the clusterclass repo
-            cy.removeFleetGitRepo(clusterClassRepoName);
-
-            // Delete secret and AzureClusterIdentity
-            cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], 'azure-creds-secret', namespace)
-            cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'AzureClusterIdentities'], 'cluster-identity', 'capi-clusters')
-            cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], 'cluster-identity', namespace)
-        })
-        );
-    }
+  }
 
 });


### PR DESCRIPTION
### What does this PR do?
1. Change indentation to 2 spaces for the files that were missing it.
2. Add and remove clusterclass repo for all the CAPD tests, same as other providers; this will allow successful run of test files without depending upon the order in which they are ran. For e.g. currently if we run `capd_ui_clusterclass.spec.ts` before/without `capd_kubeadm_cluster.spec.ts`, the test will fail since it misses the clusterclass fleet repo addition.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes part of #214 

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions (if applicable) - [@short :green_circle:](https://github.com/rancher/rancher-turtles-e2e/actions/runs/16310892275/job/46071858874)
### Special notes for your reviewer:
