### PR TITLE
Dependabot PR grouping and triggering

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
       interval: "weekly"
       day: "monday"
     labels: ["dependencies"]
+    groups:
+      gha:
+        patterns:
+          - "*"
     open-pull-requests-limit: 10
   - package-ecosystem: "npm"
     directory: "/tests/cypress/latest"
@@ -22,4 +26,13 @@ updates:
       interval: "weekly"
       day: "monday"
     labels: ["dependencies"]
+    groups:
+      npm:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "*cypress*"
+      cypress:
+        patterns:
+          - "*cypress*"
     open-pull-requests-limit: 10

--- a/.github/workflows/label-and-add-to-project.yaml
+++ b/.github/workflows/label-and-add-to-project.yaml
@@ -7,6 +7,8 @@ on:
       - assigned
   pull_request:
     types: [opened, reopened]
+  branches-ignore:
+    - 'dependabot/**'
 
 jobs:
   add_label:

--- a/.github/workflows/ui-e2e.yaml
+++ b/.github/workflows/ui-e2e.yaml
@@ -10,7 +10,10 @@ run-name: >-
        github.event.schedule == '0 4 * * *' && format('[{0}] Nightly e2e job for `@vsphere`', github.run_number) ||
        github.event.schedule == '0 5 * * 6' && format('[{0}] Weekly e2e job for `@full`', github.run_number) ||
        github.event.schedule == '0 3 * * 6' && format('[{0}] Weekly e2e job for `@upgrade`', github.run_number) ||
-       'Unknown scheduled job') }}
+       'Unknown scheduled job') ||
+      github.event_name == 'pull_request' &&
+      format('[{0}] Validate Dependabot PR#{1}', github.run_number, github.event.pull_request.number)
+    }}
 
 on:
   workflow_dispatch:
@@ -61,6 +64,11 @@ on:
     - cron: '0 4 * * *' # @vsphere
     - cron: '0 5 * * 6' # @full on Saturdays only
     - cron: '0 3 * * 6' # @upgrade @short on Saturdays only
+  pull_request:
+    types:
+      - opened
+    branches:
+      - 'dependabot/**'
 
 jobs:
   ui:
@@ -94,4 +102,4 @@ jobs:
       skip_cluster_delete: ${{ inputs.skip_cluster_delete || (github.event_name == 'schedule' && false) }}
       runner_template: ${{ inputs.runner_template || 'capi-e2e-ci-runner-spot-n2-highmem-16-template-v3' }}
       cluster_name_suffix: ${{ inputs.cluster_name_suffix || github.run_number }}
-      grep_test_by_tag: ${{ inputs.grep_test_by_tag || (github.event.schedule == '0 3 * * *' && '@install @short') || (github.event.schedule == '0 4 * * *' && '@install @vsphere') || (github.event.schedule == '0 5 * * 6' && '@install @full') || (github.event.schedule == '0 3 * * 6' && '@install @upgrade @short') }}
+      grep_test_by_tag: ${{ inputs.grep_test_by_tag || (github.event.schedule == '0 3 * * *' && '@install @short') || (github.event.schedule == '0 4 * * *' && '@install @vsphere') || (github.event.schedule == '0 5 * * 6' && '@install @full') || (github.event.schedule == '0 3 * * 6' && '@install @upgrade @short') || (github.event_name == 'pull_request' && '@install') }}


### PR DESCRIPTION
### What does this PR do?
* groups individual dependabot PRs into single PR per ecosystem and group pattern
* runs e2e `@install` test when new dependabot PR is opened
* does not label nor add dependabot PRs into project

Fixes last part of #268