### PR TITLE
Use new template in scheduled runs

### DIFF
--- a/.github/workflows/ui-e2e.yaml
+++ b/.github/workflows/ui-e2e.yaml
@@ -96,6 +96,6 @@ jobs:
       target_build_type: ${{ inputs.target_build_type || 'prime' }}
       turtles_chart_version: ${{ inputs.turtles_chart_version }}
       skip_cluster_delete: ${{ inputs.skip_cluster_delete || (github.event_name == 'schedule' && false) }}
-      runner_template: ${{ inputs.runner_template || 'capi-e2e-ci-runner-spot-n2-highmem-16-template-v4' }}
+      runner_template: ${{ inputs.runner_template || 'rancher-turtles-e2e-ci-spot-20260414141337391900000001' }}
       cluster_name_suffix: ${{ inputs.cluster_name_suffix || github.run_number }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag || (github.event.schedule == '0 3 * * *' && '@install @short') || (github.event.schedule == '0 4 * * *' && '@install @vsphere') || (github.event.schedule == '0 5 * * 6' && '@install @full') || (github.event.schedule == '0 3 * * 6' && '@install @migration @short') || (github.event.schedule == '0 5 * * 0' && '@install @upgrade') }}


### PR DESCRIPTION
### What does this PR do?
Fix for providing new GCP template for scheduled run

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [x] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions (if applicable): N/A - this is for cron scheduled runs only

### Special notes for your reviewer:

<!-- e2e-result-start -->
### E2E Test Results:

| Run Name | Run Result |
|----------|------------|
<!-- e2e-result-end -->