### PR TITLE
Bump to Rancher 2.13

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -252,6 +252,7 @@ jobs:
       QASE_TESTOPS_RUN_DESCRIPTION: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       # Cypress
       TURTLES_REPO: rancher/turtles
+      TURTLES_BRANCH: main
       CONTROLLER_IMG: localhost:5000/$TURTLES_REPO
       BROWSER: chrome
       CYPRESS_DOCKER: 'cypress/included:15.2.0'
@@ -315,11 +316,21 @@ jobs:
           else
             echo "RANCHER_VERSION=${{ inputs.rancher_version }}" >> ${GITHUB_ENV}
           fi
-      - name: Check out rancher-turtles repo
+      - name: Set rancher/turtles repo branch
+        run: |
+          if [[ "${{ env.RANCHER_VERSION }}" =~ "2.13" ]]; then
+            echo "TURTLES_BRANCH=release/v0.25" >> ${GITHUB_ENV}
+          elif [[ "${{ env.RANCHER_VERSION }}" =~ "2.12" ]]; then
+            echo "TURTLES_BRANCH=release-0.24" >> ${GITHUB_ENV}
+          else
+            echo "TURTLES_BRANCH=${{ env.TURTLES_BRANCH }}" >> ${GITHUB_ENV}
+          fi
+      - name: Check out rancher/turtles repo
         if: ${{ inputs.turtles_dev_chart == true }}
         uses: actions/checkout@v5
         with:
           repository: ${{ env.TURTLES_REPO }}
+          ref: ${{ env.TURTLES_BRANCH }}
       - name: Install Go
         if: ${{ inputs.turtles_dev_chart == true }}
         uses: actions/setup-go@v6

--- a/.github/workflows/ui-e2e.yaml
+++ b/.github/workflows/ui-e2e.yaml
@@ -17,7 +17,7 @@ on:
     inputs:
       rancher_version:
         description: Rancher Manager channel/<version|head_version>[/head_version] to use for installation
-        default: head/2.12
+        default: head/2.13
         type: string
       turtles_chart_version:
         description: Rancher Turtles chart version to test (eg. 0.24.1 | 108.0.0+up0.25.0)
@@ -87,7 +87,7 @@ jobs:
       test_description: "UI - e2e tests with Standard K3s"
       cluster_name: rancher-k3s-cluster
       destroy_runner: ${{ github.event_name == 'schedule' && true || inputs.destroy_runner }}
-      rancher_version: ${{ inputs.rancher_version || 'head/2.12' }}
+      rancher_version: ${{ inputs.rancher_version || 'head/2.13' }}
       qase_report: ${{ inputs.qase_report == true || (github.event_name == 'schedule' && true) }}
       turtles_dev_chart: ${{ inputs.turtles_dev_chart == true || (github.event_name == 'schedule' && true) }}
       target_build_type: ${{ inputs.target_build_type || 'prime' }}

--- a/tests/cypress/latest/e2e/providers_setup.spec.ts
+++ b/tests/cypress/latest/e2e/providers_setup.spec.ts
@@ -18,8 +18,8 @@ function matchAndWaitForProviderReadyStatus(
   providerString: string,
   providerType: string,
   providerName: string,
-  // providerVersion: string, TODO: add provider-version check
-  timeout: number = 120000,
+  _providerVersion: string, // TODO: add provider-version check
+  timeout: number = 60000,
 ) {
   const readyState = 'Ready'; // Default state
   cy.reload();
@@ -74,11 +74,11 @@ describe('Enable CAPI Providers', () => {
 
   // Assign the provider versions based on the build type
   const kubeadmProviderVersion = providerVersions[buildType].kubeadm
-  // const fleetProviderVersion = providerVersions[buildType].fleet
-  // const vsphereProviderVersion = providerVersions[buildType].vsphere
-  // const amazonProviderVersion = providerVersions[buildType].amazon
-  // const googleProviderVersion = providerVersions[buildType].google
-  // const azureProviderVersion = providerVersions[buildType].azure
+  const fleetProviderVersion = providerVersions[buildType].fleet
+  const vsphereProviderVersion = providerVersions[buildType].vsphere
+  const amazonProviderVersion = providerVersions[buildType].amazon
+  const googleProviderVersion = providerVersions[buildType].google
+  const azureProviderVersion = providerVersions[buildType].azure
 
   const kubeadmBaseURL = 'https://github.com/kubernetes-sigs/cluster-api/releases/'
   const kubeadmProviderTypes = ['bootstrap', 'control plane']
@@ -112,15 +112,13 @@ describe('Enable CAPI Providers', () => {
             const providerURL = kubeadmBaseURL + kubeadmProviderVersion + '/' + 'control-plane' + '-components.yaml'
             const providerName = kubeadmProvider + '-' + 'control-plane'
             cy.addCustomProvider(providerName, 'capi-kubeadm-control-plane-system', kubeadmProvider, providerType, kubeadmProviderVersion, providerURL);
-            // matchAndWaitForProviderReadyStatus(providerName, 'controlPlane', kubeadmProvider, kubeadmProviderVersion, 120000);
-            matchAndWaitForProviderReadyStatus(providerName, 'controlPlane', kubeadmProvider);
+            matchAndWaitForProviderReadyStatus(providerName, 'controlPlane', kubeadmProvider, kubeadmProviderVersion, 120000);
           } else {
             // https://github.com/kubernetes-sigs/cluster-api/releases/v1.10.6/bootstrap-components.yaml
             const providerURL = kubeadmBaseURL + kubeadmProviderVersion + '/' + providerType + '-components.yaml'
             const providerName = kubeadmProvider + '-' + providerType
             cy.addCustomProvider(providerName, 'capi-kubeadm-bootstrap-system', kubeadmProvider, providerType, kubeadmProviderVersion, providerURL);
-            // matchAndWaitForProviderReadyStatus(providerName, providerType, kubeadmProvider, kubeadmProviderVersion, 120000);
-            matchAndWaitForProviderReadyStatus(providerName, providerType, kubeadmProvider);
+            matchAndWaitForProviderReadyStatus(providerName, providerType, kubeadmProvider, kubeadmProviderVersion, 120000);
           }
         })
       );
@@ -131,8 +129,7 @@ describe('Enable CAPI Providers', () => {
         // Create Docker Infrastructure provider
         const namespace = 'capd-system'
         cy.addInfraProvider('Docker', namespace);
-        // matchAndWaitForProviderReadyStatus(dockerProvider, 'infrastructure', dockerProvider, kubeadmProviderVersion, 120000);
-        matchAndWaitForProviderReadyStatus(dockerProvider, 'infrastructure', dockerProvider);
+        matchAndWaitForProviderReadyStatus(dockerProvider, 'infrastructure', dockerProvider, kubeadmProviderVersion, 120000);
         cy.verifyCAPIProviderImage(dockerProvider, namespace);
       })
     );
@@ -163,8 +160,7 @@ describe('Enable CAPI Providers', () => {
       // Fleet addon provider is provisioned automatically when enabled during installation
       cy.checkCAPIMenu();
       cy.contains('Providers').click();
-      // matchAndWaitForProviderReadyStatus(fleetProvider, 'addon', fleetProvider, fleetProviderVersion, 30000);
-      matchAndWaitForProviderReadyStatus(fleetProvider, 'addon', fleetProvider, 30000);
+      matchAndWaitForProviderReadyStatus(fleetProvider, 'addon', fleetProvider, fleetProviderVersion, 30000);
     });
   });
 
@@ -187,8 +183,7 @@ describe('Enable CAPI Providers', () => {
         cy.addCloudCredsVMware(vsphereProvider, vsphereUsername, vspherePassword, vsphereServer, vspherePort);
         cy.burgerMenuOperate('open');
         cy.addInfraProvider('vSphere', vsphereProviderNamespace, vsphereProvider);
-        // matchAndWaitForProviderReadyStatus(vsphereProvider, 'infrastructure', vsphereProvider, vsphereProviderVersion, 120000);
-        matchAndWaitForProviderReadyStatus(vsphereProvider, 'infrastructure', vsphereProvider);
+        matchAndWaitForProviderReadyStatus(vsphereProvider, 'infrastructure', vsphereProvider, vsphereProviderVersion, 120000);
         cy.verifyCAPIProviderImage(vsphereProvider, vsphereProviderNamespace);
       })
     );
@@ -208,8 +203,7 @@ describe('Enable CAPI Providers', () => {
         cy.addCloudCredsAWS(amazonProvider, Cypress.env('aws_access_key'), Cypress.env('aws_secret_key'));
         cy.burgerMenuOperate('open');
         cy.addInfraProvider('Amazon', namespace, amazonProvider);
-        // matchAndWaitForProviderReadyStatus(amazonProvider, providerType, amazonProvider, amazonProviderVersion, 120000);
-        matchAndWaitForProviderReadyStatus(amazonProvider, providerType, amazonProvider);
+        matchAndWaitForProviderReadyStatus(amazonProvider, providerType, amazonProvider, amazonProviderVersion, 120000);
         cy.verifyCAPIProviderImage(amazonProvider, namespace);
       })
     );
@@ -221,8 +215,7 @@ describe('Enable CAPI Providers', () => {
         cy.addCloudCredsGCP(googleProvider, Cypress.env('gcp_credentials'));
         cy.burgerMenuOperate('open');
         cy.addInfraProvider('Google Cloud Platform', namespace, googleProvider);
-        // matchAndWaitForProviderReadyStatus(googleProvider, providerType, googleProvider, googleProviderVersion, 120000);
-        matchAndWaitForProviderReadyStatus(googleProvider, providerType, googleProvider);
+        matchAndWaitForProviderReadyStatus(googleProvider, providerType, googleProvider, googleProviderVersion, 120000);
         cy.verifyCAPIProviderImage(googleProvider, namespace);
       })
     );
@@ -231,8 +224,7 @@ describe('Enable CAPI Providers', () => {
       const namespace = 'capz-system'
       // Create Azure Infrastructure provider
       cy.addInfraProvider('Azure', namespace, azureProvider);
-      // matchAndWaitForProviderReadyStatus(azureProvider, providerType, azureProvider, azureProviderVersion, 180000);
-      matchAndWaitForProviderReadyStatus(azureProvider, providerType, azureProvider, 180000);
+      matchAndWaitForProviderReadyStatus(azureProvider, providerType, azureProvider, azureProviderVersion, 180000);
       cy.verifyCAPIProviderImage(azureProvider, namespace);
     })
     );


### PR DESCRIPTION
### What does this PR do?
- Bump Rancher version for nightly CI tests, Ref: https://github.com/rancher/turtles/blob/main/charts/rancher-turtles/Chart.yaml#L21
- Temporarily disable providers version check, to be addressed in https://github.com/rancher/rancher-turtles-e2e/issues/303

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #304 

### Checklist:
- [x] GitHub Actions:
:green_circle:  [2.12 @install @short](https://github.com/rancher/rancher-turtles-e2e/actions/runs/18307404181),
[2.13 @install](https://github.com/rancher/rancher-turtles-e2e/actions/runs/18307411051) (failure expected until https://github.com/rancher/rancher-turtles-e2e/issues/292 is done)

