### PR TITLE
Bump k3s for 2.14

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -88,7 +88,7 @@ on:
         type: string
       upstream_cluster_version:
         description: Cluster upstream version where to install Rancher (K3s)
-        default: v1.32.3+k3s1
+        default: v1.34.4+k3s1
         type: string
       zone:
         description: GCP zone to host the runner
@@ -317,6 +317,13 @@ jobs:
             echo "TURTLES_BRANCH=release/v0.25" >> ${GITHUB_ENV}
           else
             echo "TURTLES_BRANCH=${{ env.TURTLES_BRANCH }}" >> ${GITHUB_ENV}
+          fi
+      - name: Set k3s Install version
+        run: |
+          if [[ "${{ env.RANCHER_VERSION }}" =~ (2\.12) ]]; then
+            echo INSTALL_K3S_VERSION="v1.32.3+k3s1" >> ${GITHUB_ENV}
+          else
+            echo INSTALL_K3S_VERSION=${{ inputs.upstream_cluster_version }} >> ${GITHUB_ENV}
           fi
 
       # Checkout into r/turtles repo if dev=true to build turtles and providers chart;


### PR DESCRIPTION
### What does this PR do?
Bumps k3s version for 2.14

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions:
:green_circle: [2.12](https://github.com/rancher/rancher-turtles-e2e/actions/runs/22477244754), [2.13](https://github.com/rancher/rancher-turtles-e2e/actions/runs/22477237007), [2.14](https://github.com/rancher/rancher-turtles-e2e/actions/runs/22477257720)

### Special notes for your reviewer:
