### PR TITLE
Overload it and describe to support tags

### DIFF
--- a/tests/cypress/latest/support/cypress.d.ts
+++ b/tests/cypress/latest/support/cypress.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="cypress" />
+
+declare namespace Cypress {
+  interface SuiteConfigOverrides {
+    tags?: string | string[];
+  }
+  interface TestConfigOverrides {
+    tags?: string | string[];
+  }
+}


### PR DESCRIPTION
### What does this PR do?
This should overload it() and describe() cypress commands to accept tags used by cypress/grep in VS Code.

ref. https://glebbahmutov.com/blog/type-check-test-tags/
