### PR TITLE
Add turtles switch test for 2.13

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -288,6 +288,7 @@ jobs:
         e2e/capz_aks_clusterclass.spec.ts
         e2e/capz_rke2_clusterclass.spec.ts
         e2e/capz_kubeadm_clusterclass.spec.ts
+        e2e/capi_features_switch.spec.ts
     steps:
       - name: Add /usr/local/bin into PATH
         run: |

--- a/tests/cypress/latest/e2e/capi_features_switch.spec.ts
+++ b/tests/cypress/latest/e2e/capi_features_switch.spec.ts
@@ -1,0 +1,157 @@
+import '~/support/commands';
+import {capiNamespace, getClusterName, isRancherManagerVersion, turtlesNamespace} from '~/support/utils';
+import {capdResourcesCleanup, capiClusterDeletion} from '~/support/cleanup_support';
+import {vars} from '~/support/variables';
+
+Cypress.config();
+describe('Switch CAPI Feature Flags', {tags: '@switch'}, () => {
+  const capiProvisioningNamespace = 'cattle-provisioning-capi-system';
+  const turtlesHelmApp = 'rancher-turtles'
+  const capiProvisioningHelmApp = 'rancher-provisioning-capi'
+  const coreCAPICM = 'core-cluster-api-v1.10.6'
+  const timeout = vars.shortTimeout;
+  const classNamePrefix = 'docker-rke2';
+  const clusterName = getClusterName(classNamePrefix);
+  const classesPath = 'examples/clusterclasses/docker/rke2';
+  const clusterClassRepoName = 'docker-rke2-clusterclass';
+  const classClusterFileName = './fixtures/docker/capd-rke2-class-cluster-v1beta1.yaml';
+  const dockerAuthUsernameBase64 = btoa(Cypress.expose('docker_auth_username'));
+  const dockerAuthPasswordBase64 = btoa(Cypress.expose('docker_auth_password'));
+
+  beforeEach(() => {
+    cy.login();
+    cy.burgerMenuOperate('open');
+  });
+
+  if (isRancherManagerVersion('2.13')) {
+
+    context('[SETUP]', () => {
+      it('Verify rancher-turtles exists and rancher-provisioning-capi does not', () => {
+        cy.checkKubernetesResource('local', ['Apps', 'Installed Apps'], turtlesHelmApp, true, turtlesNamespace);
+        cy.checkKubernetesResource('local', ['Apps', 'Installed Apps'], capiProvisioningHelmApp, false, capiProvisioningNamespace);
+      });
+
+      it('Verify capi-controller-manager deployment exists', () => {
+        cy.checkKubernetesResource('local', ['Workloads', 'Deployments'], 'capi-controller-manager', true, capiNamespace);
+      });
+
+      it('Import ClusterctlConfig', () => {
+        cy.importYAML('./fixtures/switch/clusterctlconfig.yaml');
+      });
+
+    });
+
+    context('[CLUSTER-IMPORT]', () => {
+      it('Setup the namespace for importing', () => {
+        cy.namespaceAutoImport('Disable');
+      });
+
+      it('Create Docker Auth Secret', () => {
+        cy.readFile('./fixtures/docker/capd-auth-token-secret.yaml').then((data) => {
+          data = data.replace(/replace_cluster_docker_auth_username/, dockerAuthUsernameBase64);
+          data = data.replace(/replace_cluster_docker_auth_password/, dockerAuthPasswordBase64);
+          cy.importYAML(data, vars.capiClustersNS);
+        });
+      });
+
+      it('Add CAPD RKE2 ClusterClass Fleet Repo', () => {
+        cy.addFleetGitRepo(clusterClassRepoName, vars.turtlesRepoUrl, vars.classBranch, classesPath, vars.capiClassesNS);
+        cy.checkCAPIClusterClass(classNamePrefix);
+      });
+
+      it('Import CAPD RKE2 class-cluster using YAML', () => {
+        cy.readFile(classClusterFileName).then((data) => {
+          data = data.replace(/replace_cluster_name/g, clusterName);
+          data = data.replace(/replace_rke2_version/g, vars.rke2Version);
+          data = data.replace(/replace_kind_version/g, vars.kindVersion);
+          cy.importYAML(data, vars.capiClustersNS);
+        });
+        cy.checkCAPICluster(clusterName);
+      });
+
+      it('Auto import child CAPD cluster', () => {
+        cy.checkCAPIClusterProvisioned(clusterName, timeout);
+        cy.goToHome();
+        cy.contains(clusterName).should('exist');
+        cy.searchCluster(clusterName);
+        cy.contains(new RegExp('Active.*' + clusterName), {timeout: timeout});
+        cy.checkCAPIClusterActive(clusterName, timeout);
+      });
+
+    });
+
+    context('[SWITCH-TO-CAPI-PROVISIONING]', () => {
+      it('Uninstall Rancher Turtles Providers chart', () => {
+        cy.deleteKubernetesResource('local', ['Apps', 'Installed Apps'], 'rancher-turtles-providers', turtlesNamespace);
+      });
+
+      it('Enable embedded-cluster-api and disable turtles', () => {
+        cy.setCAPIFeature('embedded-cluster-api', 'true');
+        cy.setCAPIFeature('turtles', 'false');
+      });
+
+      it('Verify rancher-provisioning-capi exists and rancher-turtles does not', {retries: 2}, () => {
+        cy.checkKubernetesResource('local', ['Apps', 'Installed Apps'], capiProvisioningHelmApp, true, capiProvisioningNamespace, timeout);
+        cy.checkKubernetesResource('local', ['Apps', 'Installed Apps'], turtlesHelmApp, false, turtlesNamespace);
+      });
+
+      it('Verify ClusterctlConfig does not exist', () => {
+        // This resource will not be found since it was deployed in turtlesNamespace which gets deleted on uninstalling turtles chart
+        cy.checkKubernetesResource('local', ['More Resources', 'turtles-capi.cattle.io'], 'clusterctl-config', false, turtlesNamespace);
+      });
+
+      it('Verify core-cluster-api ConfigMap does not exist', () => {
+        cy.checkKubernetesResource('local', ['More Resources', 'Core', 'ConfigMaps'], coreCAPICM, false, capiNamespace);
+      });
+
+      it('Verify CAPD cluster is still active', () => {
+        cy.goToHome();
+        cy.contains(clusterName).should('exist');
+        cy.searchCluster(clusterName);
+        cy.contains(new RegExp('Active.*' + clusterName));
+      });
+    });
+
+    context('[SWITCH-TO-TURTLES]', () => {
+      it('Disable embedded-cluster-api and enable turtles', () => {
+        cy.setCAPIFeature('embedded-cluster-api', 'false');
+        cy.setCAPIFeature('turtles', 'true');
+      });
+
+      it('Verify rancher-turtles exists and rancher-provisioning-capi does not', {retries: 2}, () => {
+        cy.checkKubernetesResource('local', ['Apps', 'Installed Apps'], turtlesHelmApp, true, turtlesNamespace, timeout);
+        cy.checkKubernetesResource('local', ['Apps', 'Installed Apps'], capiProvisioningHelmApp, false, capiProvisioningNamespace);
+      });
+
+      it('Verify core-cluster-api ConfigMap exists', () => {
+        cy.checkKubernetesResource('local', ['More Resources', 'Core', 'ConfigMaps'], coreCAPICM, true, capiNamespace, timeout);
+      });
+
+      it('Reinstall turtles-providers-chart', () => {
+        const providerSelectionFunction = (text: any) => {
+          // @ts-ignore
+          text.providers.infrastructureDocker.enabled = true;
+          // @ts-ignore
+          text.providers.infrastructureDocker.enableAutomaticUpdate = true;
+        }
+        // Install Rancher Turtles Certified Providers chart
+        cy.checkChart('local', 'Install', vars.turtlesProvidersChartName, turtlesNamespace, {
+          version: '0.25',
+          modifyYAMLOperation: providerSelectionFunction
+        });
+      })
+    });
+
+    context('[TEARDOWN]', () => {
+      it('Delete the CAPD cluster', () => {
+        capiClusterDeletion(clusterName, timeout);
+      });
+
+      it('Delete the ClusterClass fleet repo', () => {
+        cy.removeFleetGitRepo(clusterClassRepoName);
+        capdResourcesCleanup();
+      });
+    });
+
+  }
+});

--- a/tests/cypress/latest/e2e/providers_setup.spec.ts
+++ b/tests/cypress/latest/e2e/providers_setup.spec.ts
@@ -138,7 +138,7 @@ describe('Enable CAPI Providers', () => {
         // @ts-ignore
         text.providers.controlplaneKubeadm.enableAutomaticUpdate = true;
 
-        if (isCypressTag('@short') || isCypressTag('@upgrade')) {
+        if (isCypressTag('@short') || isCypressTag('@upgrade') || isCypressTag('@switch')) {
             // @ts-ignore
             text.providers.infrastructureDocker.enabled = true;
             // @ts-ignore
@@ -247,7 +247,7 @@ describe('Enable CAPI Providers', () => {
     });
   });
 
-  context('Docker provider', {tags: ['@short', '@upgrade']}, () => {
+  context('Docker provider', {tags: ['@short', '@upgrade', '@switch']}, () => {
     const dockerProviderNamespace = 'capd-system'
     it('Verify CAPD provider', () => {
       // Verify Docker Infrastructure provider

--- a/tests/cypress/latest/fixtures/switch/clusterctlconfig.yaml
+++ b/tests/cypress/latest/fixtures/switch/clusterctlconfig.yaml
@@ -1,0 +1,13 @@
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: ClusterctlConfig
+metadata:
+  name: clusterctl-config
+  namespace: cattle-turtles-system
+spec:
+  providers:
+    - name: vsphere
+      url: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/releases/v1.12.0/infrastructure-components.yaml
+      type: InfrastructureProvider
+  images:
+    - name: infrastructure-vsphere
+      repository: registry.k8s.io/cluster-api-vsphere

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -646,11 +646,17 @@ Cypress.Commands.add('checkChart', (clusterName, operation, chartName, namespace
     cy.getBySel('btn-chart-install').click();
     cy.contains(operation + ': Step 1');
 
-    // TODO: This is a temp workaround until https://github.com/rancher/rancher/issues/53883 is fixed
-    if (chartName == "rancher-turtles-providers") {
-      cy.setNamespace('All Namespaces', 'all_user');
-      cy.getBySel('name-ns-description-namespace').type(namespace + '{enter}');
-    }
+
+    // Select namespace if an option is given
+    cy.get('div.step__basic').then((step) => {
+      const namespaceSelectorTestID = "name-ns-description-namespace"
+      const namespaceRequired = step.find(`div[data-testid=${namespaceSelectorTestID}]`).length
+      if (namespaceRequired) {
+        cy.setNamespace('All Namespaces', 'all_user')
+        cy.getBySel(namespaceSelectorTestID).type(namespace + '{enter}');
+      }
+    });
+
     cy.clickButton('Next');
 
     // Used for entering questions and answering them
@@ -1049,7 +1055,7 @@ Cypress.Commands.add('deleteKubernetesResource', (clusterName = 'local', resourc
 
   // using `cy.clickNavMenu()` does not always work here, so we explicitly wait after clicking a label.
   resourcePath.forEach(label => {
-    cy.get('nav').contains(label).click()
+    cy.get('.nav').contains(label).click()
     cy.wait(1000);
   });
 
@@ -1063,6 +1069,36 @@ Cypress.Commands.add('deleteKubernetesResource', (clusterName = 'local', resourc
   cy.getBySel('sortable-cell-0-1', {timeout: 60000}).should('not.exist');
   cy.namespaceReset();
 })
+
+Cypress.Commands.add('checkKubernetesResource', (clusterName = 'local', resourcePath: string[], resourceName: string, shouldExist: boolean, namespace: string, timeout: number = 60000) => {
+  cy.exploreCluster(clusterName);
+
+  // Check if the namespace exists in the dropdown before attempting to set it
+  cy.getBySel('namespaces-dropdown').click();
+  cy.get('div.ns-dropdown-menu').then((dropdownMenu) => {
+    const namespaceFound = dropdownMenu.find(`div[id='ns_${namespace}']`).length > 0;
+
+    // Close the dropdown
+    cy.getBySel('namespaces-dropdown').click();
+
+    if (!namespaceFound && !shouldExist) {
+      // Namespace doesn't exist, so the resource can't exist either
+      return;
+    }
+
+    cy.setNamespace(namespace);
+    // Sometimes if a resource does not exist in a namespace, the navigation menu won't be visible. So we navigate after a namespace has been set.
+    cy.clickNavMenu(resourcePath);
+
+    cy.typeInFilter(resourceName);
+    if (shouldExist) {
+      cy.getBySel('sortable-cell-0-1', {timeout}).should('exist');
+    } else {
+      cy.getBySel('sortable-cell-0-1', {timeout}).should('not.exist');
+    }
+    cy.namespaceReset();
+  });
+});
 
 Cypress.Commands.add('exploreCluster', (clusterName: string) => {
   cy.burgerMenuOperate('open');

--- a/tests/cypress/latest/support/e2e.ts
+++ b/tests/cypress/latest/support/e2e.ts
@@ -89,6 +89,8 @@ declare global {
       createAzureClusterIdentity(clientID: string, tenantID: string, clientSecret: string): Chainable<Element>;
       createAzureASOCredential(clientID: string, tenantID: string, clientSecret: string, subscriptionID: string): Chainable<Element>;
       deleteKubernetesResource(clusterName: string, resourcePath: string[], resourceName: string, namespace?: string): Chainable<Element>;
+
+      checkKubernetesResource(clusterName: string, resourcePath: string[], resourceName: string, shouldExist: boolean, namespace: string, timeout?: number): Chainable<Element>;
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?
1. Add a new test for testing feature switch from turtles to embedded-cluster-api and back.
2. This test only runs on 2.13 where `embedded-cluster-api` feature still exists.
3. With turtles chart uninstallation, this test also checks if it deletes all the necessary configmap and clusterctlconfig resources.
4. Add a new `checkKubernetesResource` function to check if a resource exists.
5. Modify `checkChart` to select namespace if there is an option to do so; this feature is helpful with https://github.com/rancher/rancher/issues/53882 which still does not parse correct namespace for turtles providers chart.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #405 

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions (if applicable) - [head/2.13 @install @switch](https://github.com/rancher/rancher-turtles-e2e/actions/runs/24021680602/job/70051722113) :green_circle: ,  [[3937] Rancher-head/2.14 - @install @short destroy=true dev=true #3937](https://github.com/rancher/rancher-turtles-e2e/actions/runs/24029033962) :green_circle:  

### Special notes for your reviewer:
