### PR TITLE
Skip workflow for Dependabot pull requests

### DIFF
--- a/.github/workflows/label-and-add-to-project.yaml
+++ b/.github/workflows/label-and-add-to-project.yaml
@@ -33,6 +33,8 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GH_TOKEN }}
       run: |
+        # Do not run on Dependabot PRs (no access to secrets)
+        if [[ -n "$GH_TOKEN" ]]; then return 0; fi
         OWNER=${{ github.repository_owner }}
         REPO=$(echo "${{ github.repositoryUrl }}" | sed -E 's/.*\/([^/]+)\.git/\1/')
         PR_NUMBER=$(( ${{ github.event.pull_request.number }} ))

--- a/.github/workflows/label-and-add-to-project.yaml
+++ b/.github/workflows/label-and-add-to-project.yaml
@@ -34,7 +34,7 @@ jobs:
         GH_TOKEN: ${{ secrets.GH_TOKEN }}
       run: |
         # Do not run on Dependabot PRs (no access to secrets)
-        if [[ -n "$GH_TOKEN" ]]; then return 0; fi
+        if [[ -n "$GH_TOKEN" ]]; then exit 0; fi
         OWNER=${{ github.repository_owner }}
         REPO=$(echo "${{ github.repositoryUrl }}" | sed -E 's/.*\/([^/]+)\.git/\1/')
         PR_NUMBER=$(( ${{ github.event.pull_request.number }} ))


### PR DESCRIPTION
Add condition to "skip" execution for Dependabot PRs.

As dependabot doesn't have access to standard secrets we can simply check if GH_TOKEN is set and if not we can return 0 instead of assigning to the board.