### PR TITLE
Version pin CAPV to v1.13.1 and update image registry for providers chart for cloud providers

### DIFF
--- a/tests/cypress/latest/e2e/capv_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capv_kubeadm_clusterclass.spec.ts
@@ -61,8 +61,8 @@ describe('Import CAPV Kubeadm Class-Cluster', {tags: '@vsphere'}, () => {
 
     // TODO: Create Provider via UI, ref: capi-ui-extension/issues/128
     it('Create VSphere CAPIProvider & VSphereClusterIdentity', () => {
-      cy.removeCAPIResource('Providers', providerName);
-      cy.createCAPIProvider(providerName);
+      // cy.removeCAPIResource('Providers', providerName);
+      // cy.createCAPIProvider(providerName);
 
       const vsphere_username = JSON.stringify(vsphere_secrets_json.vsphere_username).replace(/\"/g, "")
       const vsphere_password = JSON.stringify(vsphere_secrets_json.vsphere_password).replace(/\"/g, "")

--- a/tests/cypress/latest/e2e/capv_rke2_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capv_rke2_clusterclass.spec.ts
@@ -71,8 +71,8 @@ describe('Import CAPV RKE2 Class-Cluster', {tags: '@vsphere'}, () => {
 
     // TODO: Create Provider via UI, ref: capi-ui-extension/issues/128
     it('Create VSphere CAPIProvider & VSphereClusterIdentity', () => {
-      cy.removeCAPIResource('Providers', providerName);
-      cy.createCAPIProvider(providerName);
+      // cy.removeCAPIResource('Providers', providerName);
+      // cy.createCAPIProvider(providerName);
 
       const vsphere_username = JSON.stringify(vsphere_secrets_json.vsphere_username).replace(/\"/g, "")
       const vsphere_password = JSON.stringify(vsphere_secrets_json.vsphere_password).replace(/\"/g, "")

--- a/tests/cypress/latest/fixtures/providers-chart/providers-chart-helmop.yaml
+++ b/tests/cypress/latest/fixtures/providers-chart/providers-chart-helmop.yaml
@@ -33,6 +33,7 @@ spec:
         infrastructureVSphere:
           enabled: false
           version: v1.13.1
+          enableAutomaticUpdate: false
           features:
             machinePool: true
             clusterResourceSet: true

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -566,7 +566,7 @@ Cypress.Commands.add('checkChart', (operation, chartName, namespace, version, qu
   let chartSelector = isRancherManagerVersion('>=2.12') ? 'app-chart-cards-container' : 'chart-selection-grid';
   if (turtlesChart) {
     let turtlesChartSelector: string;
-    
+
     if (isRancherManagerVersion('2.13')) {
       const devChart = Cypress.env('chartmuseum_repo') != ''
       turtlesChartSelector = devChart ? '"item-card-cluster/turtles-chart/rancher-turtles"' : '"item-card-cluster/rancher-charts/rancher-turtles"'; // turtles-chart repo == null


### PR DESCRIPTION
### What does this PR do?
Ref: https://github.com/rancher/rancher-turtles-e2e/actions/runs/18517403845/job/52770535217

```
   1) Enable CAPI Providers
       vSphere provider
         Create CAPV provider (Qase ID: 40):
      Timed out retrying after 30000ms
      + expected - actual
      -'v1.14.0'
      +'v1.13.1'
      
```
### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [ ] GitHub Actions (if applicable) - [[2446] Rancher-head/2.13 - @install @vsphere destroy=true dev=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/18521801549)
- [x] Almost ok run https://github.com/rancher/rancher-turtles-e2e/actions/runs/18587856697
### Special notes for your reviewer:
