### PR TITLE
Fix failure with setting use-caapf feature gate

### DIFF
--- a/tests/cypress/latest/e2e/providers_setup.spec.ts
+++ b/tests/cypress/latest/e2e/providers_setup.spec.ts
@@ -15,6 +15,7 @@ import '~/support/commands';
 import {
   capiNamespace,
   isCypressTag,
+  isHeadBuild,
   isRancherManagerVersion,
   isTurtlesDevChart,
   isUpgrade,
@@ -71,7 +72,7 @@ describe('Enable CAPI Providers', () => {
     },
     'prod-v2.14': {
       capi: 'v1.12.2',
-      rke2: 'v0.24.1',
+      rke2: 'v0.24.2',
       kubeadm: 'v1.12.2',
       fleet: 'v0.14.1',
       vsphere: 'v1.15.2',
@@ -126,8 +127,8 @@ describe('Enable CAPI Providers', () => {
       cy.addFleetGitRepo('helm-ops', vars.turtlesRepoUrl, vars.classBranch, 'examples/applications/', vars.capiClustersNS);
     })
 
-    // This feature gates needs to be enabled for >=2.14.1
-    if (isRancherManagerVersion('>=2.14')) {
+    // This feature gate needs to be enabled for >=2.14.1
+    if (isRancherManagerVersion('>=2.14.1') || (isRancherManagerVersion('2.14') && isHeadBuild)) {
       it('Enable turtles feature gate: use-caapf', () => {
         const enableFeatureGate = (text: any) => {
           // to disable the feature flag, simply removing this data won't be enough. The value must be reset to "false".
@@ -146,7 +147,7 @@ describe('Enable CAPI Providers', () => {
         cy.clickNavMenu(["Workloads", "Deployments"]);
         cy.typeInFilter('rancher-turtles-controller-manager');
         // We need to explicitly wait for the turtles controller deployment to restart
-        cy.getBySel('sortable-cell-0-0').contains('In Progress', {timeout: 30000});
+        cy.getBySel('sortable-cell-0-0').contains('In Progress', {timeout: 60000});
         cy.getBySel('sortable-cell-0-0').contains('Active', {timeout: 30000});
         cy.getBySel('sortable-table-0-action-button').click();
         cy.get('div.dropdownTarget').contains('Show Configuration').click();


### PR DESCRIPTION
### What does this PR do?
1. The test is a little flaky when waiting for the turtles deployment to be `In Progress`. Increasing the timeout and adding a retry should help. [Ref](https://github.com/rancher/rancher-turtles-e2e/actions/runs/24440658339).
2. Only run the test for 2.14.1 since we still test 2.14.0, and the entire suite fails since <2.14.1 does not support the feature gate. [Ref](https://github.com/rancher/rancher-turtles-e2e/actions/runs/24444701381). 
3. Bump RKE2 version for prod-v2.14. [Ref](https://github.com/rancher/rancher-turtles-e2e/actions/runs/24440658339/job/71430263520#step:28:475).

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [ ] GitHub Actions (if applicable)

### Special notes for your reviewer:

<!-- e2e-result-start -->
### E2E Test Results:

| Run Name | Run Result |
|----------|------------|
| [[4051] Rancher-latest/2.14.0 - **@install** dev=false destroy=false](https://github.com/rancher/rancher-turtles-e2e/actions/runs/24447521578) (this has failed, but the failure is related to broken regular registry) | ❌ Fail |
| [[4055] Rancher-prime-alpha/2.14.1-alpha2 - **@install** dev=false destroy=false](https://github.com/rancher/rancher-turtles-e2e/actions/runs/24455314105) | ✅ Pass |
<!-- e2e-result-end -->



