### PR TITLE
Turn off linter warnings

### DIFF
--- a/tests/cypress/latest/.eslintrc.json
+++ b/tests/cypress/latest/.eslintrc.json
@@ -9,8 +9,8 @@
   ],
   "rules": {
     "cypress/no-unnecessary-waiting": "off",
-    "@typescript-eslint/no-explicit-any": "warn",
-    "cypress/unsafe-to-chain-command": "warn"
+    "@typescript-eslint/no-explicit-any": "off",
+    "cypress/unsafe-to-chain-command": "off"
   },
   "parser": "@typescript-eslint/parser",
   "parserOptions": {


### PR DESCRIPTION
### What does this PR do?
Turn off linter warnings. It shows warnings in PRs for files that are unchanged.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [ ] GitHub Actions (if applicable)

### Special notes for your reviewer:
