### PR TITLE
Fix flakiness installApp tests

### DIFF
--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -18,7 +18,7 @@ import 'cypress-file-upload';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import jsyaml from 'js-yaml';
 import _ from 'lodash';
-import { isRancherManagerVersion } from '~/support/utils';
+import {isRancherManagerVersion} from '~/support/utils';
 
 // Generic commands
 // Go to specific Sub Menu from Access Menu
@@ -627,7 +627,7 @@ Cypress.Commands.add('checkChart', (operation, chartName, namespace, version, qu
     };
     checkApiStatus();
   } else {
-    cy.getBySel("windowmanager").then((windowmanager) => {
+    cy.get("div.wm.drag-end").then((windowmanager) => {
       // Check if the installation panel has appeared;
       if (windowmanager.find('div[role=tabpanel]').length) {
         // Wait for both CRD and main helm chart to be installed


### PR DESCRIPTION
### What does this PR do?
The locator used by windowmanager is not present on 2.12, so the backup was not working. The locator has now been fixed to something that is present on both the versions.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #267

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions (if applicable) - [2.12 @short :green_circle: ](https://github.com/rancher/rancher-turtles-e2e/actions/runs/17823879864), [2.11 @short :red_circle: failure is not related to the change in this PR](https://github.com/rancher/rancher-turtles-e2e/actions/runs/17823917320)

### Special notes for your reviewer:
