### PR TITLE
Remove workaround for broken staging registry

### DIFF
--- a/tests/cypress/latest/e2e/providers_setup.spec.ts
+++ b/tests/cypress/latest/e2e/providers_setup.spec.ts
@@ -14,11 +14,11 @@ limitations under the License.
 import '../support/commands';
 import {
   capiNamespace,
-  isUseCAAPFSupported,
   isCypressTag,
   isRancherManagerVersion,
   isTurtlesDevChart,
   isUpgrade,
+  isUseCAAPFSupported,
   providersChartNeedsStgRegistry,
   turtlesNamespace,
 } from '../support/utils';
@@ -206,7 +206,7 @@ describe('Enable CAPI Providers', () => {
       }
       // Install Rancher Turtles Certified Providers chart
       let operation = isRancherManagerVersion('2.14') && isUpgrade ? 'Upgrade' : 'Install'
-      let turtlesProvidersChartVersion = providersChartNeedsStgRegistry() && isRancherManagerVersion('2.13') ? '0.25' : providersChartNeedsStgRegistry() && isRancherManagerVersion('2.14') ? '0.26' : undefined // TODO: Remove this once https://github.com/rancher/rancher/issues/53882 and 53883 is fixed; staging registry is currently broken for everything
+      let turtlesProvidersChartVersion = providersChartNeedsStgRegistry() && isRancherManagerVersion('2.13') ? '0.25' : undefined
       cy.checkChart('local', operation, vars.turtlesProvidersChartName, turtlesNamespace, {
         version: turtlesProvidersChartVersion,
         modifyYAMLOperation: providerSelectionFunction

--- a/tests/cypress/latest/support/utils.ts
+++ b/tests/cypress/latest/support/utils.ts
@@ -40,13 +40,6 @@ export const providersChartNeedsStgRegistry = (): boolean => {
   return (!isTurtlesDevChart) && (isPreRelease || isHeadBuild);
 }
 
-// Check if Rancher Turtles Providers chart should use staging registry chart name
-// Returns true for Rancher 2.13 alpha/rc builds
-// TODO: Remove this once https://github.com/rancher/rancher/issues/53882 and 53883 is fixed; staging registry is currently broken for everything
-export const needsProvidersStgChartName = (): boolean => {
-  return isRancherManagerVersion('2.13') && isPreRelease && !isTurtlesDevChart
-}
-
 export const isTurtlesPrimeBuild = (): boolean =>{
   return Cypress.expose("turtles_build_type") === "prime";
 }

--- a/tests/cypress/latest/support/variables.ts
+++ b/tests/cypress/latest/support/variables.ts
@@ -1,10 +1,4 @@
-import {
-  isRancherManagerVersion,
-  isTurtlesDevChart,
-  isUpgrade,
-  needsProvidersStgChartName,
-  providersChartNeedsStgRegistry
-} from './utils';
+import {isRancherManagerVersion, isTurtlesDevChart, isUpgrade, providersChartNeedsStgRegistry} from './utils';
 
 export const vars = {
   shortTimeout: 600000,
@@ -19,7 +13,7 @@ export const vars = {
   dockerAuthPasswordBase64: btoa(Cypress.expose("docker_auth_password")),
   turtlesProvidersHelmApp: 'rancher-turtles-providers',
   turtlesProvidersOCIRepo: providersChartNeedsStgRegistry() ? Cypress.expose('providers_stg_oci_repo') : Cypress.expose('providers_oci_repo'), // For alpha|rc|head builds, use stgregistry, for released versions, use regular registry.
-  turtlesProvidersChartName: needsProvidersStgChartName() ? 'rancher-turtles-providers' : 'Rancher Turtles Certified Providers', // TODO: Remove this once https://github.com/rancher/rancher/issues/53882 and 53883 is fixed; staging registry is currently broken for everything
+  turtlesProvidersChartName: 'Rancher Turtles Certified Providers',
   turtlesProvidersChartSelector: isRancherManagerVersion('2.13') && isUpgrade ? 'item-card-cluster/turtles-providers-chart/rancher-turtles-providers' : isTurtlesDevChart ? 'item-card-cluster/chartmuseum-repo/rancher-turtles-providers' : 'item-card-cluster/turtles-providers-chart/rancher-turtles-providers',
   kindVersion: isRancherManagerVersion('2.12') ? 'v1.33.4' : isRancherManagerVersion('2.13') ? 'v1.34.0' : 'v1.35.0',
   k8sVersion: isRancherManagerVersion('2.12') ? 'v1.33.4' : isRancherManagerVersion('2.13') ? 'v1.34.1' : 'v1.35.0',


### PR DESCRIPTION
### What does this PR do?
This PR reverts the workaround that was added for broken staging registry.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [ ] GitHub Actions (if applicable)

### Special notes for your reviewer:

<!-- e2e-result-start -->
### E2E Test Results:

| Run Name | Run Result | Notes |
|----------|------------|------------|
| [[4135] Rancher-prime-alpha/2.14.1-alpha2 - **@install** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/24666474128) | ❌ Fail | unreleted failure with verifying RKE2 version |
| [[4134] Rancher-head/2.14 - **@install** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/24666452048) | ✅ Pass |
| [[4133] Rancher-head/2.13 - **@install** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/24666440162) | ✅ Pass |
| [[4136] Rancher-prime-alpha/2.13.5-alpha2 - **@install** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/24666513766) | ❌ Fail |
| [[4132] Rancher-head/2.14 - **@install** dev=true destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/24666427075) | ✅ Pass |
| [[4139] Rancher-prime-alpha/2.13.5-alpha2 - **@install** dev=false destroy=false](https://github.com/rancher/rancher-turtles-e2e/actions/runs/24669652677) | ❌ Fail |
<!-- e2e-result-end -->





