### PR TITLE
Add support for Rancher 2.12

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -459,7 +459,7 @@ jobs:
           fi
           cd tests && make start-cypress-tests
       - name: Upload Cypress screenshots
-        if: failure() 
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: cypress-screenshots-${{ inputs.cluster_name }}
@@ -588,7 +588,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4          
+        uses: actions/checkout@v4
       - name: Setup Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/ui-e2e.yaml
+++ b/.github/workflows/ui-e2e.yaml
@@ -21,7 +21,7 @@ on:
         type: string
       rancher_version:
         description: Rancher Manager channel/<version|head_version>[/head_version] to use for installation
-        default: head/2.11
+        default: head/2.12
         type: string
       turtles_chart_version:
         description: Rancher Turtles chart version to test (eg. 0.21.0)
@@ -87,7 +87,7 @@ jobs:
       cluster_name: rancher-k3s-cluster
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
       capi_ui_version: ${{ inputs.capi_ui_version }}
-      rancher_version: ${{ inputs.rancher_version || 'head/2.11' }}
+      rancher_version: ${{ inputs.rancher_version || 'head/2.12' }}
       qase_run_id: ${{ inputs.qase_run_id || 'auto' }}
       turtles_dev_chart: ${{ inputs.turtles_dev_chart == true || (github.event_name == 'schedule' && true) }}
       turtles_chart_version: ${{ inputs.turtles_chart_version }}

--- a/tests/cypress/latest/cypress.config.ts
+++ b/tests/cypress/latest/cypress.config.ts
@@ -5,6 +5,7 @@ const qaseAPIToken = process.env.QASE_API_TOKEN
 export default defineConfig({
   defaultCommandTimeout: 30000,
   video: true,
+  experimentalMemoryManagement: true,
   reporter: 'cypress-multi-reporters',
   reporterOptions: {
     reporterEnabled: 'cypress-mochawesome-reporter, cypress-qase-reporter',
@@ -25,6 +26,18 @@ export default defineConfig({
     // We've imported your old cypress plugins here.
     // You may want to clean this up later by importing these.
     setupNodeEvents(on, config) {
+      // Help for memory issues.
+      // Ref: https://www.bigbinary.com/blog/how-we-fixed-the-cypress-out-of-memory-error-in-chromium-browsers
+      on("before:browser:launch", (browser, launchOptions) => {
+
+        if (["chrome", "edge"].includes(browser.name)) {
+          launchOptions.args.push("--no-sandbox");
+          launchOptions.args.push("--disable-gl-drawing-for-tests");
+          launchOptions.args.push("--disable-gpu");
+          launchOptions.args.push("--js-flags=--max-old-space-size=3500");
+        }
+        return launchOptions;
+      });
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       require('./plugins/index.ts')(on, config)
       // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/tests/cypress/latest/e2e/capa_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capa_kubeadm_clusterclass.spec.ts
@@ -1,6 +1,6 @@
 import '~/support/commands';
 import {qase} from 'cypress-qase-reporter/dist/mocha';
-import {getClusterName, skipClusterDeletion, isRancherManagerVersion} from '~/support/utils';
+import {getClusterName, skipClusterDeletion} from '~/support/utils';
 import {capaResourcesCleanup, capiClusterDeletion, importedRancherClusterDeletion} from "~/support/cleanup_support";
 
 Cypress.config();
@@ -38,15 +38,8 @@ describe('Import CAPA Kubeadm Class-Cluster', { tags: '@full' }, () => {
       // Go to CAPI > ClusterClass to ensure the clusterclass is created
       cy.checkCAPIClusterClass(classNamePrefix);
 
-      // Navigate to `local` cluster, More Resources > Fleet > Helm [O]|[Ap]ps and ensure the charts are active.
-      cy.burgerMenuOperate('open');
-      cy.contains('local').click();
-      const helmPsMenuLocation = isRancherManagerVersion('2.12') ? ['More Resources', 'Fleet', 'Helm Ops'] : ['More Resources', 'Fleet', 'HelmApps'];
-      cy.accesMenuSelection(helmPsMenuLocation);
-      ['aws-ccm', 'aws-csi-driver', 'calico-cni-aws'].forEach((app) => {
-        cy.typeInFilter(app);
-        cy.getBySel('sortable-cell-0-1').should('exist');
-      })
+      // Navigate to `local` cluster, More Resources > Fleet > HelmApps and ensure the charts are present.
+      cy.checkFleetHelmApps(['aws-ccm', 'aws-csi-driver', 'calico-cni-aws']);
     })
   );
 

--- a/tests/cypress/latest/e2e/capa_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capa_kubeadm_clusterclass.spec.ts
@@ -1,6 +1,6 @@
 import '~/support/commands';
 import {qase} from 'cypress-qase-reporter/dist/mocha';
-import {getClusterName, skipClusterDeletion} from '~/support/utils';
+import {getClusterName, skipClusterDeletion, isRancherManagerVersion} from '~/support/utils';
 import {capaResourcesCleanup, capiClusterDeletion, importedRancherClusterDeletion} from "~/support/cleanup_support";
 
 Cypress.config();
@@ -38,10 +38,11 @@ describe('Import CAPA Kubeadm Class-Cluster', { tags: '@full' }, () => {
       // Go to CAPI > ClusterClass to ensure the clusterclass is created
       cy.checkCAPIClusterClass(classNamePrefix);
 
-      // Navigate to `local` cluster, More Resources > Fleet > Helm Apps and ensure the charts are active.
+      // Navigate to `local` cluster, More Resources > Fleet > Helm [O]|[Ap]ps and ensure the charts are active.
       cy.burgerMenuOperate('open');
       cy.contains('local').click();
-      cy.accesMenuSelection(['More Resources', 'Fleet', 'HelmApps']);
+      const helmPsMenuLocation = isRancherManagerVersion('2.12') ? ['More Resources', 'Fleet', 'Helm Ops'] : ['More Resources', 'Fleet', 'HelmApps'];
+      cy.accesMenuSelection(helmPsMenuLocation);
       ['aws-ccm', 'aws-csi-driver', 'calico-cni-aws'].forEach((app) => {
         cy.typeInFilter(app);
         cy.getBySel('sortable-cell-0-1').should('exist');

--- a/tests/cypress/latest/e2e/capa_rke2_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capa_rke2_clusterclass.spec.ts
@@ -1,6 +1,6 @@
 import '~/support/commands';
 import {qase} from 'cypress-qase-reporter/dist/mocha';
-import {getClusterName, skipClusterDeletion, isRancherManagerVersion} from '~/support/utils';
+import {getClusterName, skipClusterDeletion} from '~/support/utils';
 import {capaResourcesCleanup, capiClusterDeletion, importedRancherClusterDeletion} from "~/support/cleanup_support";
 
 Cypress.config();
@@ -38,15 +38,8 @@ describe('Import CAPA RKE2 Class-Cluster', { tags: '@full' }, () => {
       // Go to CAPI > ClusterClass to ensure the clusterclass is created
       cy.checkCAPIClusterClass(classNamePrefix);
 
-      // Navigate to `local` cluster, More Resources > Fleet > Helm [O]|[Ap]ps and ensure the charts are active.
-      cy.burgerMenuOperate('open');
-      cy.contains('local').click();
-      const helmPsMenuLocation = isRancherManagerVersion('2.12') ? ['More Resources', 'Fleet', 'Helm Ops'] : ['More Resources', 'Fleet', 'HelmApps'];
-      cy.accesMenuSelection(helmPsMenuLocation);
-      ['aws-ccm', 'aws-csi-driver'].forEach((app) => {
-        cy.typeInFilter(app);
-        cy.getBySel('sortable-cell-0-1').should('exist');
-      })
+      // Navigate to `local` cluster, More Resources > Fleet > HelmApps and ensure the charts are present.
+      cy.checkFleetHelmApps(['aws-ccm', 'aws-csi-driver']);
     })
   );
 

--- a/tests/cypress/latest/e2e/capa_rke2_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capa_rke2_clusterclass.spec.ts
@@ -1,6 +1,6 @@
 import '~/support/commands';
 import {qase} from 'cypress-qase-reporter/dist/mocha';
-import {getClusterName, skipClusterDeletion} from '~/support/utils';
+import {getClusterName, skipClusterDeletion, isRancherManagerVersion} from '~/support/utils';
 import {capaResourcesCleanup, capiClusterDeletion, importedRancherClusterDeletion} from "~/support/cleanup_support";
 
 Cypress.config();
@@ -38,10 +38,11 @@ describe('Import CAPA RKE2 Class-Cluster', { tags: '@full' }, () => {
       // Go to CAPI > ClusterClass to ensure the clusterclass is created
       cy.checkCAPIClusterClass(classNamePrefix);
 
-      // Navigate to `local` cluster, More Resources > Fleet > Helm Apps and ensure the charts are active.
+      // Navigate to `local` cluster, More Resources > Fleet > Helm [O]|[Ap]ps and ensure the charts are active.
       cy.burgerMenuOperate('open');
       cy.contains('local').click();
-      cy.accesMenuSelection(['More Resources', 'Fleet', 'HelmApps']);
+      const helmPsMenuLocation = isRancherManagerVersion('2.12') ? ['More Resources', 'Fleet', 'Helm Ops'] : ['More Resources', 'Fleet', 'HelmApps'];
+      cy.accesMenuSelection(helmPsMenuLocation);
       ['aws-ccm', 'aws-csi-driver'].forEach((app) => {
         cy.typeInFilter(app);
         cy.getBySel('sortable-cell-0-1').should('exist');

--- a/tests/cypress/latest/e2e/capd_rke2_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capd_rke2_clusterclass.spec.ts
@@ -53,7 +53,7 @@ describe('Import CAPD RKE2 Class-Cluster', { tags: '@short' }, () => {
       data = data.replace(/replace_cluster_docker_auth_username/, dockerAuthUsernameBase64)
       data = data.replace(/replace_cluster_docker_auth_password/, dockerAuthPasswordBase64)
       cy.importYAML(data, capiClustersNS)
-    })
+    });
   });
 
   qase(91,

--- a/tests/cypress/latest/e2e/capg_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capg_kubeadm_clusterclass.spec.ts
@@ -1,7 +1,7 @@
 import '~/support/commands';
 
 import {qase} from 'cypress-qase-reporter/dist/mocha';
-import {getClusterName, skipClusterDeletion, isRancherManagerVersion} from '~/support/utils';
+import {getClusterName, skipClusterDeletion} from '~/support/utils';
 import {capiClusterDeletion, importedRancherClusterDeletion} from "~/support/cleanup_support";
 
 Cypress.config();
@@ -29,17 +29,13 @@ describe('Import CAPG Kubeadm Class-Cluster', { tags: '@full' }, () => {
       // Go to CAPI > ClusterClass to ensure the clusterclass is created
       cy.checkCAPIClusterClass(classNamePrefix);
 
-      // Navigate to `local` cluster, More Resources > Fleet > Helm [O]|[Ap]ps and ensure the charts are active.
-      cy.burgerMenuOperate('open');
-      cy.contains('local').click();
-      const helmPsMenuLocation = isRancherManagerVersion('2.12') ? ['More Resources', 'Fleet', 'Helm Ops'] : ['More Resources', 'Fleet', 'HelmApps'];
-      cy.accesMenuSelection(helmPsMenuLocation);
-      cy.typeInFilter("calico-cni");
-      cy.getBySel('sortable-cell-0-1').should('exist');
+      // Navigate to `local` cluster, More Resources > Fleet > HelmApps and ensure the charts are present.
+      cy.checkFleetHelmApps(['calico-cni']);
+
+      // Check GCP CCM bundle is available
       cy.accesMenuSelection(['More Resources', 'Fleet', 'Bundle']);
       cy.typeInFilter("cloud-controller-manager-gcp");
       cy.getBySel('sortable-cell-0-1').should('exist');
-
     })
   );
 

--- a/tests/cypress/latest/e2e/capg_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capg_kubeadm_clusterclass.spec.ts
@@ -1,7 +1,7 @@
 import '~/support/commands';
 
 import {qase} from 'cypress-qase-reporter/dist/mocha';
-import {getClusterName, skipClusterDeletion} from '~/support/utils';
+import {getClusterName, skipClusterDeletion, isRancherManagerVersion} from '~/support/utils';
 import {capiClusterDeletion, importedRancherClusterDeletion} from "~/support/cleanup_support";
 
 Cypress.config();
@@ -29,10 +29,11 @@ describe('Import CAPG Kubeadm Class-Cluster', { tags: '@full' }, () => {
       // Go to CAPI > ClusterClass to ensure the clusterclass is created
       cy.checkCAPIClusterClass(classNamePrefix);
 
-      // Navigate to `local` cluster, More Resources > Fleet > Helm Apps and ensure the charts are active.
+      // Navigate to `local` cluster, More Resources > Fleet > Helm [O]|[Ap]ps and ensure the charts are active.
       cy.burgerMenuOperate('open');
       cy.contains('local').click();
-      cy.accesMenuSelection(['More Resources', 'Fleet', 'HelmApps']);
+      const helmPsMenuLocation = isRancherManagerVersion('2.12') ? ['More Resources', 'Fleet', 'Helm Ops'] : ['More Resources', 'Fleet', 'HelmApps'];
+      cy.accesMenuSelection(helmPsMenuLocation);
       cy.typeInFilter("calico-cni");
       cy.getBySel('sortable-cell-0-1').should('exist');
       cy.accesMenuSelection(['More Resources', 'Fleet', 'Bundle']);

--- a/tests/cypress/latest/e2e/capv_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capv_kubeadm_clusterclass.spec.ts
@@ -1,6 +1,6 @@
 import '~/support/commands';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
-import {skipClusterDeletion} from '~/support/utils';
+import {skipClusterDeletion, isRancherManagerVersion} from '~/support/utils';
 import {capiClusterDeletion, capvResourcesCleanup, importedRancherClusterDeletion} from "~/support/cleanup_support";
 
 Cypress.config();
@@ -75,10 +75,11 @@ describe('Import CAPV Kubeadm Class-Cluster', { tags: '@vsphere' }, () => {
     // Go to CAPI > ClusterClass to ensure the clusterclass is created
     cy.checkCAPIClusterClass(className);
 
-    // Navigate to `local` cluster, More Resources > Fleet > Helm Apps and ensure the charts are active.
+    // Navigate to `local` cluster, More Resources > Fleet > Helm [O]|[Ap]ps and ensure the charts are active.
     cy.burgerMenuOperate('open');
     cy.contains('local').click();
-    cy.accesMenuSelection(['More Resources', 'Fleet', 'HelmApps']);
+    const helmPsMenuLocation = isRancherManagerVersion('2.12') ? ['More Resources', 'Fleet', 'Helm Ops'] : ['More Resources', 'Fleet', 'HelmApps'];
+    cy.accesMenuSelection(helmPsMenuLocation);
     cy.typeInFilter('vsphere-ccm');
     cy.getBySel('sortable-cell-0-1').should('exist');
   });

--- a/tests/cypress/latest/e2e/capv_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capv_kubeadm_clusterclass.spec.ts
@@ -1,6 +1,6 @@
 import '~/support/commands';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
-import {skipClusterDeletion, isRancherManagerVersion} from '~/support/utils';
+import {skipClusterDeletion} from '~/support/utils';
 import {capiClusterDeletion, capvResourcesCleanup, importedRancherClusterDeletion} from "~/support/cleanup_support";
 
 Cypress.config();
@@ -75,13 +75,8 @@ describe('Import CAPV Kubeadm Class-Cluster', { tags: '@vsphere' }, () => {
     // Go to CAPI > ClusterClass to ensure the clusterclass is created
     cy.checkCAPIClusterClass(className);
 
-    // Navigate to `local` cluster, More Resources > Fleet > Helm [O]|[Ap]ps and ensure the charts are active.
-    cy.burgerMenuOperate('open');
-    cy.contains('local').click();
-    const helmPsMenuLocation = isRancherManagerVersion('2.12') ? ['More Resources', 'Fleet', 'Helm Ops'] : ['More Resources', 'Fleet', 'HelmApps'];
-    cy.accesMenuSelection(helmPsMenuLocation);
-    cy.typeInFilter('vsphere-ccm');
-    cy.getBySel('sortable-cell-0-1').should('exist');
+    // Navigate to `local` cluster, More Resources > Fleet > HelmApps and ensure the charts are present.
+    cy.checkFleetHelmApps(['vsphere-ccm']);
   });
 
 

--- a/tests/cypress/latest/e2e/capv_rke2_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capv_rke2_clusterclass.spec.ts
@@ -1,7 +1,7 @@
 import '~/support/commands';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import {qase} from 'cypress-qase-reporter/dist/mocha';
-import {skipClusterDeletion} from '~/support/utils';
+import {skipClusterDeletion, isRancherManagerVersion} from '~/support/utils';
 import {capiClusterDeletion, capvResourcesCleanup, importedRancherClusterDeletion} from "~/support/cleanup_support";
 
 Cypress.config();
@@ -95,10 +95,11 @@ describe('Import CAPV RKE2 Class-Cluster', { tags: '@vsphere' }, () => {
     // Go to CAPI > ClusterClass to ensure the clusterclass is created
     cy.checkCAPIClusterClass(className);
 
-    // Navigate to `local` cluster, More Resources > Fleet > Helm Apps and ensure the charts are active.
+    // Navigate to `local` cluster, More Resources > Fleet > Helm [O]|[Ap]ps and ensure the charts are active.
     cy.burgerMenuOperate('open');
     cy.contains('local').click();
-    cy.accesMenuSelection(['More Resources', 'Fleet', 'HelmApps']);
+    const helmPsMenuLocation = isRancherManagerVersion('2.12') ? ['More Resources', 'Fleet', 'Helm Ops'] : ['More Resources', 'Fleet', 'HelmApps'];
+    cy.accesMenuSelection(helmPsMenuLocation);
     cy.typeInFilter('vsphere-ccm');
     cy.getBySel('sortable-cell-0-1').should('exist');
   });
@@ -146,7 +147,10 @@ describe('Import CAPV RKE2 Class-Cluster', { tags: '@vsphere' }, () => {
       cy.typeInFilter('plndr-cp-lock');
       // Ensure the kube-vip lease is present
       cy.getBySel('sortable-cell-0-1').should('exist');
-      return cy.getBySel('sortable-cell-0-2').invoke('text');
+
+      // Leases table in 2.12 showing extra namespace column
+      const holderSelector = isRancherManagerVersion('2.12') ? 'sortable-cell-0-3' : 'sortable-cell-0-2';
+      return cy.getBySel(holderSelector).invoke('text');
     }
 
     // Initial count of kube-vip pods should be 3 (one for each control plane node)

--- a/tests/cypress/latest/e2e/capv_rke2_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capv_rke2_clusterclass.spec.ts
@@ -95,13 +95,8 @@ describe('Import CAPV RKE2 Class-Cluster', { tags: '@vsphere' }, () => {
     // Go to CAPI > ClusterClass to ensure the clusterclass is created
     cy.checkCAPIClusterClass(className);
 
-    // Navigate to `local` cluster, More Resources > Fleet > Helm [O]|[Ap]ps and ensure the charts are active.
-    cy.burgerMenuOperate('open');
-    cy.contains('local').click();
-    const helmPsMenuLocation = isRancherManagerVersion('2.12') ? ['More Resources', 'Fleet', 'Helm Ops'] : ['More Resources', 'Fleet', 'HelmApps'];
-    cy.accesMenuSelection(helmPsMenuLocation);
-    cy.typeInFilter('vsphere-ccm');
-    cy.getBySel('sortable-cell-0-1').should('exist');
+    // Navigate to `local` cluster, More Resources > Fleet > HelmApps and ensure the charts are present.
+    cy.checkFleetHelmApps(['vsphere-ccm']);
   });
 
   it('Add CAPV class-clusters fleet repo', () => {

--- a/tests/cypress/latest/e2e/capz_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capz_kubeadm_clusterclass.spec.ts
@@ -1,5 +1,5 @@
 import '~/support/commands';
-import {getClusterName, skipClusterDeletion} from '~/support/utils';
+import {getClusterName, skipClusterDeletion, isRancherManagerVersion} from '~/support/utils';
 import {capiClusterDeletion, capzResourcesCleanup, importedRancherClusterDeletion} from "~/support/cleanup_support";
 
 Cypress.config();
@@ -34,10 +34,11 @@ describe('Import CAPZ Kubeadm Class-Cluster', { tags: '@full' }, () => {
     // Go to CAPI > ClusterClass to ensure the clusterclass is created
     cy.checkCAPIClusterClass(classNamePrefix);
 
-    // Navigate to `local` cluster, More Resources > Fleet > Helm Apps and ensure the charts are active.
+    // Navigate to `local` cluster, More Resources > Fleet > Helm [O]|[Ap]ps and ensure the charts are active.
     cy.burgerMenuOperate('open');
     cy.contains('local').click();
-    cy.accesMenuSelection(['More Resources', 'Fleet', 'HelmApps']);
+    const helmPsMenuLocation = isRancherManagerVersion('2.12') ? ['More Resources', 'Fleet', 'Helm Ops'] : ['More Resources', 'Fleet', 'HelmApps'];
+    cy.accesMenuSelection(helmPsMenuLocation);
     ["azure-ccm", "calico-cni"].forEach((app) => {
       cy.typeInFilter(app);
       cy.getBySel('sortable-cell-0-1').should('exist');

--- a/tests/cypress/latest/e2e/capz_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capz_kubeadm_clusterclass.spec.ts
@@ -1,5 +1,5 @@
 import '~/support/commands';
-import {getClusterName, skipClusterDeletion, isRancherManagerVersion} from '~/support/utils';
+import {getClusterName, skipClusterDeletion} from '~/support/utils';
 import {capiClusterDeletion, capzResourcesCleanup, importedRancherClusterDeletion} from "~/support/cleanup_support";
 
 Cypress.config();
@@ -34,15 +34,8 @@ describe('Import CAPZ Kubeadm Class-Cluster', { tags: '@full' }, () => {
     // Go to CAPI > ClusterClass to ensure the clusterclass is created
     cy.checkCAPIClusterClass(classNamePrefix);
 
-    // Navigate to `local` cluster, More Resources > Fleet > Helm [O]|[Ap]ps and ensure the charts are active.
-    cy.burgerMenuOperate('open');
-    cy.contains('local').click();
-    const helmPsMenuLocation = isRancherManagerVersion('2.12') ? ['More Resources', 'Fleet', 'Helm Ops'] : ['More Resources', 'Fleet', 'HelmApps'];
-    cy.accesMenuSelection(helmPsMenuLocation);
-    ["azure-ccm", "calico-cni"].forEach((app) => {
-      cy.typeInFilter(app);
-      cy.getBySel('sortable-cell-0-1').should('exist');
-    })
+    // Navigate to `local` cluster, More Resources > Fleet > HelmApps and ensure the charts are present.
+    cy.checkFleetHelmApps(['azure-ccm', 'calico-cni']);
   });
 
   it('Import CAPZ Kubeadm class-cluster using YAML', () => {

--- a/tests/cypress/latest/e2e/capz_rke2_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capz_rke2_clusterclass.spec.ts
@@ -1,6 +1,6 @@
 import '~/support/commands';
 import {qase} from 'cypress-qase-reporter/dist/mocha';
-import {getClusterName, skipClusterDeletion} from '~/support/utils';
+import {getClusterName, skipClusterDeletion, isRancherManagerVersion} from '~/support/utils';
 import {capiClusterDeletion, capzResourcesCleanup, importedRancherClusterDeletion} from "~/support/cleanup_support";
 
 Cypress.config();
@@ -35,10 +35,11 @@ describe('Import CAPZ RKE2 Class-Cluster', { tags: '@full' }, () => {
     // Go to CAPI > ClusterClass to ensure the clusterclass is created
     cy.checkCAPIClusterClass(classNamePrefix);
 
-    // Navigate to `local` cluster, More Resources > Fleet > Helm Apps and ensure the charts are active.
+    // Navigate to `local` cluster, More Resources > Fleet > Helm [O]|[Ap]ps and ensure the charts are active.
     cy.burgerMenuOperate('open');
     cy.contains('local').click();
-    cy.accesMenuSelection(['More Resources', 'Fleet', 'HelmApps']);
+    const helmPsMenuLocation = isRancherManagerVersion('2.12') ? ['More Resources', 'Fleet', 'Helm Ops'] : ['More Resources', 'Fleet', 'HelmApps'];
+    cy.accesMenuSelection(helmPsMenuLocation);
     ["azure-ccm", "calico-cni"].forEach((app) => {
       cy.typeInFilter(app);
       cy.getBySel('sortable-cell-0-1').should('exist');

--- a/tests/cypress/latest/e2e/capz_rke2_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capz_rke2_clusterclass.spec.ts
@@ -1,6 +1,6 @@
 import '~/support/commands';
 import {qase} from 'cypress-qase-reporter/dist/mocha';
-import {getClusterName, skipClusterDeletion, isRancherManagerVersion} from '~/support/utils';
+import {getClusterName, skipClusterDeletion} from '~/support/utils';
 import {capiClusterDeletion, capzResourcesCleanup, importedRancherClusterDeletion} from "~/support/cleanup_support";
 
 Cypress.config();
@@ -35,15 +35,8 @@ describe('Import CAPZ RKE2 Class-Cluster', { tags: '@full' }, () => {
     // Go to CAPI > ClusterClass to ensure the clusterclass is created
     cy.checkCAPIClusterClass(classNamePrefix);
 
-    // Navigate to `local` cluster, More Resources > Fleet > Helm [O]|[Ap]ps and ensure the charts are active.
-    cy.burgerMenuOperate('open');
-    cy.contains('local').click();
-    const helmPsMenuLocation = isRancherManagerVersion('2.12') ? ['More Resources', 'Fleet', 'Helm Ops'] : ['More Resources', 'Fleet', 'HelmApps'];
-    cy.accesMenuSelection(helmPsMenuLocation);
-    ["azure-ccm", "calico-cni"].forEach((app) => {
-      cy.typeInFilter(app);
-      cy.getBySel('sortable-cell-0-1').should('exist');
-    })
+    // Navigate to `local` cluster, More Resources > Fleet > HelmApps and ensure the charts are present.
+    cy.checkFleetHelmApps(['azure-ccm', 'calico-cni']);
   })
   );
 

--- a/tests/cypress/latest/e2e/providers_setup.spec.ts
+++ b/tests/cypress/latest/e2e/providers_setup.spec.ts
@@ -13,12 +13,33 @@ limitations under the License.
 
 import '~/support/commands';
 import {qase} from 'cypress-qase-reporter/dist/mocha';
+import {isRancherManagerVersion} from '~/support/utils';
+
+function matchAndWaitForReadyProvider(
+  providerString: string,
+  providerType: string,
+  providerName: string,
+  providerVersion: string,
+  timeout: number = 60000,
+) {
+  const readyState = 'Ready'; // Default state
+  cy.get('tr.main-row', { timeout: timeout })
+    .contains('a', providerString)
+    .closest('tr')
+    .within(() => {
+      //cy.get('td').eq(1).should('contain.text', readyState);    // State - unreliable in 2.12 - often Unavailable, using Phase instead
+      cy.get('td').eq(2).should('contain.text', providerString);  // Name
+      cy.get('td').eq(3).should('contain.text', providerType);    // Type
+      cy.get('td').eq(4).should('contain.text', providerName);    // ProviderName
+      cy.get('td').eq(5).should('contain.text', providerVersion); // InstalledVersion
+      cy.get('td').eq(6).should('contain.text', readyState);      // Phase
+    });
+}
 
 Cypress.config();
 describe('Enable CAPI Providers', () => {
-  const statusReady = 'Ready'
-  const branch = 'release-0.23' // TODO: Change to main in rancher-turtles-e2e/issues/243
-  const turtlesRepoUrl = 'https://github.com/rancher/turtles.git'
+  const branch = isRancherManagerVersion('2.12') ? 'main' : 'release-0.23';
+  const turtlesRepoUrl = 'https://github.com/rancher/turtles.git';
 
   // Providers names
   const kubeadmProvider = 'kubeadm'
@@ -95,15 +116,25 @@ describe('Enable CAPI Providers', () => {
             const providerURL = kubeadmBaseURL + kubeadmProviderVersion + '/' + 'control-plane' + '-components.yaml'
             const providerName = kubeadmProvider + '-' + 'control-plane'
             cy.addCustomProvider(providerName, 'capi-kubeadm-control-plane-system', kubeadmProvider, providerType, kubeadmProviderVersion, providerURL);
-            const readyStatus = statusReady.concat(providerName, 'controlPlane', kubeadmProvider, kubeadmProviderVersion)
-            cy.contains(readyStatus);
+            matchAndWaitForReadyProvider(
+              providerName,
+              'controlPlane',
+              kubeadmProvider,
+              kubeadmProviderVersion,
+              120000
+            );
           } else {
             // https://github.com/kubernetes-sigs/cluster-api/releases/v1.10.5/bootstrap-components.yaml
             const providerURL = kubeadmBaseURL + kubeadmProviderVersion + '/' + providerType + '-components.yaml'
             const providerName = kubeadmProvider + '-' + providerType
             cy.addCustomProvider(providerName, 'capi-kubeadm-bootstrap-system', kubeadmProvider, providerType, kubeadmProviderVersion, providerURL);
-            const readyStatus = statusReady.concat(providerName, 'bootstrap', kubeadmProvider, kubeadmProviderVersion)
-            cy.contains(readyStatus);
+            matchAndWaitForReadyProvider(
+              providerName,
+              providerType,
+              kubeadmProvider,
+              kubeadmProviderVersion,
+              120000
+            );
           }
         })
       );
@@ -114,9 +145,13 @@ describe('Enable CAPI Providers', () => {
         // Create Docker Infrastructure provider
         const namespace = 'capd-system'
         cy.addInfraProvider('Docker', namespace);
-        const readyStatus = statusReady.concat(dockerProvider, 'infrastructure', dockerProvider, kubeadmProviderVersion)
-        // TODO: add actual vs expected
-        cy.contains(readyStatus);
+        matchAndWaitForReadyProvider(
+          dockerProvider,
+          'infrastructure',
+          dockerProvider,
+          kubeadmProviderVersion,
+          120000
+        );
         cy.verifyCAPIProviderImage(dockerProvider, namespace);
       })
     );
@@ -147,8 +182,7 @@ describe('Enable CAPI Providers', () => {
       // Fleet addon provider is provisioned automatically when enabled during installation
       cy.checkCAPIMenu();
       cy.contains('Providers').click();
-      const readyStatus = statusReady.concat(fleetProvider, 'addon', fleetProvider, fleetProviderVersion);
-      cy.contains(readyStatus).scrollIntoView();
+      matchAndWaitForReadyProvider(fleetProvider, 'addon', fleetProvider, fleetProviderVersion, 30000);
     });
   });
 
@@ -171,8 +205,13 @@ describe('Enable CAPI Providers', () => {
         cy.addCloudCredsVMware(vsphereProvider, vsphereUsername, vspherePassword, vsphereServer, vspherePort);
         cy.burgerMenuOperate('open');
         cy.addInfraProvider('vSphere', vsphereProviderNamespace, vsphereProvider);
-        const readyStatus = statusReady.concat(vsphereProvider, 'infrastructure', vsphereProvider, vsphereProviderVersion)
-        cy.contains(readyStatus);
+        matchAndWaitForReadyProvider(
+          vsphereProvider,
+          'infrastructure',
+          vsphereProvider,
+          vsphereProviderVersion,
+          120000
+        );
         cy.verifyCAPIProviderImage(vsphereProvider, vsphereProviderNamespace);
       })
     );
@@ -193,8 +232,13 @@ describe('Enable CAPI Providers', () => {
         cy.addCloudCredsAWS(amazonProvider, Cypress.env('aws_access_key'), Cypress.env('aws_secret_key'));
         cy.burgerMenuOperate('open');
         cy.addInfraProvider('Amazon', namespace, amazonProvider);
-        const readyStatus = statusReady.concat(amazonProvider, providerType, amazonProvider, amazonProviderVersion)
-        cy.contains(readyStatus);
+        matchAndWaitForReadyProvider(
+          amazonProvider,
+          providerType,
+          amazonProvider,
+          amazonProviderVersion,
+          120000
+        );
         cy.verifyCAPIProviderImage(amazonProvider, namespace);
       })
     );
@@ -206,8 +250,13 @@ describe('Enable CAPI Providers', () => {
         cy.addCloudCredsGCP(googleProvider, Cypress.env('gcp_credentials'));
         cy.burgerMenuOperate('open');
         cy.addInfraProvider('Google Cloud Platform', namespace, googleProvider);
-        const readyStatus = statusReady.concat(googleProvider, providerType, googleProvider, googleProviderVersion)
-        cy.contains(readyStatus, { timeout: 120000 });
+        matchAndWaitForReadyProvider(
+          googleProvider,
+          providerType,
+          googleProvider,
+          googleProviderVersion,
+          120000
+        );
         cy.verifyCAPIProviderImage(googleProvider, namespace);
       })
     );
@@ -216,8 +265,13 @@ describe('Enable CAPI Providers', () => {
       const namespace = 'capz-system'
       // Create Azure Infrastructure provider
       cy.addInfraProvider('Azure', namespace, azureProvider);
-      const readyStatus = statusReady.concat(azureProvider, providerType, azureProvider, azureProviderVersion)
-      cy.contains(readyStatus, { timeout: 180000 });
+      matchAndWaitForReadyProvider(
+        azureProvider,
+        providerType,
+        azureProvider,
+        azureProviderVersion,
+        180000
+      );
       cy.verifyCAPIProviderImage(azureProvider, namespace);
     })
     );

--- a/tests/cypress/latest/e2e/providers_setup.spec.ts
+++ b/tests/cypress/latest/e2e/providers_setup.spec.ts
@@ -15,7 +15,7 @@ import '~/support/commands';
 import {qase} from 'cypress-qase-reporter/dist/mocha';
 import {isRancherManagerVersion} from '~/support/utils';
 
-function matchAndWaitForReadyProvider(
+function matchAndWaitForProviderReadyStatus(
   providerString: string,
   providerType: string,
   providerName: string,
@@ -116,25 +116,13 @@ describe('Enable CAPI Providers', () => {
             const providerURL = kubeadmBaseURL + kubeadmProviderVersion + '/' + 'control-plane' + '-components.yaml'
             const providerName = kubeadmProvider + '-' + 'control-plane'
             cy.addCustomProvider(providerName, 'capi-kubeadm-control-plane-system', kubeadmProvider, providerType, kubeadmProviderVersion, providerURL);
-            matchAndWaitForReadyProvider(
-              providerName,
-              'controlPlane',
-              kubeadmProvider,
-              kubeadmProviderVersion,
-              120000
-            );
+            matchAndWaitForProviderReadyStatus(providerName, 'controlPlane', kubeadmProvider, kubeadmProviderVersion, 120000);
           } else {
             // https://github.com/kubernetes-sigs/cluster-api/releases/v1.10.5/bootstrap-components.yaml
             const providerURL = kubeadmBaseURL + kubeadmProviderVersion + '/' + providerType + '-components.yaml'
             const providerName = kubeadmProvider + '-' + providerType
             cy.addCustomProvider(providerName, 'capi-kubeadm-bootstrap-system', kubeadmProvider, providerType, kubeadmProviderVersion, providerURL);
-            matchAndWaitForReadyProvider(
-              providerName,
-              providerType,
-              kubeadmProvider,
-              kubeadmProviderVersion,
-              120000
-            );
+            matchAndWaitForProviderReadyStatus(providerName, providerType, kubeadmProvider, kubeadmProviderVersion, 120000);
           }
         })
       );
@@ -145,13 +133,7 @@ describe('Enable CAPI Providers', () => {
         // Create Docker Infrastructure provider
         const namespace = 'capd-system'
         cy.addInfraProvider('Docker', namespace);
-        matchAndWaitForReadyProvider(
-          dockerProvider,
-          'infrastructure',
-          dockerProvider,
-          kubeadmProviderVersion,
-          120000
-        );
+        matchAndWaitForProviderReadyStatus(dockerProvider, 'infrastructure', dockerProvider, kubeadmProviderVersion, 120000);
         cy.verifyCAPIProviderImage(dockerProvider, namespace);
       })
     );
@@ -182,7 +164,7 @@ describe('Enable CAPI Providers', () => {
       // Fleet addon provider is provisioned automatically when enabled during installation
       cy.checkCAPIMenu();
       cy.contains('Providers').click();
-      matchAndWaitForReadyProvider(fleetProvider, 'addon', fleetProvider, fleetProviderVersion, 30000);
+      matchAndWaitForProviderReadyStatus(fleetProvider, 'addon', fleetProvider, fleetProviderVersion, 30000);
     });
   });
 
@@ -205,13 +187,7 @@ describe('Enable CAPI Providers', () => {
         cy.addCloudCredsVMware(vsphereProvider, vsphereUsername, vspherePassword, vsphereServer, vspherePort);
         cy.burgerMenuOperate('open');
         cy.addInfraProvider('vSphere', vsphereProviderNamespace, vsphereProvider);
-        matchAndWaitForReadyProvider(
-          vsphereProvider,
-          'infrastructure',
-          vsphereProvider,
-          vsphereProviderVersion,
-          120000
-        );
+        matchAndWaitForProviderReadyStatus(vsphereProvider, 'infrastructure', vsphereProvider, vsphereProviderVersion, 120000);
         cy.verifyCAPIProviderImage(vsphereProvider, vsphereProviderNamespace);
       })
     );
@@ -232,13 +208,7 @@ describe('Enable CAPI Providers', () => {
         cy.addCloudCredsAWS(amazonProvider, Cypress.env('aws_access_key'), Cypress.env('aws_secret_key'));
         cy.burgerMenuOperate('open');
         cy.addInfraProvider('Amazon', namespace, amazonProvider);
-        matchAndWaitForReadyProvider(
-          amazonProvider,
-          providerType,
-          amazonProvider,
-          amazonProviderVersion,
-          120000
-        );
+        matchAndWaitForProviderReadyStatus(amazonProvider, providerType, amazonProvider, amazonProviderVersion, 120000);
         cy.verifyCAPIProviderImage(amazonProvider, namespace);
       })
     );
@@ -250,13 +220,7 @@ describe('Enable CAPI Providers', () => {
         cy.addCloudCredsGCP(googleProvider, Cypress.env('gcp_credentials'));
         cy.burgerMenuOperate('open');
         cy.addInfraProvider('Google Cloud Platform', namespace, googleProvider);
-        matchAndWaitForReadyProvider(
-          googleProvider,
-          providerType,
-          googleProvider,
-          googleProviderVersion,
-          120000
-        );
+        matchAndWaitForProviderReadyStatus(googleProvider, providerType, googleProvider, googleProviderVersion, 120000);
         cy.verifyCAPIProviderImage(googleProvider, namespace);
       })
     );
@@ -265,13 +229,7 @@ describe('Enable CAPI Providers', () => {
       const namespace = 'capz-system'
       // Create Azure Infrastructure provider
       cy.addInfraProvider('Azure', namespace, azureProvider);
-      matchAndWaitForReadyProvider(
-        azureProvider,
-        providerType,
-        azureProvider,
-        azureProviderVersion,
-        180000
-      );
+      matchAndWaitForProviderReadyStatus(azureProvider, providerType, azureProvider, azureProviderVersion, 180000);
       cy.verifyCAPIProviderImage(azureProvider, namespace);
     })
     );

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -365,7 +365,10 @@ Cypress.Commands.add('addInfraProvider', (providerType, namespace, cloudCredenti
   cy.clickButton('Create');
   const selector = "'select-icon-grid-" + providerType + "'"
   cy.getBySel(selector).click();
-  cy.contains('Provider: Create ' + providerType, { matchCase: false }).should('be.visible');
+
+  // Match only with the first word of the provider type to avoid issues with providers like 'Google Cloud Platform' in 2.12
+  const firstWordOfProviderType = providerType.includes(' ') ? providerType.split(' ')[0] : providerType;
+  cy.contains('Provider: Create ' + firstWordOfProviderType, { matchCase: false }).should('be.visible');
 
   // TODO: Add variables support after capi-ui-extension/issues/49
   cy.getBySel('name-ns-description-namespace').type(namespace + '{enter}');

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -18,6 +18,7 @@ import 'cypress-file-upload';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import jsyaml from 'js-yaml';
 import _ from 'lodash';
+import { isRancherManagerVersion } from '~/support/utils';
 
 // Generic commands
 // Go to specific Sub Menu from Access Menu
@@ -72,10 +73,13 @@ Cypress.Commands.add('createNamespace', (namespace) => {
   cy.contains('local')
     .click();
   cypressLib.accesMenu('Projects/Namespaces');
-  cy.setNamespace('Not', 'all_orphans');
+  cy.contains('Create Project').should('be.visible');
 
-  // Create namespace
-  cy.contains('Create Namespace').click();
+  // Workaround for 2.12, find a row with 'Not in a Project' and press button 'Create Namespace'
+  // Ref. https://github.com/rancher/dashboard/issues/15193
+  // cy.setNamespace('Not', 'all_orphans');
+  cy.contains('Not in a Project').parents('tr').find('a').contains('Create Namespace').click();
+
   cy.typeValue('Name', namespace);
   cy.clickButton('Create');
   cy.contains(new RegExp('Active.*' + namespace));
@@ -349,7 +353,8 @@ Cypress.Commands.add('addCustomProvider', (name, namespace, providerName, provid
     cy.typeValue('URL', url);
   }
   cy.clickButton('Create');
-  cy.contains('Providers').should('be.visible');
+  cy.wait(10000); // needed for 2.12
+  cy.getBySel('sortable-table-list-container').should('be.visible');
 });
 
 // Command to add CAPI Infrastructure provider
@@ -360,17 +365,18 @@ Cypress.Commands.add('addInfraProvider', (providerType, namespace, cloudCredenti
   cy.clickButton('Create');
   const selector = "'select-icon-grid-" + providerType + "'"
   cy.getBySel(selector).click();
+  cy.contains('Provider: Create ' + providerType, { matchCase: false }).should('be.visible');
+
   // TODO: Add variables support after capi-ui-extension/issues/49
   cy.getBySel('name-ns-description-namespace').type(namespace + '{enter}');
 
-  if (providerType != 'Docker' && providerType != 'Azure') {
+  if (providerType != 'Docker' && providerType != 'Azure' && cloudCredentials) {
     cy.getBySel('cluster-prov-select-credential').trigger('click');
     cy.contains(cloudCredentials).click();
   }
-  
   cy.getBySel('capi-provider-create-save').should('be.visible');
   cy.clickButton('Create');
-  cy.contains('Providers').should('be.visible');
+  cy.getBySel('sortable-table-list-container').should('be.visible');
 });
 
 // Command to delete CAPI resource
@@ -385,8 +391,8 @@ Cypress.Commands.add('removeCAPIResource', (resourcetype, resourceName, timeout)
   cy.getBySel('sortable-cell-0-1').should('exist');
   cy.viewport(1920, 1080);
   cy.getBySel('sortable-table_check_select_all').click();
-  cy.getBySel('sortable-table-promptRemove').click();
-  cy.getBySel('prompt-remove-confirm-button').click();
+  cy.getBySel('sortable-table-promptRemove').click({ctrlKey: true}); // this will prevent to display confirmation dialog
+  cy.wait(2000); // needed for 2.12
   cy.typeInFilter(resourceName);
   if (timeout != undefined) {
     cy.getBySel('sortable-cell-0-1', { timeout: timeout }).should('not.exist');
@@ -511,29 +517,27 @@ Cypress.Commands.add('checkChart', (operation, chartName, namespace, version, qu
   }
 
   cy.get('.nav').contains('Charts').click();
-  cy.contains('Featured Charts').should('be.visible');
 
-  const findChart = (retries = 10) => {
+  if (isRancherManagerVersion('2.12')) {
+    cy.getBySel('charts-header-title').should('be.visible');
+  } else {
+    cy.contains('Featured Charts').should('be.visible'); // TODO check if this cannot be unified with 2.12
+  }
+
+  // Chart filter input is not normal filter in 2.12 :(
+  if (isRancherManagerVersion('2.12')) {
+    cy.getBySel('charts-filter-input').clear().type(chartName);
+  } else {
     cy.typeInFilter(chartName);
-    cy.getBySel('chart-selection-grid').within(() => {
-      cy.contains(chartName, { timeout: 10000 }).then($el => {
-        if ($el.length) {
-          // Chart found, proceed with click
-          cy.wrap($el).click();
-        } else if (retries > 0) {
-          // Chart not found, refresh and try again
-          cy.get('.icon.icon-lg.icon-refresh').click();
-          cy.get('.icon.icon-lg.icon-checkmark', { timeout: 60000 }).should('be.visible');
-          findChart(retries - 1);
-        } else {
-          // Max attempts reached, fail the test
-          throw new Error(`Chart ${chartName} not found`);
-        }
-      });
-    })
-    cy.contains('Charts: ' + chartName);
-  };
-  findChart();
+  }
+  const chartSelector = isRancherManagerVersion('2.12') ? 'app-chart-cards-container' : 'chart-selection-grid';
+  cy.getBySel(chartSelector).within(() => {
+    cy.contains(chartName, { timeout: 10000 }).then($el => {
+      cy.wait(500);
+      cy.wrap($el).should('be.visible').click();
+    });
+  })
+  cy.contains('Charts: ' + chartName);
 
   if (version && version != "") {
     cy.contains(version).click();
@@ -603,6 +607,7 @@ Cypress.Commands.add('checkChart', (operation, chartName, namespace, version, qu
           // Once /dashboard/about is back, reload the page
           cy.wait(5000);
           cy.reload();
+          cy.wait(2000);
         }
       });
     };
@@ -632,8 +637,10 @@ Cypress.Commands.add('checkChart', (operation, chartName, namespace, version, qu
     cy.waitForAllRowsInState('Deployed', 180000);
     cy.namespaceReset();
   } else {
+    cy.setNamespace(namespace);
     cy.contains(new RegExp('Installed App:.*Deployed'), { timeout: 120000 }).should('be.visible');
     cy.waitForAllRowsInState('Active');
+    cy.namespaceReset();
   }
 });
 
@@ -715,6 +722,7 @@ Cypress.Commands.add('deleteCluster', (clusterName, timeout = 120000) => {
   cy.getBySel('prompt-remove-input')
     .type(clusterName);
   cy.getBySel('prompt-remove-confirm-button').click();
+  cy.wait(2000); // needed for 2.12
   cy.contains(clusterName, { timeout: timeout }).should('not.exist');
 });
 
@@ -723,7 +731,7 @@ Cypress.Commands.add('typeInFilter', (text, selector = '.input-sm') => {
   cy.get(selector)
     .click()
     .clear()
-    .type(text)
+    .type(text + '{enter}')
     .wait(2000);
 });
 
@@ -736,15 +744,33 @@ Cypress.Commands.add('goToHome', () => {
 // Fleet commands
 // Command add Fleet Git Repository
 Cypress.Commands.add('addFleetGitRepo', (repoName, repoUrl, branch, paths, targetNamespace, workspace) => {
-  cy.accesMenuSelection(['Continuous Delivery', 'Git Repos']);
-  cy.getBySel('masthead-create').should('be.visible');
-  cy.getBySel('workspace-switcher').click();
-  if (!workspace) {
-    workspace = 'fleet-local';
+  function selectWorkspace(workspace?: string) {
+    // Select workspace
+    cy.getBySel('workspace-switcher').click();
+    if (!workspace) {
+      workspace = 'fleet-local';
+    }
+    cy.contains(workspace).should('be.visible').click();
   }
-  cy.contains(workspace).should('be.visible').click();
-  cy.clickButton('Add Repository');
-  cy.contains('Git Repo:').should('be.visible');
+
+  if (isRancherManagerVersion('2.12')) {
+    cy.accesMenuSelection(['Continuous Delivery', 'App Bundles']);
+    // replacement for cy.getBySel('masthead-create').should('be.visible');
+    cy.contains('Create App Bundle').should('be.visible');
+    selectWorkspace(workspace);
+    cy.clickButton('Create App Bundle');
+    // Click on gitrepo container
+    cy.contains('Git Repos').should('be.visible').click();
+    cy.contains('App Bundle:').should('be.visible');
+
+  } else {
+    cy.accesMenuSelection(['Continuous Delivery', 'Git Repos']);
+    cy.getBySel('masthead-create').should('be.visible');
+    selectWorkspace(workspace);
+    cy.clickButton('Add Repository');
+    cy.contains('Git Repo:').should('be.visible');
+  }
+
   cy.typeValue('Name', repoName);
   cy.clickButton("Next");
   cy.get('button.btn').contains('Previous').should('be.visible');
@@ -754,9 +780,7 @@ Cypress.Commands.add('addFleetGitRepo', (repoName, repoUrl, branch, paths, targe
   const pathsArray = Array.isArray(paths) ? paths : [paths];
   pathsArray.forEach((path, index) => {
     cy.clickButton('Add Path');
-    cy.getBySel('gitRepo-paths').within(() => {
-      cy.getBySel('input-' + index).type(path);
-    })
+    cy.get(`[data-testid="array-list-box${ index }"] input[placeholder="e.g. /directory/in/your/repo"]`).type(path);
   })
   cy.clickButton('Next');
   cy.get('button.btn').contains('Previous').should('be.visible');
@@ -766,7 +790,7 @@ Cypress.Commands.add('addFleetGitRepo', (repoName, repoUrl, branch, paths, targe
   }
   cy.clickButton("Next");
   cy.get('button.btn').contains('Previous').should('be.visible');
-  cy.clickButton('Create');
+  cy.clickButton('Create'); // TODO Check there is no error after clicking
 
   // Navigate to fleet repo
   cy.checkFleetGitRepo(repoName, workspace); // Wait until the repo details are loaded
@@ -776,17 +800,26 @@ Cypress.Commands.add('addFleetGitRepo', (repoName, repoUrl, branch, paths, targe
 Cypress.Commands.add('removeFleetGitRepo', (repoName, workspace) => {
   cy.checkFleetGitRepo(repoName, workspace);
   // Click on the actions menu and select 'Delete' from the menu
-  cy.get('.actions .btn.actions').click();
-  cy.get('.icon.group-icon.icon-trash').click();
-  cypressLib.confirmDelete();
-  cy.contains(repoName).should('not.exist');
+  if (isRancherManagerVersion('2.12')) {
+    cy.getBySel('masthead-action-menu').should('be.visible').click();
+  } else {
+    cy.get('.actions .btn.actions').click();
+  }
+  cy.get('.icon.group-icon.icon-trash').click({ctrlKey: true}); // this will prevent to display confirmation dialog
+  cy.wait(2000); // needed for 2.12
+  cy.getBySel('sortable-table-list-container').should('be.visible');
+  cy.contains('td', repoName, { timeout: 120000 }).should('not.exist');
 })
 
 // Command forcefully update Fleet Git Repository
 Cypress.Commands.add('forceUpdateFleetGitRepo', (repoName, workspace) => {
   cy.checkFleetGitRepo(repoName, workspace);
   // Click on the actions menu and select 'Force Update' from the menu
-  cy.get('.actions .btn.actions').click();
+  if (isRancherManagerVersion('2.12')) {
+    cy.getBySel('masthead-action-menu').should('be.visible').click();
+  } else {
+    cy.get('.actions .btn.actions').click();
+  }
   cy.get('.icon.group-icon.icon-refresh').click();
   cy.clickButton('Update')
 })
@@ -795,7 +828,8 @@ Cypress.Commands.add('forceUpdateFleetGitRepo', (repoName, workspace) => {
 Cypress.Commands.add('checkFleetGitRepo', (repoName, workspace) => {
   // Go to 'Continuous Delivery' > 'Git Repos'
   cy.burgerMenuOperate('open');
-  cy.accesMenuSelection(['Continuous Delivery', 'Git Repos']);
+  const gitRepoMenuLocation = isRancherManagerVersion('2.12') ? ['Continuous Delivery', 'Resources', 'Git Repos'] : ['Continuous Delivery', 'Git Repos'];
+  cy.accesMenuSelection(gitRepoMenuLocation);
   cy.getBySel('masthead-create').should('be.visible');
   // Change the workspace using the dropdown on the top bar
   cy.getBySel('workspace-switcher').click();
@@ -808,8 +842,7 @@ Cypress.Commands.add('checkFleetGitRepo', (repoName, workspace) => {
   cy.url().should("include", "fleet/fleet.cattle.io.gitrepo/" + workspace + "/" + repoName)
   // Ensure there are no errors after waiting for a few seconds
   cy.wait(5000);
-  cy.get('.badge-state.masthead-state').should("not.contain", "Err Applied");
-
+  cy.get('.badge-state').should("not.contain", "Err Applied");
 })
 
 // Fleet namespace toggle
@@ -894,8 +927,8 @@ Cypress.Commands.add('deleteKubernetesResource', (clusterName = 'local', resourc
   cy.getBySel('sortable-cell-0-1').should('exist');
   cy.viewport(1920, 1080);
   cy.getBySel('sortable-table_check_select_all').click();
-  cy.getBySel('sortable-table-promptRemove').click();
-  cy.getBySel('prompt-remove-confirm-button').click();
+  cy.getBySel('sortable-table-promptRemove').click({ctrlKey: true}); // this will prevent to display confirmation dialog
+  cy.wait(2000); // needed for 2.12
   cy.typeInFilter(resourceName);
   cy.getBySel('sortable-cell-0-1').should('not.exist');
 })
@@ -1010,4 +1043,5 @@ Cypress.Commands.add('verifyCAPIProviderImage', (providerName, providerNamespace
   cy.accesMenuSelection(['Workloads', 'Deployments']);
   cy.setNamespace(providerNamespace);
   cy.contains(providerImageRegistry).should('be.visible');
+  cy.namespaceReset();
 });

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -268,7 +268,6 @@ Cypress.Commands.add('createCAPICluster', (cluster) => {
   cy.get('div[id=cru-errors]').should('not.exist');
 })
 
-
 // Command to check CAPI cluster presence under CAPI Menu
 Cypress.Commands.add('checkCAPICluster', (clusterName) => {
   cy.checkCAPIMenu();
@@ -330,6 +329,18 @@ Cypress.Commands.add('checkCAPIMenu', () => {
   cy.contains('.nav', 'Cluster Classes')
   cy.contains('.nav', 'Providers')
 });
+
+// Command to check presence of HelmApps under Fleet on local cluster
+Cypress.Commands.add('checkFleetHelmApps', (appList: string[]) => {
+  cy.burgerMenuOperate('open');
+  cy.contains('local').click();
+  const helmPsMenuLocation = isRancherManagerVersion('2.12') ? ['More Resources', 'Fleet', 'Helm Ops'] : ['More Resources', 'Fleet', 'HelmApps'];
+  cy.accesMenuSelection(helmPsMenuLocation);
+  appList.forEach((app) => {
+    cy.typeInFilter(app);
+    cy.getBySel('sortable-cell-0-1').should('exist');
+  })
+})
 
 // Command to add CAPI Custom provider
 Cypress.Commands.add('addCustomProvider', (name, namespace, providerName, providerType, version, url) => {

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -718,10 +718,7 @@ Cypress.Commands.add('deleteCluster', (clusterName, timeout = 120000) => {
   cy.searchCluster(clusterName);
   cy.viewport(1920, 1080);
   cy.getBySel('sortable-table_check_select_all').click();
-  cy.clickButton('Delete');
-  cy.getBySel('prompt-remove-input')
-    .type(clusterName);
-  cy.getBySel('prompt-remove-confirm-button').click();
+  cy.getBySel('sortable-table-promptRemove').click({ctrlKey: true}); // this will prevent to display confirmation dialog
   cy.wait(2000); // needed for 2.12
   cy.contains(clusterName, { timeout: timeout }).should('not.exist');
 });
@@ -731,7 +728,7 @@ Cypress.Commands.add('typeInFilter', (text, selector = '.input-sm') => {
   cy.get(selector)
     .click()
     .clear()
-    .type(text + '{enter}')
+    .type(text)
     .wait(2000);
 });
 

--- a/tests/cypress/latest/support/e2e.ts
+++ b/tests/cypress/latest/support/e2e.ts
@@ -52,6 +52,7 @@ declare global {
       checkCAPIClusterProvisioned(clustername: string, timeout?: number): Chainable<Element>;
       checkCAPIClusterDeleted(clustername: string, timeout: number): Chainable<Element>;
       checkCAPIMenu(): Chainable<Element>;
+      checkFleetHelmApps(appList: string[]): Chainable<Element>;
       namespaceReset(): Chainable<Element>;
       addCustomProvider(name: string, namespace: string, providerName: string, providerType: string, version?: string, url?: string): Chainable<Element>;
       addInfraProvider(providerType: string, namespace: string, cloudCredentials?: string): Chainable<Element>;

--- a/tests/scripts/start-cypress-tests
+++ b/tests/scripts/start-cypress-tests
@@ -51,4 +51,5 @@ docker run --init -v $PWD:/workdir -w /workdir \
     --add-host host.docker.internal:host-gateway \
     --ipc=host \
     $CYPRESS_DOCKER \
-    -s $SPEC
+    --browser=$BROWSER \
+    --spec $(echo $SPEC | tr ' ' ',')


### PR DESCRIPTION
### What does this PR do?
Adding support for rancher 2.12
* Backward compatible with 2.11
* Uses `head/2.12` by default (but 2.11 for upgrade tests)
* Changes provider waiting and matching
* Prevents showing confirmation dialog when deleting resources by clicking while holding Ctrl key
* Usage of HelmApps or HelmOps is driven by installed rancher version
* Changed way how we create namespaces out of projects (new pagination doesn't allow filter out `Not in a Project`)
* checkChart() without refreshing repo when chart is not available
* Fixed browser selection to Chrome + tweaked memory handling and performance
* Specs for cy docker run are comma separated

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #243

### Checklist:
- [ ] Squashed commits into logical changes
- [x] GitHub Actions (if applicable):
* 🟢 `head/2.12 @install @vsphere` [here](https://github.com/rancher/rancher-turtles-e2e/actions/runs/17553898499)
* 🟢 `head/2.12 @install @short` [here](https://github.com/rancher/rancher-turtles-e2e/actions/runs/17552780841)
* 🟢 `head/2.11 @install @short` [here](https://github.com/rancher/rancher-turtles-e2e/actions/runs/17553907037)

* 🟢 `head/2.12 @install @short` after implementing comments from first round of review [here](https://github.com/rancher/rancher-turtles-e2e/actions/runs/17578347722)

### Special notes for your reviewer:
- [x] bump our workflows to use `head/2.12` by default?
