### PR TITLE
Use main for 2.13 and release-0.24 for the rest

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -397,7 +397,7 @@ jobs:
         with:
           node-version: current
       - name: Prepare for Providers Chart installation
-        if: ${{ inputs.turtles_dev_chart == true }}
+        if: ${{ inputs.turtles_dev_chart == true && (contains(env.RANCHER_VERSION, '2.13') || contains(env.RANCHER_VERSION, '2.12')) }}
         run: |
           kubectl apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/rancher/pre-turtles-install.yaml
           kubectl delete mutatingwebhookconfiguration mutating-webhook-configuration --ignore-not-found

--- a/tests/cypress/latest/e2e/providers_setup.spec.ts
+++ b/tests/cypress/latest/e2e/providers_setup.spec.ts
@@ -13,9 +13,10 @@ limitations under the License.
 
 import '~/support/commands';
 import {qase} from 'cypress-qase-reporter/mocha';
+import {isRancherManagerVersion} from "~/support/utils";
 
 const buildType = Cypress.env('chartmuseum_repo') ? 'dev' : 'prod';
-const isDevBuild = buildType == 'dev';
+const isDevBuild = buildType == 'dev' && isRancherManagerVersion('>=2.12');
 
 function matchAndWaitForProviderReadyStatus(
   providerString: string,


### PR DESCRIPTION
### What does this PR do?
for 2.13, we should stick to main branch. Alex cherry-picks all commits from main to release/v0.25 at once before release, which means at all other times we would running nightly builds from release/v0.25 on the same commit. So except <=2.12 which should use `release-0.24`, all the other releases must use main.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions (if applicable) - [2.11 short](https://github.com/rancher/rancher-turtles-e2e/actions/runs/18488577231), [2.12 short](https://github.com/rancher/rancher-turtles-e2e/actions/runs/18488568813)

### Special notes for your reviewer:
