### PR TITLE
Skip the externally-managed cluster test

### DIFF
--- a/tests/cypress/latest/e2e/capd_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capd_kubeadm_clusterclass.spec.ts
@@ -108,8 +108,9 @@ describe('Import CAPD Kubeadm Class-Cluster', {tags: '@short'}, () => {
       })
     )
 
+    // Skip until https://github.com/rancher/turtles/issues/1880 is fixed
     qase(43,
-      it('Check if annotation for externally-managed cluster is set', () => {
+      xit('Check if annotation for externally-managed cluster is set', () => {
         cy.searchCluster(clusterName)
         // click the three-dots menu and click View YAML
         cy.getBySel('sortable-table-0-action-button').click();


### PR DESCRIPTION
### What does this PR do?
Ref: https://github.com/rancher/turtles/issues/1880

The issue does not seem to occur in dev e2e tests, but it was reproducible when creating clusters using https://turtles.docs.rancher.com/turtles/next/en/user/clusterclass.html and in our automation, which kinda makes sense since we use the examples mentioned in the doc.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #343 

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [ ] GitHub Actions (if applicable)

### Special notes for your reviewer:
