### PR TITLE
Fix TS support for tags in it() and describe()

### DIFF
--- a/tests/cypress/latest/package.json
+++ b/tests/cypress/latest/package.json
@@ -22,7 +22,6 @@
   },
   "homepage": "https://github.com/rancher/rancher-turtles-e2e",
   "dependencies": {
-    "@cypress/grep": "^5.0.0",
     "@rancher-ecp-qa/cypress-library": "2.0.1",
     "cy-verify-downloads": "^0.3.0",
     "cypress-file-upload": "^5.0.8",
@@ -37,8 +36,11 @@
     "typescript": "^5.9.2"
   },
   "devDependencies": {
+    "@cypress/grep": "^5.0.0",
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.35.0",
+    "@types/js-yaml": "^4.0.9",
+    "@types/lodash": "^4.17.20",
     "@types/randomstring": "^1.3.0",
     "@typescript-eslint/eslint-plugin": "^8.43.0",
     "@typescript-eslint/parser": "^8.43.0",

--- a/tests/cypress/latest/tsconfig.json
+++ b/tests/cypress/latest/tsconfig.json
@@ -28,8 +28,7 @@
       "cypress",
       "cy-verify-downloads",
       "@rancher-ecp-qa/cypress-library",
-      "cypress-file-upload",
-      "@cypress/grep"
+      "cypress-file-upload"
     ]
   },
   "exclude": [


### PR DESCRIPTION
### What does this PR do?
* After updating `@cypress/grep` to v5 the types checking for `it` and `describe` enhanced by `tags` stopped to work. Problem was that TypeScript type declarations are now included in the package and loading external types via `types: ["@cypress/grep"]` in `tsconfig.json` is no longer supported and causes TypeScript and/or IntelliSense issues. Removing it from `tsconfig.json` allows TypeScript to correctly load the built-in declarations.

* When doing so I also fixed missing types for `lodash` and `js-yaml` libs by adding them into `package.json`

Initial update to v5 was done here https://github.com/rancher/rancher-turtles-e2e/pull/288

### Checklist:
- [x] GitHub Actions (if applicable) https://github.com/rancher/rancher-turtles-e2e/actions/runs/18101155481