### PR TITLE
Fix fleet namespace selection

### DIFF
--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -623,7 +623,7 @@ Cypress.Commands.add('goToHome', () => {
 Cypress.Commands.add('addFleetGitRepo', (repoName, repoUrl, branch, paths, targetNamespace, workspace) => {
   cy.accesMenuSelection(['Continuous Delivery', 'Git Repos']);
   cy.getBySel('masthead-create').should('be.visible');
-  cy.contains('fleet-').click();
+  cy.getBySel('workspace-switcher').click();
   if (!workspace) {
     workspace = 'fleet-local';
   }
@@ -683,7 +683,7 @@ Cypress.Commands.add('checkFleetGitRepo', (repoName, workspace) => {
   cy.accesMenuSelection(['Continuous Delivery', 'Git Repos']);
   cy.getBySel('masthead-create').should('be.visible');
   // Change the workspace using the dropdown on the top bar
-  cy.contains('fleet-').click();
+  cy.getBySel('workspace-switcher').click();
   if (!workspace) {
     workspace = 'fleet-local';
   }


### PR DESCRIPTION
### What does this PR do?
Fix fleet namespace selection

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes - Failing CI

### Checklist:
- [x] GitHub Actions:
:green_circle: [@short](https://github.com/rancher/rancher-turtles-e2e/actions/runs/16366087338), [@vsphere](https://github.com/rancher/rancher-turtles-e2e/actions/runs/16366140612) (failure does not seem related)