### PR TITLE
Update module resolution to "nodenext" to support Cypress grep tags

### DIFF
--- a/tests/cypress/latest/support/e2e.ts
+++ b/tests/cypress/latest/support/e2e.ts
@@ -17,7 +17,6 @@ import yaml from 'js-yaml';
 import './capz_support';
 import './cleanup_support';
 import {Cluster, Question} from './structs';
-// @ts-expect-error ignore the error
 import {register as registerCypressGrep} from '@cypress/grep'
 
 declare global {

--- a/tests/cypress/latest/tsconfig.json
+++ b/tests/cypress/latest/tsconfig.json
@@ -1,12 +1,12 @@
 {
   "compilerOptions": {
     "target": "ES2018",
-    "module": "ESNext",
-    "moduleResolution": "Node",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "lib": [
-      "ESNext",
-      "ESNext.AsyncIterable",
-      "DOM"
+      "esnext",
+      "esnext.asynciterable",
+      "dom"
     ],
     "esModuleInterop": true,
     "allowJs": true,
@@ -24,7 +24,6 @@
     },
     "types": [
       "@types/node",
-      "@nuxt/types",
       "cypress",
       "cy-verify-downloads",
       "@rancher-ecp-qa/cypress-library",


### PR DESCRIPTION
### What does this PR do?
Fixes IntelliSense issues with grep tags - the change will allow loading of the incorporated type definition from `cypress/grep`

### Checklist:
- [x] GitHub Actions (if applicable) https://github.com/rancher/rancher-turtles-e2e/actions/runs/18287197862 (failed but it was expected)
- [x] With enabled QASE https://github.com/rancher/rancher-turtles-e2e/actions/runs/18288398372

### Special notes for your reviewer:
Removes also `nuxt/types` which caused problems with opening `{` in tsconfig.json (red underscore).
