### PR TITLE
Prevent gh rate-limit in crust-gather-installer.sh

### DIFF
--- a/.github/scripts/collect-rancher-logs.sh
+++ b/.github/scripts/collect-rancher-logs.sh
@@ -5,6 +5,8 @@ set -evx
 # Variables
 RANCHER_LOG_COLLECTER="https://raw.githubusercontent.com/rancherlabs/support-tools/master/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh"
 CRUST_GATHER_INSTALLER="https://github.com/crust-gather/crust-gather/raw/main/install.sh"
+# Due to GH API rate limiting, we need to specify the crust version
+CRUST_VERSION="v0.11.0"
 
 # Create directory to store logs
 mkdir -p -m 755 logs
@@ -27,7 +29,7 @@ cd crust-gather-logs
 
 curl -L ${CRUST_GATHER_INSTALLER} -o crust-gather-installer.sh
 chmod +x crust-gather-installer.sh
-sudo ./crust-gather-installer.sh -y
+sudo VERSION=${CRUST_VERSION} ./crust-gather-installer.sh -y
 
 crust-gather collect
 


### PR DESCRIPTION
### What does this PR do?
Prevents gh rate-limit when running crust-gather-installer.sh to get latest version from github api

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [x] Squashed commits into logical changes
- [x] Documentation
- [x] GitHub Actions (if applicable) https://github.com/rancher/rancher-turtles-e2e/actions/runs/19098345463/job/54563957970#step:29:69 (rancher installation failed for some reason but the collector is working now)
### Special notes for your reviewer:
