### PR TITLE
Update gcp templates and set trusted interfaces for kind network

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -87,7 +87,7 @@ on:
         type: boolean
       runner_template:
         description: Runner template to use
-        default: rancher-turtles-e2e-ci-spot-20260414141337391900000001
+        default: rancher-turtles-e2e-ci-spot-20260417075336903600000001
         type: string
       test_description:
         description: Short description of the test

--- a/.github/workflows/ui-e2e.yaml
+++ b/.github/workflows/ui-e2e.yaml
@@ -53,11 +53,11 @@ on:
         type: boolean
       runner_template:
         description: Runner template to use
-        default: rancher-turtles-e2e-ci-spot-20260414141337391900000001
+        default: rancher-turtles-e2e-ci-spot-20260417075336903600000001
         type: choice
         options:
-          - rancher-turtles-e2e-ci-spot-20260414141337391900000001
-          - rancher-turtles-e2e-ci-standard-20260414141535697900000001
+          - rancher-turtles-e2e-ci-spot-20260417075336903600000001
+          - rancher-turtles-e2e-ci-standard-20260417075451469600000001
   schedule:
     - cron: '0 3 * * *' # @short
     - cron: '0 4 * * *' # @vsphere
@@ -96,6 +96,6 @@ jobs:
       target_build_type: ${{ inputs.target_build_type || 'prime' }}
       turtles_chart_version: ${{ inputs.turtles_chart_version }}
       skip_cluster_delete: ${{ inputs.skip_cluster_delete || (github.event_name == 'schedule' && false) }}
-      runner_template: ${{ inputs.runner_template || 'capi-e2e-ci-runner-spot-n2-highmem-16-template-v4' }}
+      runner_template: ${{ inputs.runner_template || 'rancher-turtles-e2e-ci-spot-20260417075336903600000001' }}
       cluster_name_suffix: ${{ inputs.cluster_name_suffix || github.run_number }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag || (github.event.schedule == '0 3 * * *' && '@install @short') || (github.event.schedule == '0 4 * * *' && '@install @vsphere') || (github.event.schedule == '0 5 * * 6' && '@install @full') || (github.event.schedule == '0 3 * * 6' && '@install @migration @short') || (github.event.schedule == '0 5 * * 0' && '@install @upgrade') }}

--- a/tests/scripts/start-cypress-tests
+++ b/tests/scripts/start-cypress-tests
@@ -8,12 +8,20 @@ pushd cypress/latest
 npm install
 
 # Create network for CAPD, TODO: find way to run via cy.exec()
+KIND_SUBNET='172.19.0.0/16'
+KIND_GATEWAY='172.19.0.1'
+
+# Docker 28+: allow traffic from host interfaces used by k3s to the KIND network.
+# See: https://docs.docker.com/engine/network/port-publishing/#direct-routing-to-containers-in-bridge-networks
+TRUSTED_INTERFACES='flannel.1:cni0'
+
 docker network create \
     --driver=bridge \
-    --subnet=172.19.0.0/16 \
-    --gateway=172.19.0.1 \
+    --subnet=${KIND_SUBNET} \
+    --gateway=${KIND_GATEWAY} \
     --opt "com.docker.network.bridge.enable_ip_masquerade"="true" \
     --opt "com.docker.network.driver.mtu"="1500" \
+    --opt "com.docker.network.bridge.trusted_host_interfaces=${TRUSTED_INTERFACES}" \
     kind || true
 
 # Start Cypress tests with docker - only root or user with uid 1000 is working


### PR DESCRIPTION
### What does this PR do?

* replaced accidentally deleted GCP templates with new ones
* added extra flag for creating docker kind network to allow communication from k3s to kind docker network - this is mandatory for latest images with recent docker 28+

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [x] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions (if applicable)

### Special notes for your reviewer:

<!-- e2e-result-start -->
### E2E Test Results:

| Run Name | Run Result | Note |
|----------|------------|---|
| [[4091] Rancher-head/2.14 - **@install @short** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/24555805177) | ❌ Fail | flaky? only capd_rke2_fleet_clusterclass.spec.ts failed
| [[4090] Rancher-head/2.14 - **@install @short** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/24555791409) | ✅ Pass |
| [[4097] Rancher-head/2.14 - **@install @short** dev=true destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/24559255801) | ❌ Fail | rke2 provider version mismatch
| [[4091] Rancher-head/2.14 - **@install @short** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/24555805177) | ❌ Fail | flaky? only capd_rke2_fleet_clusterclass.spec.ts failed
| [[4101] Rancher-head/2.14 - **@install @short** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/24561685647) | ❌ Fail | automagically canceled?
| [[4102] Rancher-head/2.14 - **@install @short** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/24561842430) | ✅ Pass |
<!-- e2e-result-end -->












