### PR TITLE
Disable feature-flag test for 2.14

### DIFF
--- a/tests/cypress/latest/e2e/azure_rke2_v2prov_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/azure_rke2_v2prov_cluster.spec.ts
@@ -13,7 +13,7 @@ describe('Create Azure RKE2 Cluster', {tags: ['@short', '@migration']}, () => {
   const k8sVersion = vars.rke2Version
   const clusterName = 'turtles-qa-azure-v2-' + randomstring.generate({length: 4, capitalization: "lowercase"})
 
-  if (isRancherManagerVersion('>=2.13')) {
+  if (isRancherManagerVersion('2.13')) {
     features.push('embedded-cluster-api');
   }
 
@@ -100,7 +100,7 @@ describe('Create Azure RKE2 Cluster', {tags: ['@short', '@migration']}, () => {
           cy.getBySel('log').click();
           cy.contains('[INFO ] provisioning done');
 
-          if (isRancherManagerVersion('>=2.13')) {
+          if (isRancherManagerVersion('2.13')) {
             // Switch the features
             if (feature == 'turtles') {
               cy.setCAPIFeature('embedded-cluster-api', 'true');

--- a/tests/cypress/latest/e2e/providers_setup.spec.ts
+++ b/tests/cypress/latest/e2e/providers_setup.spec.ts
@@ -87,11 +87,11 @@ describe('Enable CAPI Providers', () => {
     },
     'dev-v2.14': {
       capi: 'v1.12.2',
-      rke2: 'v0.23.0',
+      rke2: 'v0.23.1',
       kubeadm: 'v1.12.2',
       fleet: 'v0.14.0',
-      vsphere: 'v1.14.0',
-      amazon: 'v2.10.0',
+      vsphere: 'v1.15.2',
+      amazon: 'v2.10.1',
       google: 'v1.11.0',
       azure: 'v1.22.0'
     }


### PR DESCRIPTION
### What does this PR do?
- Disables turtles feature-flag tests for 2.14 onwards
- Bump providers

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #406 

### Checklist:
- [x] GitHub Actions:
:green_circle: [2.13](https://github.com/rancher/rancher-turtles-e2e/actions/runs/22430161878), [2.14 ](https://github.com/rancher/rancher-turtles-e2e/actions/runs/22430752173)

