### PR TITLE
Skip CAPD Kubeadm cluster deletion 

### DIFF
--- a/tests/cypress/latest/e2e/capd_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capd_kubeadm_clusterclass.spec.ts
@@ -152,7 +152,7 @@ describe('Import CAPD Kubeadm Class-Cluster', {tags: '@short'}, () => {
       })
     );
 
-    it('Remove imported CAPD cluster from Rancher Manager', {retries: 1}, () => {
+    xit('Remove imported CAPD cluster from Rancher Manager', {retries: 1}, () => {
       // Delete the imported cluster
       // Ensure that the provisioned CAPI cluster still exists
       // this check can fail, ref: https://github.com/rancher/turtles/issues/1587


### PR DESCRIPTION
### What does this PR do?
Temporarily skips CAPD Kubeadm cluster deletion, occuring probably due to https://github.com/rancher/turtles/issues/1587

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes - failing CI

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions:
https://github.com/rancher/rancher-turtles-e2e/actions/runs/20522837469/job/58993366785#step:21:706
