### PR TITLE
Support dev on Prime and add persistence for git-http-backend container

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -339,7 +339,7 @@ jobs:
             sed -i 's#{{- printf "%s\/" \.Values\.global\.cattle\.systemDefaultRegistry -}}#{{- "" -}}#g' charts/rancher-turtles/templates/_helpers.tpl
 
             TARGET_BUILD=${{ env.BUILD_TYPE }} TAG=v${{ env.TAG }} CONTROLLER_IMG=${{ env.CONTROLLER_IMG }} make e2e-image-build
-            RELEASE_TAG=v${{ env.TAG }} CONTROLLER_IMG=${{ env.CONTROLLER_IMG }} CONTROLLER_IMAGE_VERSION=v${{ env.TAG }} make build-chart verify-gen
+            RELEASE_TAG=v${{ env.TAG }} CONTROLLER_IMG=${{ env.CONTROLLER_IMG }} CONTROLLER_IMAGE_VERSION=v${{ env.TAG }} make build-chart # verify-gen
             docker run -d -p 5000:5000 --name registry registry:2
             docker push ${{ env.CONTROLLER_IMG }}:v${{ env.TAG }}
           fi


### PR DESCRIPTION
### What does this PR do?
* This will prevent deletion of `git-http-backend` docker container data (patched `rancher/charts` git repository) for runs with `destroy=false`. Originally the data were mounted from actions-runner directory which is getting deleted at the end of every job by `Post Checkout` step so then the backend returned 404 when debugging manually on the GCP runner.

Data as container images stored in self-hosted registry and charts artifacts in chartmuseum are persistent already.

WARNING: assets/ with yaml resources used maybe by importYAML() are still unavailable as they are cleaned within `Post Checkout` step as well

* hack for removing `systemDefaultRegistry` which is set on Prime-rc/alpha to `stgregistry.suse.com` - let see if this is gonna be set in Prime GM. This will prevent pulling turtles image from `stgregistry.suse.com/localhost:5000/rancher/turtles:v2025.11.24` when using dev turtles builds
* removed make verify-gen target to make the hack above pass

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions (if applicable)
* :green_circle: run `@install on prime-alpha/2.13.0-alpha8 dev=true` with the systemDefaultRegistry hack and disabling verify-gen target https://github.com/rancher/rancher-turtles-e2e/actions/runs/19643773366
* :orange_circle: same as above but `@install @short` https://github.com/rancher/rancher-turtles-e2e/actions/runs/19644450372
* :green_circle: `@install @short head/2.13 dev=true` https://github.com/rancher/rancher-turtles-e2e/actions/runs/19662923993
### Special notes for your reviewer:
