### PR TITLE
Usage of RKE2 built-in CNI in e2e

### DIFF
--- a/tests/assets/rancher-turtles-fleet-example/capd/rke2/class-clusters-v1beta1/templates/cluster.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capd/rke2/class-clusters-v1beta1/templates/cluster.yaml
@@ -7,7 +7,6 @@ metadata:
   annotations:
     cluster-api.cattle.io/upstream-system-agent: "true"
   labels:
-    cni: calico
     cluster-api.cattle.io/rancher-auto-import: "true"
 spec:
   clusterNetwork:
@@ -25,7 +24,7 @@ spec:
       replicas: 3
     variables:
     - name: rke2CNI
-      value: none
+      value: ""
     - name: dockerImage
       value: kindest/node:v1.34.0
     - name: dockerAuthSecret

--- a/tests/assets/rancher-turtles-fleet-example/capd/rke2/class-clusters/templates/cluster.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/capd/rke2/class-clusters/templates/cluster.yaml
@@ -7,7 +7,6 @@ metadata:
   annotations:
     cluster-api.cattle.io/upstream-system-agent: "true"
   labels:
-    cni: calico
     cluster-api.cattle.io/rancher-auto-import: "true"
 spec:
   clusterNetwork:
@@ -26,12 +25,12 @@ spec:
       replicas: 3
     variables:
     - name: rke2CNI
-      value: none
+      value: ""
     - name: dockerImage
-      value: kindest/node:v1.34.0
+      value: kindest/node:v1.35.0
     - name: dockerAuthSecret
       value: capd-docker-token
-    version: v1.34.1+rke2r1
+    version: v1.35.1+rke2r1
     workers:
       machineDeployments:
       - class: default-worker

--- a/tests/cypress/latest/e2e/capd_rke2_fleet_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capd_rke2_fleet_clusterclass.spec.ts
@@ -18,7 +18,7 @@ import {capdResourcesCleanup, capiClusterDeletion, importedRancherClusterDeletio
 import {vars} from '~/support/variables';
 
 Cypress.config();
-describe('Import CAPD RKE2 Class-Cluster using Fleet', {tags: '@short'}, () => {
+describe('Import CAPD RKE2 (Default CNI) Class-Cluster using Fleet', {tags: '@short'}, () => {
   let clusterName: string
   const timeout = vars.shortTimeout
   const classNamePrefix = 'docker-rke2'
@@ -82,6 +82,15 @@ describe('Import CAPD RKE2 Class-Cluster using Fleet', {tags: '@short'}, () => {
   })
 
   context('[CLUSTER-OPERATIONS]', () => {
+    it('Check rke2 Default CNI', () => {
+      cy.contains(clusterName).click();
+      cy.accesMenuSelection(['Workloads', 'Pods']);
+      cy.setNamespace('All Namespaces', 'all_user');
+      // Filter out cni pods by image name
+      cy.typeInFilter('calico');
+      cy.waitForAllRowsInState('Running', timeout);
+    })
+
     it('Install App on imported cluster', {retries: 1}, () => {
       cy.checkChart(clusterName, 'Install', 'Logging', 'cattle-logging-system');
     })


### PR DESCRIPTION
### What does this PR do?
Modify existing `capd_rke2_fleet_clusterclass.spec.ts` to implement https://github.com/rancher/turtles/issues/2159

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions:
:green_circle: [2.13](https://github.com/rancher/rancher-turtles-e2e/actions/runs/24239294888), [2.14](https://github.com/rancher/rancher-turtles-e2e/actions/runs/24239305544)