### PR TITLE
Add No-Caapf tests

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -272,6 +272,7 @@ jobs:
       PROVIDERS_STG_OCI_REPO: ${{ secrets.providers_stg_oci_repo }}
       # Common specs: @short @vsphere @full
       SPECS: |
+        e2e/capd_rke2_nocaapf_clusterclass.spec.ts
         e2e/providers_setup_legacy.spec.ts
         e2e/providers_setup.spec.ts
         e2e/capd_rke2_clusterclass.spec.ts

--- a/tests/cypress/latest/e2e/capd_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capd_kubeadm_clusterclass.spec.ts
@@ -12,7 +12,6 @@ limitations under the License.
 */
 
 import '../support/commands';
-import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import {getClusterName, isAPIv1beta1, isRancherManagerVersion, skipClusterDeletion} from '../support/utils';
 import {capiClusterDeletion, importedRancherClusterDeletion} from "../support/cleanup_support";
 import {vars} from '../support/variables';
@@ -101,25 +100,9 @@ describe('Import CAPD Kubeadm Class-Cluster', {tags: '@short'}, () => {
       })
     }
 
-    // fleet-addon provider checks (for rancher dev/2.10.3 and up)
-    qase(42,
-      // skip due to turtles/issues/1329
-      xit('Check if cluster is registered in Fleet only once', () => {
-        cypressLib.accesMenu('Continuous Delivery');
-        cy.contains('Dashboard').should('be.visible');
-        cypressLib.accesMenu('Clusters');
-        cy.fleetNamespaceToggle('fleet-default');
-        // Verify the cluster is registered and Active
-        const rowNumber = 0
-        cy.verifyTableRow(rowNumber, 'Active', clusterName);
-        // Make sure there is only one registered cluster in fleet (there should be one table row)
-        cy.get('table.sortable-table').find(`tbody tr[data-testid="sortable-table-${rowNumber}-row"]`).should('have.length', 1);
-      })
-    )
-
     // Ref: https://github.com/rancher/turtles/issues/1880
     qase(43,
-      it('Check if annotation for externally-managed cluster is set', () => {
+      it('Check the annotation for externally-managed fleet is set on cluster', () => {
         cy.searchCluster(clusterName);
         cy.getBySel('sortable-cell-0-1').click();
         cy.getBySel('related').click();

--- a/tests/cypress/latest/e2e/capd_rke2_migration_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capd_rke2_migration_clusterclass.spec.ts
@@ -185,7 +185,7 @@ describe('Import CAPD RKE2 Class-Cluster for Migration', {tags: '@migration'}, (
         capdResourcesCleanup();
 
         // Uninstall Rancher Turtles providers chart
-        cy.deleteKubernetesResource('local', ['Apps', 'Installed Apps'], 'rancher-turtles-providers', turtlesNamespace);
+        cy.deleteKubernetesResource('local', ['Apps', 'Installed Apps'], vars.turtlesProvidersHelmApp, turtlesNamespace);
         cy.get('.closer').click();
 
         // Remove namespaces

--- a/tests/cypress/latest/e2e/capd_rke2_nocaapf_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capd_rke2_nocaapf_clusterclass.spec.ts
@@ -1,35 +1,23 @@
-/*
-Copyright © 2022 - 2023 SUSE LLC
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 
 import '../support/commands';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
-import {isUseCAAPFSupported, skipClusterDeletion} from '../support/utils';
+import {skipClusterDeletion, turtlesNamespace, isUseCAAPFSupported} from '../support/utils';
 import {capdResourcesCleanup, capiClusterDeletion, importedRancherClusterDeletion} from "../support/cleanup_support";
 import {vars} from '../support/variables';
 
 Cypress.config();
-describe('Import CAPD RKE2 (Default CNI) Class-Cluster using Fleet', {tags: '@short'}, () => {
+describe('Import CAPD RKE2 (Default CNI & No-Caapf) Class-Cluster using Fleet', {tags: '@short'}, () => {
   let clusterName: string
   const timeout = vars.shortTimeout
   const classNamePrefix = 'docker-rke2'
-  const path = '/tests/assets/rancher-turtles-fleet-example/capd/rke2/class-clusters-v1beta1'
+  const path = '/tests/assets/rancher-turtles-fleet-example/capd/rke2/class-clusters'
   const classesPath = 'examples/clusterclasses/docker/rke2'
   const clustersRepoName = 'docker-rke2-class-clusters'
   const clusterClassRepoName = "docker-rke2-clusterclass"
 
   beforeEach(function () {
-    if (isUseCAAPFSupported) {
-      // This test is only meant for <2.14.1
+    if (!isUseCAAPFSupported) {
+      // This test is only meant for >=2.14.1
       this.skip();
     }
     cy.login();
@@ -37,14 +25,33 @@ describe('Import CAPD RKE2 (Default CNI) Class-Cluster using Fleet', {tags: '@sh
   });
 
   context('[SETUP]', () => {
+    it('Create Docker Resources', () => {
+      // Docker rke2 lb-config
+      cy.addFleetGitRepo('lb-docker', vars.turtlesRepoUrl, vars.classBranch, 'examples/applications/lb/docker', vars.capiClustersNS);
+      cy.burgerMenuOperate('open');
+      // Prevention for Docker.io rate limiting
+      cy.createDockerAuthSecret();
+    });
+
     it('Setup the namespace for importing', () => {
       cy.namespaceAutoImport('Disable');
     })
 
-    it('Create Docker Auth Secret', () => {
-      // Prevention for Docker.io rate limiting
-      cy.createDockerAuthSecret();
-    });
+    // We install providers chart here because the test runs before providers_setup.spec.ts
+    it('Install turtles-providers-chart for Docker, RKE2', () => {
+      const providerSelectionFunction = (text: any) => {
+        // @ts-ignore
+        text.providers.infrastructureDocker.enabled = true;
+        // @ts-ignore
+        text.providers.infrastructureDocker.enableAutomaticUpdate = true;
+      }
+
+      // Install Rancher Turtles Certified Providers chart
+      cy.checkChart('local', 'Install', vars.turtlesProvidersChartName, turtlesNamespace, {
+      version: undefined,
+      modifyYAMLOperation: providerSelectionFunction
+      });
+    })
 
     it('Add CAPD RKE2 ClusterClass Fleet Repo', () => {
       cy.addFleetGitRepo(clusterClassRepoName, vars.turtlesRepoUrl, vars.classBranch, classesPath, vars.capiClassesNS)
@@ -70,8 +77,7 @@ describe('Import CAPD RKE2 (Default CNI) Class-Cluster using Fleet', {tags: '@sh
     it('Auto import child CAPD cluster', () => {
       // Go to Cluster Management > CAPI > Clusters and check if the cluster has provisioned
       cy.checkCAPIClusterProvisioned(clusterName, timeout);
-
-      // Check child cluster is created and auto-imported
+       // Check child cluster is created and auto-imported
       // This is checked by ensuring the cluster is available in navigation menu
       cy.goToHome();
       cy.contains(clusterName).should('exist');
@@ -94,6 +100,31 @@ describe('Import CAPD RKE2 (Default CNI) Class-Cluster using Fleet', {tags: '@sh
       // Filter out cni pods by image name
       cy.typeInFilter('calico');
       cy.waitForAllRowsInState('Running', timeout);
+    })
+
+    it('Check if cluster is registered in Fleet only once', () => {
+      cypressLib.accesMenu('Continuous Delivery');
+      cy.contains('Dashboard').should('be.visible');
+      cypressLib.accesMenu('Clusters');
+      cy.fleetNamespaceToggle('fleet-default');
+      // Verify the cluster is registered and Active
+      const rowNumber = 0
+      cy.verifyTableRow(rowNumber, 'Active', clusterName);
+      // Make sure there is only one registered cluster in fleet (there should be one table row)
+      cy.get('table.sortable-table').find(`tbody tr[data-testid="sortable-table-${rowNumber}-row"]`).should('have.length', 1);
+    })
+
+    it('Check the annotation for externally-managed fleet is not set on cluster', () => {
+      cy.searchCluster(clusterName);
+      cy.getBySel('sortable-cell-0-1').click();
+      cy.getBySel('related').click();
+      cy.get('a[href*="management.cattle.io.cluster/c-"]').click();
+      const annotation = 'provisioning.cattle.io/externally-managed: \'true\'';
+      cy.get('.CodeMirror').then((editor) => {
+        // @ts-expect-error known error with CodeMirror
+        const text = editor[0].CodeMirror.getValue();
+        expect(text).to.not.include(annotation);
+      });
     })
 
     it('Install App on imported cluster', {retries: 1}, () => {
@@ -122,5 +153,16 @@ describe('Import CAPD RKE2 (Default CNI) Class-Cluster using Fleet', {tags: '@sh
         capdResourcesCleanup();
       })
     }
+
+    it('Delete the provider-charts and other resources', () => {
+      // Remove the lb-config
+      cy.removeFleetGitRepo('lb-docker');
+      cy.deleteKubernetesResource('local', ['Storage', 'ConfigMaps'], 'docker-rke2-lb-config', vars.capiClustersNS);
+
+      // Uninstall Rancher Turtles Providers chart
+      cy.deleteKubernetesResource('local', ['Apps', 'Installed Apps'], vars.turtlesProvidersHelmApp, turtlesNamespace);
+      cy.contains(new RegExp(`"${vars.turtlesProvidersHelmApp}"` + ' uninstalled'), {timeout: timeout}).should('be.visible');
+      cy.get('.closer').click();
+    })
   })
 });

--- a/tests/cypress/latest/e2e/capi_features_switch.spec.ts
+++ b/tests/cypress/latest/e2e/capi_features_switch.spec.ts
@@ -82,7 +82,10 @@ describe('Switch CAPI Feature Flags', {tags: '@switch'}, () => {
 
     context('[SWITCH-TO-CAPI-PROVISIONING]', () => {
       it('Uninstall Rancher Turtles Providers chart', () => {
-        cy.deleteKubernetesResource('local', ['Apps', 'Installed Apps'], 'rancher-turtles-providers', turtlesNamespace);
+        // Uninstall Rancher Turtles Providers chart
+        cy.deleteKubernetesResource('local', ['Apps', 'Installed Apps'], vars.turtlesProvidersHelmApp, turtlesNamespace);
+        cy.contains(new RegExp(`"${vars.turtlesProvidersHelmApp}"` + ' uninstalled'), {timeout: timeout}).should('be.visible');
+        cy.get('.closer').click();
       });
 
       it('Enable embedded-cluster-api and disable turtles', () => {

--- a/tests/cypress/latest/e2e/providers_setup.spec.ts
+++ b/tests/cypress/latest/e2e/providers_setup.spec.ts
@@ -14,8 +14,8 @@ limitations under the License.
 import '../support/commands';
 import {
   capiNamespace,
+  isUseCAAPFSupported,
   isCypressTag,
-  isHeadBuild,
   isRancherManagerVersion,
   isTurtlesDevChart,
   isUpgrade,
@@ -128,7 +128,7 @@ describe('Enable CAPI Providers', () => {
     })
 
     // This feature gate needs to be enabled for >=2.14.1
-    if (isRancherManagerVersion('>=2.14.1') || (isRancherManagerVersion('2.14') && isHeadBuild)) {
+    if (isUseCAAPFSupported) {
       it('Enable turtles feature gate: use-caapf', () => {
         const enableFeatureGate = (text: any) => {
           // to disable the feature flag, simply removing this data won't be enough. The value must be reset to "false".
@@ -260,26 +260,6 @@ describe('Enable CAPI Providers', () => {
         }
       });
     })
-
-    xit('Custom Fleet addon config', () => {
-      // Skipped as we are unable to install Monitoring app on clusters without cattle-fleet-system namespace
-      // Ref. https://github.com/rancher/fleet/issues/3521
-      // Allows Fleet addon to be installed on specific clusters only
-
-      const clusterName = 'local';
-      const resourceKind = 'configMap';
-      const resourceName = 'fleet-addon-config';
-      const namespace = turtlesNamespace;
-      const patch = {
-        data: {
-          manifests: {
-            isNestedIn: true,
-            spec: {cluster: {selector: {matchLabels: {cni: 'by-fleet-addon-kindnet'}}}}
-          }
-        }
-      };
-       cy.patchYamlResource(clusterName, namespace, resourceKind, resourceName, patch);
-    });
   });
 
   context('Docker provider', {tags: ['@short', '@upgrade', '@switch']}, () => {

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -593,7 +593,7 @@ Cypress.Commands.add('checkChart', (clusterName, operation, chartName, namespace
 
     // for >=2.13 we use an external repo to install providers chart, and for 2.12 there is no need to install it.
     if (isTurtlesProvidersChart && isRancherManagerVersion('>=2.13')) {
-      return vars.turtlesProvidersChartSelector;
+      return `"${vars.turtlesProvidersChartSelector}"`;
     }
 
     return 'app-chart-cards-container';
@@ -878,23 +878,13 @@ Cypress.Commands.add('addFleetGitRepo', (repoName, repoUrl, branch, paths, targe
     cy.contains(workspace).should('be.visible').click();
   }
 
-  if (isRancherManagerVersion('>=2.12')) {
-    cy.accesMenuSelection(['Continuous Delivery', 'App Bundles']);
-    // replacement for cy.getBySel('masthead-create').should('be.visible');
-    cy.contains('Create App Bundle').should('be.visible');
-    selectWorkspace(workspace);
-    cy.clickButton('Create App Bundle');
-    // Click on gitrepo container
-    cy.contains('Git Repos').should('be.visible').click();
-    cy.contains('App Bundle:').should('be.visible');
-
-  } else {
-    cy.accesMenuSelection(['Continuous Delivery', 'Git Repos']);
-    cy.getBySel('masthead-create').should('be.visible');
-    selectWorkspace(workspace);
-    cy.clickButton('Add Repository');
-    cy.contains('Git Repo:').should('be.visible');
-  }
+  cy.accesMenuSelection(['Continuous Delivery', 'App Bundles']);
+  cy.contains('Create App Bundle').should('be.visible');
+  selectWorkspace(workspace);
+  cy.clickButton('Create App Bundle');
+  // Click on gitrepo container
+  cy.contains('Git Repos').should('be.visible').click();
+  cy.contains('App Bundle:').should('be.visible');
 
   cy.typeValue('Name', repoName);
   cy.clickButton("Next");
@@ -925,11 +915,7 @@ Cypress.Commands.add('addFleetGitRepo', (repoName, repoUrl, branch, paths, targe
 Cypress.Commands.add('removeFleetGitRepo', (repoName, workspace = 'fleet-local') => {
   cy.checkFleetGitRepoActive(repoName, workspace);
   // Click on the actions menu and select 'Delete' from the menu
-  if (isRancherManagerVersion('>=2.12')) {
-    cy.getBySel('masthead-action-menu').should('be.visible').click();
-  } else {
-    cy.get('.actions .btn.actions').click();
-  }
+  cy.getBySel('masthead-action-menu').should('be.visible').click();
   cy.get('.icon.group-icon.icon-trash').click({ctrlKey: true}); // this will prevent to display confirmation dialog
   cy.wait(2000); // needed for 2.12
   cy.goToFleetGitRepos(workspace);
@@ -941,11 +927,7 @@ Cypress.Commands.add('removeFleetGitRepo', (repoName, workspace = 'fleet-local')
 Cypress.Commands.add('forceUpdateFleetGitRepo', (repoName, workspace) => {
   cy.checkFleetGitRepoActive(repoName, workspace);
   // Click on the actions menu and select 'Force Update' from the menu
-  if (isRancherManagerVersion('>=2.12')) {
-    cy.getBySel('masthead-action-menu').should('be.visible').click();
-  } else {
-    cy.get('.actions .btn.actions').click();
-  }
+  cy.getBySel('masthead-action-menu').should('be.visible').click();
   // On prime 2.13.0-alpha4 the refresh icon selector didn't change but parent <div> must be clicked
   cy.get('.icon.group-icon.icon-refresh').parent().click();
   cy.clickButton('Update')
@@ -955,8 +937,7 @@ Cypress.Commands.add('forceUpdateFleetGitRepo', (repoName, workspace) => {
 Cypress.Commands.add('goToFleetGitRepos', (workspace = 'fleet-local') => {
   // Go to 'Continuous Delivery' > 'Git Repos'
   cy.burgerMenuOperate('open');
-  const gitRepoMenuLocation = isRancherManagerVersion('>=2.12') ? ['Continuous Delivery', 'Resources', 'Git Repos'] : ['Continuous Delivery', 'Git Repos'];
-  cy.accesMenuSelection(gitRepoMenuLocation);
+  cy.accesMenuSelection(['Continuous Delivery', 'Resources', 'Git Repos']);
   cy.getBySel('masthead-create').should('be.visible');
   // Change the workspace using the dropdown on the top bar
   cy.getBySel('workspace-switcher').click();
@@ -971,11 +952,7 @@ Cypress.Commands.add('checkFleetGitRepoActive', (repoName, workspace) => {
   cy.url().should("include", "fleet/fleet.cattle.io.gitrepo/" + workspace + "/" + repoName)
   // Ensure there are no errors after waiting for a few seconds
   cy.wait(5000);
-  if (isRancherManagerVersion('>=2.12')) {
-    cy.get('.badge-state', {timeout: 3000}).should("not.contain", "Error");
-  } else {
-    cy.get('.badge-state', {timeout: 3000}).should("not.contain", "Err Applied");
-  }
+  cy.get('.badge-state', {timeout: 10000}).should("not.contain", "Error");
 })
 
 // Fleet namespace toggle

--- a/tests/cypress/latest/support/utils.ts
+++ b/tests/cypress/latest/support/utils.ts
@@ -69,3 +69,5 @@ export const isAPIv1beta1 = isRancherManagerVersion('<=2.13')
 export const isUpgrade = isCypressTag('@upgrade')
 
 export const isTurtlesDevChart = Cypress.expose('turtles_dev_chart')
+
+export const isUseCAAPFSupported = (isRancherManagerVersion('>=2.14.1') || (isRancherManagerVersion('2.14') && isHeadBuild))

--- a/tests/cypress/latest/support/variables.ts
+++ b/tests/cypress/latest/support/variables.ts
@@ -17,9 +17,10 @@ export const vars = {
   turtlesRepoUrl: 'https://github.com/rancher/turtles',
   dockerAuthUsernameBase64: btoa(Cypress.expose("docker_auth_username")),
   dockerAuthPasswordBase64: btoa(Cypress.expose("docker_auth_password")),
+  turtlesProvidersHelmApp: 'rancher-turtles-providers',
   turtlesProvidersOCIRepo: providersChartNeedsStgRegistry() ? Cypress.expose('providers_stg_oci_repo') : Cypress.expose('providers_oci_repo'), // For alpha|rc|head builds, use stgregistry, for released versions, use regular registry.
   turtlesProvidersChartName: needsProvidersStgChartName() ? 'rancher-turtles-providers' : 'Rancher Turtles Certified Providers', // TODO: Remove this once https://github.com/rancher/rancher/issues/53882 and 53883 is fixed; staging registry is currently broken for everything
-  turtlesProvidersChartSelector: isRancherManagerVersion('2.13') && isUpgrade ? '"item-card-cluster/turtles-providers-chart/rancher-turtles-providers"' : isTurtlesDevChart ? '"item-card-cluster/chartmuseum-repo/rancher-turtles-providers"' : '"item-card-cluster/turtles-providers-chart/rancher-turtles-providers"',
+  turtlesProvidersChartSelector: isRancherManagerVersion('2.13') && isUpgrade ? 'item-card-cluster/turtles-providers-chart/rancher-turtles-providers' : isTurtlesDevChart ? 'item-card-cluster/chartmuseum-repo/rancher-turtles-providers' : 'item-card-cluster/turtles-providers-chart/rancher-turtles-providers',
   kindVersion: isRancherManagerVersion('2.12') ? 'v1.33.4' : isRancherManagerVersion('2.13') ? 'v1.34.0' : 'v1.35.0',
   k8sVersion: isRancherManagerVersion('2.12') ? 'v1.33.4' : isRancherManagerVersion('2.13') ? 'v1.34.1' : 'v1.35.0',
   rke2Version: isRancherManagerVersion('2.12') ? 'v1.33.4+rke2r1' : isRancherManagerVersion('2.13') ? 'v1.34.1+rke2r1' : 'v1.35.0+rke2r1',


### PR DESCRIPTION
### What does this PR do?
- Adds No-Caapf tests (default on 2.14.1 fresh install)
- Removes usage 2.12 filter in `commands.ts`

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [ ] GitHub Actions (if applicable)

### Special notes for your reviewer:

<!-- e2e-result-start -->
### E2E Test Results:

| Run Name | Run Result |
|----------|------------|
| [[4114] Rancher-prime-alpha/2.14.1-alpha2 - **@install @short** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/24572213551) | ✅ Pass |
| [[4112] Rancher-head/2.14 - **@install @short** dev=true destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/24572047818) | ✅ Pass |
| [[4113] Rancher-head/2.13 - **@install @short** dev=true destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/24572058512) | ✅ Pass |
<!-- e2e-result-end -->






