### PR TITLE
Enable fleet addon explicitly

### DIFF
--- a/tests/cypress/latest/e2e/capd_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capd_kubeadm_clusterclass.spec.ts
@@ -117,6 +117,7 @@ describe('Import CAPD Kubeadm Class-Cluster', {tags: '@short'}, () => {
       })
     )
 
+    // Ref: https://github.com/rancher/turtles/issues/1880
     qase(43,
       it('Check if annotation for externally-managed cluster is set', () => {
         cy.searchCluster(clusterName);

--- a/tests/cypress/latest/e2e/providers_setup.spec.ts
+++ b/tests/cypress/latest/e2e/providers_setup.spec.ts
@@ -126,6 +126,35 @@ describe('Enable CAPI Providers', () => {
       cy.addFleetGitRepo('helm-ops', vars.turtlesRepoUrl, vars.classBranch, 'examples/applications/', vars.capiClustersNS);
     })
 
+    if (isRancherManagerVersion('>=2.14')) {
+      qase('', it('Enable turtles feature gate: use-caapf', () => {
+        const enableFeatureGate = (text: any) => {
+          // to disable the feature flag, simply removing this data won't be enough. The value must be reset to "false".
+          text.data["rancher-turtles"] = `{"features": {"use-caapf": {"enabled": "true"}}}`;
+        }
+        cy.editKubernetesResource({
+          name: "rancher-config",
+          clusterName: "local",
+          resourcePath: ["More Resources", "Core", "ConfigMaps"],
+          namespace: "cattle-system",
+          modifyYAMLOperation: enableFeatureGate
+        });
+
+        // Ensure the turtles deployment has the feature gate enabled
+        cy.setNamespace(turtlesNamespace)
+        cy.clickNavMenu(["Workloads", "Deployments"]);
+        cy.typeInFilter('rancher-turtles-controller-manager');
+        // We need to explicitly wait for the turtles controller deployment to restart
+        cy.getBySel('sortable-cell-0-0').contains('In Progress', {timeout: 30000});
+        cy.getBySel('sortable-cell-0-0').contains('Active', {timeout: 30000});
+        cy.getBySel('sortable-table-0-action-button').click();
+        cy.get('div.dropdownTarget').contains('Show Configuration').click();
+        cy.getBySel('btn-yaml-tab').click();
+        cy.get('.CodeMirror-code').contains("use-caapf=true");
+        cy.clickButton('Close');
+        cy.namespaceReset();
+      }));
+    }
     it('Create Providers using Charts', () => {
       const providerSelectionFunction = (text: any) => {
         // @ts-ignore
@@ -137,6 +166,10 @@ describe('Enable CAPI Providers', () => {
         text.providers.controlplaneKubeadm.enabled = true;
         // @ts-ignore
         text.providers.controlplaneKubeadm.enableAutomaticUpdate = true;
+
+        // fleet-addon needs to be explicitly enabled for 2.14.
+        // @ts-ignore
+        text.providers.addonFleet.enabled = true;
 
         if (isCypressTag('@short') || isCypressTag('@upgrade') || isCypressTag('@switch')) {
             // @ts-ignore

--- a/tests/cypress/latest/e2e/providers_setup.spec.ts
+++ b/tests/cypress/latest/e2e/providers_setup.spec.ts
@@ -126,8 +126,8 @@ describe('Enable CAPI Providers', () => {
       cy.addFleetGitRepo('helm-ops', vars.turtlesRepoUrl, vars.classBranch, 'examples/applications/', vars.capiClustersNS);
     })
 
-    if (isRancherManagerVersion('>=2.14')) {
-      qase('', it('Enable turtles feature gate: use-caapf', () => {
+    if (isRancherManagerVersion('>=2.14.1')) {
+      it('Enable turtles feature gate: use-caapf', () => {
         const enableFeatureGate = (text: any) => {
           // to disable the feature flag, simply removing this data won't be enough. The value must be reset to "false".
           text.data["rancher-turtles"] = `{"features": {"use-caapf": {"enabled": "true"}}}`;
@@ -153,7 +153,7 @@ describe('Enable CAPI Providers', () => {
         cy.get('.CodeMirror-code').contains("use-caapf=true");
         cy.clickButton('Close');
         cy.namespaceReset();
-      }));
+      });
     }
     it('Create Providers using Charts', () => {
       const providerSelectionFunction = (text: any) => {
@@ -167,7 +167,7 @@ describe('Enable CAPI Providers', () => {
         // @ts-ignore
         text.providers.controlplaneKubeadm.enableAutomaticUpdate = true;
 
-        // fleet-addon needs to be explicitly enabled for 2.14.
+        // fleet-addon needs to be explicitly enabled starting >=2.14.1.
         // @ts-ignore
         text.providers.addonFleet.enabled = true;
 

--- a/tests/cypress/latest/e2e/providers_setup.spec.ts
+++ b/tests/cypress/latest/e2e/providers_setup.spec.ts
@@ -126,7 +126,8 @@ describe('Enable CAPI Providers', () => {
       cy.addFleetGitRepo('helm-ops', vars.turtlesRepoUrl, vars.classBranch, 'examples/applications/', vars.capiClustersNS);
     })
 
-    if (isRancherManagerVersion('>=2.14.1')) {
+    // This feature gates needs to be enabled for >=2.14.1
+    if (isRancherManagerVersion('>=2.14')) {
       it('Enable turtles feature gate: use-caapf', () => {
         const enableFeatureGate = (text: any) => {
           // to disable the feature flag, simply removing this data won't be enough. The value must be reset to "false".
@@ -167,7 +168,7 @@ describe('Enable CAPI Providers', () => {
         // @ts-ignore
         text.providers.controlplaneKubeadm.enableAutomaticUpdate = true;
 
-        // fleet-addon needs to be explicitly enabled starting >=2.14.1.
+        // fleet-addon needs to be explicitly enabled for >=2.14.1.
         // @ts-ignore
         text.providers.addonFleet.enabled = true;
 

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -29,8 +29,7 @@ import {
   isPrimeChannel,
   isRancherManagerVersion,
   isTurtlesDevChart,
-  isTurtlesPrimeBuild,
-  providersChartNeedsStgRegistry
+  isTurtlesPrimeBuild
 } from '~/support/utils';
 import {vars} from '~/support/variables'
 
@@ -1069,6 +1068,37 @@ Cypress.Commands.add('deleteKubernetesResource', (clusterName = 'local', resourc
   cy.wait(2000); // needed for 2.12
   cy.typeInFilter(resourceName);
   cy.getBySel('sortable-cell-0-1', {timeout: 60000}).should('not.exist');
+  cy.namespaceReset();
+})
+
+Cypress.Commands.add('editKubernetesResource', (options) => {
+  cy.exploreCluster(options.clusterName);
+  cy.setNamespace(options.namespace);
+  // using `cy.clickNavMenu()` does not always work here, so we explicitly wait after clicking a label.
+  options.resourcePath.forEach(label => {
+    cy.get('.nav').contains(label).click()
+    cy.wait(1000);
+  });
+
+  cy.typeInFilter(options.name);
+  cy.getBySel('sortable-cell-0-1').should('exist');
+  cy.viewport(1920, 1080);
+  cy.getBySel('sortable-table-0-action-button').click();
+  cy.get('div.dropdownTarget').contains('Edit YAML').click();
+
+  if (options.modifyYAMLOperation) {
+    cy.get('.CodeMirror').then((editor) => {
+      // @ts-expect-error known error with CodeMirror
+      let text = yaml.load(editor[0].CodeMirror.getValue());
+      // @ts-ignore
+      options.modifyYAMLOperation(text);
+      // @ts-expect-error known error with CodeMirror
+      editor[0].CodeMirror.setValue(yaml.dump(text));
+    });
+  }
+  cy.clickButton('Save');
+  // ensure there was no error with Editing the YAML.
+  cy.getBySel('error-banner0', {timeout: 3000}).should('not.exist');
   cy.namespaceReset();
 })
 

--- a/tests/cypress/latest/support/e2e.ts
+++ b/tests/cypress/latest/support/e2e.ts
@@ -16,7 +16,7 @@ import './commands';
 import yaml from 'js-yaml';
 import './capz_support';
 import './cleanup_support';
-import {ChartInstallExtraOptions, Cluster} from './structs';
+import {ChartInstallExtraOptions, Cluster, EditKubernetesResourceOptions} from './structs';
 import {register as registerCypressGrep} from '@cypress/grep'
 
 // This ensures the qase() function exists globally before ANY spec file loads
@@ -90,6 +90,7 @@ declare global {
       createAzureASOCredential(clientID: string, tenantID: string, clientSecret: string, subscriptionID: string): Chainable<Element>;
       deleteKubernetesResource(clusterName: string, resourcePath: string[], resourceName: string, namespace?: string): Chainable<Element>;
 
+      editKubernetesResource(options: EditKubernetesResourceOptions): Chainable<Element>;
       checkKubernetesResource(clusterName: string, resourcePath: string[], resourceName: string, shouldExist: boolean, namespace: string, timeout?: number): Chainable<Element>;
     }
   }

--- a/tests/cypress/latest/support/structs.ts
+++ b/tests/cypress/latest/support/structs.ts
@@ -46,3 +46,12 @@ export type ChartInstallExtraOptions = {
     refreshRepo?: boolean
     modifyYAMLOperation?: (text: any) => void
 }
+
+export type EditKubernetesResourceOptions = {
+    clusterName: string,
+    name: string,
+    resourcePath: string[]
+    namespace: string
+    modifyYAMLOperation?: (text: any) => void
+    timeout?: number
+}


### PR DESCRIPTION
### What does this PR do?
This PR attempts to fix failure caused by fleetaddon provider being disabled by default.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions (if applicable) -  [[4030] Rancher-head/2.14 - @install @short destroy=true dev=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/24390912482/job/71236537769) :green_circle: ,[  [4032] Rancher-head/2.14 - @install @short destroy=true dev=false](https://github.com/rancher/rancher-turtles-e2e/actions/runs/24393871240) :green_circle: 
### Special notes for your reviewer:
