### PR TITLE
Rewrite image value in chart for dev

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -335,7 +335,7 @@ jobs:
       - name: Make Turtles and Providers chart
         run: |
           if [[ ${{ inputs.turtles_dev_chart }} == true ]]; then
-            if [[ "${{ inputs.rancher_version }}" =~ "prime" ]]; then
+            if [[ "${{ env.RANCHER_VERSION }}" =~ "prime" ]]; then
               # Inject custom image into turtles chart deployment.yaml without using the system_default_registry prefix
               # This is needed on Prime because the local registry is not accessible via system_default_registry
               # Sed command uses range from `if` to `end` to replace templating by actual image


### PR DESCRIPTION
### What does this PR do?
Replacing original hack for setting `system-default-registry` to empty string by another sed command which is used to replace only the turtles image templating by actual image available on local registry.

This is mandatory for upcoming rancher prime releases which are using non empty `system-default-registry` values.

This is what the command does with turtles chart.
```
diff --git a/charts/rancher-turtles/templates/deployment.yaml b/charts/rancher-turtles/templates/deployment.yaml
index eb67109..3d370e1 100644
--- a/charts/rancher-turtles/templates/deployment.yaml
+++ b/charts/rancher-turtles/templates/deployment.yaml
@@ -45,11 +45,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.uid
-        {{- if (contains "sha256:" .Values.image.tag) }}
-        image: '{{ template "system_default_registry" . }}{{ .Values.image.repository }}@{{ .Values.image.tag }}'
-        {{- else }}
-        image: '{{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}'
-        {{- end}}
+        image: localhost:5000/rancher/turtles:v2025.12.10
         imagePullPolicy: '{{ .Values.image.imagePullPolicy }}'
         livenessProbe:
```

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [ ] GitHub Actions (if applicable):
Check content of `cat /tmp/system-charts/charts/charts/rancher-turtles/108.0.0+up99.99.99/templates/deployment.yaml` on the runner whether it is patched

* :green_circle: `head/2.13 dev=true` https://github.com/rancher/rancher-turtles-e2e/actions/runs/20103789948 - the deployment is not patched :heavy_check_mark: 
* :orange_circle: `prime-alpha/2.13.0-alpha8 dev=true` https://github.com/rancher/rancher-turtles-e2e/actions/runs/20104037192 - will fail because of unavailable provider images on stgregistry - the deployment is patched :heavy_check_mark: and turtles pod is running :heavy_check_mark: 

### Special notes for your reviewer:
