### PR TITLE
Fix providers chart installation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,6 @@ Fixes #
 <!-- e2e-result-start -->
 ### E2E Test Results:
 
-| Run Name | Run Result |
-|----------|------------|
+| Run Name | Run Result | Notes |
+|----------|------------|-------|
 <!-- e2e-result-end -->

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -319,6 +319,10 @@ jobs:
             # Required for upgrade tests
             echo "RANCHER_VERSION=prime/2.13.5" >> ${GITHUB_ENV}
             echo "COMMON_SPECS=$(echo "${{ env.SPECS }}" | tr '\n' ' ')" >> ${GITHUB_ENV}
+          elif [[ "${{ inputs.grep_test_by_tag }}" =~ "@switch" ]]; then
+            # Required for switch tests
+            echo "RANCHER_VERSION=prime/2.13.5" >> ${GITHUB_ENV}
+            echo "COMMON_SPECS=$(echo "${{ env.SPECS }}" | tr '\n' ' ')" >> ${GITHUB_ENV}
           else
             echo "RANCHER_VERSION=${{ inputs.rancher_version }}" >> ${GITHUB_ENV}
           fi

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -750,7 +750,7 @@ jobs:
 
           RUN_NAME="[${{ github.run_number }}] Rancher-${{ inputs.rancher_version }} - **${{ inputs.grep_test_by_tag }}** dev=${{ inputs.turtles_dev_chart }} destroy=${{ inputs.destroy_runner }}"
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          NEW_ROW="| [${RUN_NAME}](${RUN_URL}) | ${STATUS} |"
+          NEW_ROW="| [${RUN_NAME}](${RUN_URL}) | ${STATUS} | |"
 
           # Get current PR body
           gh pr view "$PR_NUMBER" --repo "$REPO" --json body --jq '.body' > /tmp/pr_body.txt
@@ -765,8 +765,8 @@ jobs:
           <!-- e2e-result-start -->
           ### E2E Test Results:
 
-          | Run Name | Run Result |
-          |----------|------------|
+          | Run Name | Run Result | Notes |
+          |----------|------------|-------|
           ${NEW_ROW}
           <!-- e2e-result-end -->
           EOF

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -317,7 +317,7 @@ jobs:
             echo "SPECS=" >> ${GITHUB_ENV}
           elif [[ "${{ inputs.grep_test_by_tag }}" =~ "@upgrade" ]]; then
             # Required for upgrade tests
-            echo "RANCHER_VERSION=prime/2.13.4" >> ${GITHUB_ENV}
+            echo "RANCHER_VERSION=prime/2.13.5" >> ${GITHUB_ENV}
             echo "COMMON_SPECS=$(echo "${{ env.SPECS }}" | tr '\n' ' ')" >> ${GITHUB_ENV}
           else
             echo "RANCHER_VERSION=${{ inputs.rancher_version }}" >> ${GITHUB_ENV}
@@ -542,7 +542,7 @@ jobs:
       - name: Set Rancher Manager Upgrade version
         if: ${{ contains(inputs.grep_test_by_tag, '@upgrade') }}
         run: |
-          echo "RANCHER_VERSION=prime-alpha/2.14.1-alpha3" >> ${GITHUB_ENV}
+          echo "RANCHER_VERSION=prime/2.14.1" >> ${GITHUB_ENV}
       - name: Upgrade Rancher Manager
         if: ${{ contains(inputs.grep_test_by_tag, '@migration') || contains(inputs.grep_test_by_tag, '@upgrade') }}
         env:

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -399,7 +399,7 @@ jobs:
 
       # Build providers chart to push to chartmuseum in a later step
       - name: Make Turtles Providers Chart
-        if: ${{ (inputs.turtles_dev_chart == true && (!contains(env.RANCHER_VERSION, '2.12')) || contains(inputs.grep_test_by_tag, '@migration') || contains(inputs.grep_test_by_tag, '@upgrade'))  }}
+        if: ${{ (inputs.turtles_dev_chart == true && (!contains(env.RANCHER_VERSION, '2.12')) || contains(inputs.grep_test_by_tag, '@migration') || contains(inputs.grep_test_by_tag, '@upgrade')) }}
         run: RELEASE_TAG=v${{ env.TAG }} make build-providers-chart
 
       - name: Clone, build and publish artificial system charts for 2.13 onwards

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ What tests are doing:
     2.13). These tests are only supported with `dev=true` options; `dev=true` is applicable to 2.13.
 12. Upgrade tests from 2.13 to 2.14 to test turtles CAPI upgrade from v1.10 to v1.12. These tests are only supported
     with `dev=true` options; `dev=true` is applicable to 2.14.
+13. Add Feature Switch test for 2.13 to test switch between `embedded-cluster-api` and `turtles` features switch.
 
 ## Running the tests locally
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ What tests are doing:
 8. Install App on imported CAPI cluster
 9. Scale the imported CAPI cluster
 10. Remove & Delete the imported CAPI cluster
-
+11. Migration test from 2.12 to 2.13 to test turtles migration from an external chart(2.12) to system integrated chart(
+    2.13). These tests are only supported with `dev=true` options; `dev=true` is applicable to 2.13.
+12. Upgrade tests from 2.13 to 2.14 to test turtles CAPI upgrade from v1.10 to v1.12. These tests are only supported
+    with `dev=true` options; `dev=true` is applicable to 2.14.
 
 ## Running the tests locally
 
@@ -26,7 +29,7 @@ What tests are doing:
 1. `cd tests/cypress/latest`
 2. Install Cypress and its dependencies: `npm install`
 3. Export the following ENV VAR: `RANCHER_URL` (format: `https://<FQDN>/dashboard`), `RANCHER_PASSWORD`, `RANCHER_USER`,
-   `GREPTAGS=@install [@short @full|@vsphere]`, and provider specific env var:
+   `GREPTAGS=@install [@short @full @upgrade @migration | @vsphere ]`, and provider specific env var:
     1. CAPA - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
     2. CAPG - `GCP_CREDENTIALS` and `GCP_PROJECT`
     3. CAPZ - `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, and `AZURE_SUBSCRIPTION_ID`.

--- a/tests/cypress/latest/e2e/capd_rke2_migration_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capd_rke2_migration_clusterclass.spec.ts
@@ -118,7 +118,7 @@ describe('Import CAPD RKE2 Class-Cluster for Migration', {tags: '@migration'}, (
     if (isRancherManagerVersion('2.13')) {
       it('Create Fleet Provider using provider charts', () => {
         // Install Rancher Turtles Certified Providers chart with default values
-        cy.checkChart('local', 'Install', 'Rancher Turtles Certified Providers', turtlesNamespace);
+        cy.checkChart('local', 'Install', vars.turtlesProvidersChartName, turtlesNamespace);
       })
 
       it('Check cluster & Resources status post-migration', () => {

--- a/tests/cypress/latest/e2e/capd_rke2_nocaapf_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capd_rke2_nocaapf_clusterclass.spec.ts
@@ -1,7 +1,6 @@
-
 import '../support/commands';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
-import {skipClusterDeletion, turtlesNamespace, isUseCAAPFSupported} from '../support/utils';
+import {isUseCAAPFSupported, skipClusterDeletion, turtlesNamespace} from '../support/utils';
 import {capdResourcesCleanup, capiClusterDeletion, importedRancherClusterDeletion} from "../support/cleanup_support";
 import {vars} from '../support/variables';
 
@@ -47,10 +46,7 @@ describe('Import CAPD RKE2 (Default CNI & No-Caapf) Class-Cluster using Fleet', 
       }
 
       // Install Rancher Turtles Certified Providers chart
-      cy.checkChart('local', 'Install', vars.turtlesProvidersChartName, turtlesNamespace, {
-      version: undefined,
-      modifyYAMLOperation: providerSelectionFunction
-      });
+      cy.checkChart('local', 'Install', vars.turtlesProvidersChartName, turtlesNamespace, {modifyYAMLOperation: providerSelectionFunction});
     })
 
     it('Add CAPD RKE2 ClusterClass Fleet Repo', () => {
@@ -161,7 +157,7 @@ describe('Import CAPD RKE2 (Default CNI & No-Caapf) Class-Cluster using Fleet', 
 
       // Uninstall Rancher Turtles Providers chart
       cy.deleteKubernetesResource('local', ['Apps', 'Installed Apps'], vars.turtlesProvidersHelmApp, turtlesNamespace);
-      cy.contains(new RegExp(`"${vars.turtlesProvidersHelmApp}"` + ' uninstalled'), {timeout: timeout}).should('be.visible');
+      cy.contains(new RegExp(`"${vars.turtlesProvidersHelmApp}.*"` + ' uninstalled'), {timeout: timeout}).should('be.visible');
       cy.get('.closer').click();
     })
   })

--- a/tests/cypress/latest/e2e/capi_features_switch.spec.ts
+++ b/tests/cypress/latest/e2e/capi_features_switch.spec.ts
@@ -84,7 +84,7 @@ describe('Switch CAPI Feature Flags', {tags: '@switch'}, () => {
       it('Uninstall Rancher Turtles Providers chart', () => {
         // Uninstall Rancher Turtles Providers chart
         cy.deleteKubernetesResource('local', ['Apps', 'Installed Apps'], vars.turtlesProvidersHelmApp, turtlesNamespace);
-        cy.contains(new RegExp(`"${vars.turtlesProvidersHelmApp}"` + ' uninstalled'), {timeout: timeout}).should('be.visible');
+        cy.contains(new RegExp(`"${vars.turtlesProvidersHelmApp}.*"` + ' uninstalled'), {timeout: timeout}).should('be.visible');
         cy.get('.closer').click();
       });
 

--- a/tests/cypress/latest/e2e/capi_features_switch.spec.ts
+++ b/tests/cypress/latest/e2e/capi_features_switch.spec.ts
@@ -1,5 +1,11 @@
 import '../support/commands';
-import {capiNamespace, getClusterName, isRancherManagerVersion, turtlesNamespace} from '../support/utils';
+import {
+  capiNamespace,
+  getClusterName,
+  isRancherManagerVersion,
+  isTurtlesDevChart,
+  turtlesNamespace
+} from '../support/utils';
 import {capdResourcesCleanup, capiClusterDeletion} from '../support/cleanup_support';
 import {vars} from '../support/variables';
 
@@ -139,7 +145,7 @@ describe('Switch CAPI Feature Flags', {tags: '@switch'}, () => {
         }
         // Install Rancher Turtles Certified Providers chart
         cy.checkChart('local', 'Install', vars.turtlesProvidersChartName, turtlesNamespace, {
-          version: '0.25',
+          version: !isTurtlesDevChart ? '0.25' : undefined,
           modifyYAMLOperation: providerSelectionFunction
         });
       })

--- a/tests/cypress/latest/e2e/post_upgrade_setup.spec.ts
+++ b/tests/cypress/latest/e2e/post_upgrade_setup.spec.ts
@@ -1,11 +1,11 @@
 import '../support/commands';
 import {vars} from '../support/variables';
-import {turtlesNamespace} from '../support/utils';
+import {isTurtlesDevChart, turtlesNamespace} from '../support/utils';
 
 Cypress.config();
 describe('Post Upgrade', {tags: '@upgrade'}, () => {
-  let chartMuseumRepo = Cypress.expose('chartmuseum_repo')
-  let turtlesChartDevVersion = Cypress.expose('turtles_chart_dev_version')
+  // Since we upgrade to 2.14, turtles chart version value can be hardcoded for dev=false
+  let turtlesChartVersion: string = isTurtlesDevChart ? Cypress.expose('turtles_chart_dev_version') : '0.26';
   const timeout = vars.shortTimeout
 
   beforeEach(() => {
@@ -19,13 +19,8 @@ describe('Post Upgrade', {tags: '@upgrade'}, () => {
     cy.clickNavMenu(['Apps', 'Installed Apps']);
     cy.typeInFilter('rancher-turtles');
     cy.getBySel('sortable-cell-0-1').should('exist');
-    cy.contains(turtlesChartDevVersion, {timeout: timeout});
+    cy.contains(turtlesChartVersion, {timeout: timeout});
     cy.waitForAllRowsInState('Deployed', timeout);
   })
 
-  it("Add turtles-providers GitRepo", () => {
-    cy.task('log', "Adding chartmuseum repo for turtles-providers");
-    expect(chartMuseumRepo, "checking chartmuseum repo").to.not.be.empty;
-    cy.addRepository('chartmuseum-repo', `${chartMuseumRepo}:8080`, 'http', 'none');
-  })
 });

--- a/tests/cypress/latest/e2e/post_upgrade_setup.spec.ts
+++ b/tests/cypress/latest/e2e/post_upgrade_setup.spec.ts
@@ -1,11 +1,10 @@
 import '../support/commands';
 import {vars} from '../support/variables';
-import {isTurtlesDevChart, turtlesNamespace} from '../support/utils';
+import {turtlesNamespace} from '../support/utils';
 
 Cypress.config();
 describe('Post Upgrade', {tags: '@upgrade'}, () => {
-  // Since we upgrade to 2.14, turtles chart version value can be hardcoded for dev=false
-  let turtlesChartVersion: string = isTurtlesDevChart ? Cypress.expose('turtles_chart_dev_version') : '0.26';
+  let turtlesChartDevVersion = Cypress.expose('turtles_chart_dev_version')
   const timeout = vars.shortTimeout
 
   beforeEach(() => {
@@ -19,7 +18,7 @@ describe('Post Upgrade', {tags: '@upgrade'}, () => {
     cy.clickNavMenu(['Apps', 'Installed Apps']);
     cy.typeInFilter('rancher-turtles');
     cy.getBySel('sortable-cell-0-1').should('exist');
-    cy.contains(turtlesChartVersion, {timeout: timeout});
+    cy.contains(turtlesChartDevVersion, {timeout: timeout});
     cy.waitForAllRowsInState('Deployed', timeout);
   })
 

--- a/tests/cypress/latest/e2e/post_upgrade_setup.spec.ts
+++ b/tests/cypress/latest/e2e/post_upgrade_setup.spec.ts
@@ -4,6 +4,7 @@ import {turtlesNamespace} from '../support/utils';
 
 Cypress.config();
 describe('Post Upgrade', {tags: '@upgrade'}, () => {
+  let chartMuseumRepo = Cypress.expose('chartmuseum_repo')
   let turtlesChartDevVersion = Cypress.expose('turtles_chart_dev_version')
   const timeout = vars.shortTimeout
 
@@ -22,4 +23,9 @@ describe('Post Upgrade', {tags: '@upgrade'}, () => {
     cy.waitForAllRowsInState('Deployed', timeout);
   })
 
+  it("Add turtles-providers GitRepo", () => {
+    cy.task('log', "Adding chartmuseum repo for turtles-providers");
+    expect(chartMuseumRepo, "checking chartmuseum repo").to.not.be.empty;
+    cy.addRepository('chartmuseum-repo', `${chartMuseumRepo}:8080`, 'http', 'none');
+  })
 });

--- a/tests/cypress/latest/e2e/providers_setup.spec.ts
+++ b/tests/cypress/latest/e2e/providers_setup.spec.ts
@@ -14,11 +14,11 @@ limitations under the License.
 import '../support/commands';
 import {
   capiNamespace,
-  isUseCAAPFSupported,
   isCypressTag,
   isRancherManagerVersion,
   isTurtlesDevChart,
   isUpgrade,
+  isUseCAAPFSupported,
   providersChartNeedsStgRegistry,
   turtlesNamespace,
 } from '../support/utils';
@@ -206,7 +206,7 @@ describe('Enable CAPI Providers', () => {
       }
       // Install Rancher Turtles Certified Providers chart
       let operation = isRancherManagerVersion('2.14') && isUpgrade ? 'Upgrade' : 'Install'
-      let turtlesProvidersChartVersion = providersChartNeedsStgRegistry() && isRancherManagerVersion('2.13') ? '0.25' : providersChartNeedsStgRegistry() && isRancherManagerVersion('2.14') ? '0.26' : undefined // TODO: Remove this once https://github.com/rancher/rancher/issues/53882 and 53883 is fixed; staging registry is currently broken for everything
+      let turtlesProvidersChartVersion = providersChartNeedsStgRegistry() && isRancherManagerVersion('2.13') ? '0.25' : providersChartNeedsStgRegistry() && isRancherManagerVersion('2.14') ? '0.26' : undefined
       cy.checkChart('local', operation, vars.turtlesProvidersChartName, turtlesNamespace, {
         version: turtlesProvidersChartVersion,
         modifyYAMLOperation: providerSelectionFunction

--- a/tests/cypress/latest/e2e/turtles_chart.spec.ts
+++ b/tests/cypress/latest/e2e/turtles_chart.spec.ts
@@ -65,8 +65,9 @@ describe('Install Turtles Chart - @install', {tags: '@install'}, () => {
       }
 
       if (isUpgrade) {
-        // Used in Pre-migration: For Upgrade tests; providers will be installed from turtles-providers-chart repo
+        // Used in Pre-upgrade: For Upgrade tests; providers will be installed from turtles-providers-chart repo
         installTurtlesProvidersRepo();
+        // In Post-upgrade, providers will be installed using chartmuseum repo
       }
     })
   }
@@ -83,11 +84,7 @@ describe('Install Turtles Chart - @install', {tags: '@install'}, () => {
         // Used in Pre-migration: For Migration test; turtles will be installed from turtles-chart repo.
         // dev=true is only applicable for 2.13 or version test is upgrading to.
         installTurtlesRepo();
-
-        // Used in Post-migration: We add turtles-providers-chart repo for dev=false to install providers charts
-        if (!isTurtlesDevChart) {
-          installTurtlesProvidersRepo();
-        }
+        // In Post-migration, chartmuseum repo will be used to install providers chart
       }
     })
 

--- a/tests/cypress/latest/e2e/turtles_chart.spec.ts
+++ b/tests/cypress/latest/e2e/turtles_chart.spec.ts
@@ -40,49 +40,54 @@ describe('Install Turtles Chart - @install', {tags: '@install'}, () => {
     cy.contains("Include Prerelease Versions").should('not.have.class', 'bg-disabled');
   })
 
+  let installTurtlesProvidersRepo = function () {
+    cy.task('suiteLog', "Adding turtles-providers-chart repo");
+    cy.addRepository('turtles-providers-chart', vars.turtlesProvidersOCIRepo, 'oci', 'none')
+  }
+
+  let installChartMuseumRepo = function () {
+    cy.task('suiteLog', "Adding chartmuseum repo");
+    expect(chartMuseumRepo, "checking chartmuseum repo").to.not.be.empty;
+    cy.addRepository('chartmuseum-repo', `${chartMuseumRepo}:8080`, 'http', 'none');
+  }
+
+  let installTurtlesRepo = function () {
+    cy.task('suiteLog', "Adding turtles-chart repo");
+    cy.addRepository('turtles-chart', 'https://rancher.github.io/turtles/', 'http', 'none');
+  }
+
   if (isRancherManagerVersion(">=2.13")) {
     it("Add turtles-providers GitRepo", () => {
       if (isTurtlesDevChart) {
-        cy.task('suiteLog', "Adding chartmuseum repo for turtles-providers");
-        expect(chartMuseumRepo, "checking chartmuseum repo").to.not.be.empty;
-        cy.addRepository('chartmuseum-repo', `${chartMuseumRepo}:8080`, 'http', 'none');
+        installChartMuseumRepo();
       } else {
-        cy.task('suiteLog', "Adding turtles-providers-chart repo");
-        cy.addRepository('turtles-providers-chart', vars.turtlesProvidersOCIRepo, 'oci', 'none')
+        installTurtlesProvidersRepo();
       }
-      
-      if (isRancherManagerVersion("2.13") && isUpgrade) {
-        cy.deleteKubernetesResource('local', ['Apps', 'Repositories'], 'chartmuseum-repo');
-        cy.burgerMenuOperate('open');
-        cy.task('log', "Removed chartmuseum-repo & Adding turtles-providers-chart repo");
-        cy.addRepository('turtles-providers-chart', vars.turtlesProvidersOCIRepo, 'oci', 'none')
+
+      if (isUpgrade) {
+        // Used in Pre-migration: For Upgrade tests; providers will be installed from turtles-providers-chart repo
+        installTurtlesProvidersRepo();
       }
     })
   }
 
   if (isRancherManagerVersion("<=2.12")) {
     it("Add turtles GitRepo", () => {
-      if (isTurtlesDevChart || isMigration) {
-        cy.task('suiteLog', "Adding turtles dev chart repo");
-        cy.task('suiteLog', "Adding turtles-providers-chart dev repo for migration test");
-        expect(chartMuseumRepo, "checking chartmuseum repo").to.not.be.empty;
-        cy.addRepository('chartmuseum-repo', `${chartMuseumRepo}:8080`, 'http', 'none');
+      if (isTurtlesDevChart) {
+        installChartMuseumRepo();
       } else {
-        cy.task('suiteLog', "Adding turtles chart repo");
-        cy.addRepository('turtles-chart', 'https://rancher.github.io/turtles/', 'http', 'none');
-        if (isMigration) {
-          cy.burgerMenuOperate('open');
-          cy.task('suiteLog', "Adding turtles-providers-chart repo for migration test");
-          cy.addRepository('turtles-providers-chart', vars.turtlesProvidersOCIRepo, 'oci', 'none')
-        }
+        installTurtlesRepo();
       }
 
       if (isMigration) {
-        // For <=2.12, dev=true and migration test, we will install turtles from standard chart repo;
+        // Used in Pre-migration: For Migration test; turtles will be installed from turtles-chart repo.
         // dev=true is only applicable for 2.13 or version test is upgrading to.
-        cy.burgerMenuOperate('open');
-        cy.task('suiteLog', "Adding turtles chart repo for migration test");
-        cy.addRepository('turtles-chart', 'https://rancher.github.io/turtles/', 'http', 'none');
+        installTurtlesRepo();
+
+        // Used in Post-migration: We add turtles-providers-chart repo for dev=false to install providers charts
+        if (!isTurtlesDevChart) {
+          installTurtlesProvidersRepo();
+        }
       }
     })
 

--- a/tests/cypress/latest/e2e/turtles_chart.spec.ts
+++ b/tests/cypress/latest/e2e/turtles_chart.spec.ts
@@ -40,18 +40,18 @@ describe('Install Turtles Chart - @install', {tags: '@install'}, () => {
     cy.contains("Include Prerelease Versions").should('not.have.class', 'bg-disabled');
   })
 
-  let installTurtlesProvidersRepo = function () {
+  let addTurtlesProvidersRepo = function () {
     cy.task('suiteLog', "Adding turtles-providers-chart repo");
     cy.addRepository('turtles-providers-chart', vars.turtlesProvidersOCIRepo, 'oci', 'none')
   }
 
-  let installChartMuseumRepo = function () {
+  let addChartMuseumRepo = function () {
     cy.task('suiteLog', "Adding chartmuseum repo");
     expect(chartMuseumRepo, "checking chartmuseum repo").to.not.be.empty;
     cy.addRepository('chartmuseum-repo', `${chartMuseumRepo}:8080`, 'http', 'none');
   }
 
-  let installTurtlesRepo = function () {
+  let addTurtlesRepo = function () {
     cy.task('suiteLog', "Adding turtles-chart repo");
     cy.addRepository('turtles-chart', 'https://rancher.github.io/turtles/', 'http', 'none');
   }
@@ -59,14 +59,16 @@ describe('Install Turtles Chart - @install', {tags: '@install'}, () => {
   if (isRancherManagerVersion(">=2.13")) {
     it("Add turtles-providers GitRepo", () => {
       if (isTurtlesDevChart) {
-        installChartMuseumRepo();
+        addChartMuseumRepo();
       } else {
-        installTurtlesProvidersRepo();
+        addTurtlesProvidersRepo();
       }
 
-      if (isUpgrade) {
+      if (isRancherManagerVersion('2.13') && isUpgrade) {
+        cy.task('log', "Removed chartmuseum-repo & Adding turtles-providers-chart repo");
+        cy.deleteKubernetesResource('local', ['Apps', 'Repositories'], 'chartmuseum-repo');
         // Used in Pre-upgrade: For Upgrade tests; providers will be installed from turtles-providers-chart repo
-        installTurtlesProvidersRepo();
+        addTurtlesProvidersRepo();
         // In Post-upgrade, providers will be installed using chartmuseum repo
       }
     })
@@ -75,15 +77,15 @@ describe('Install Turtles Chart - @install', {tags: '@install'}, () => {
   if (isRancherManagerVersion("<=2.12")) {
     it("Add turtles GitRepo", () => {
       if (isTurtlesDevChart) {
-        installChartMuseumRepo();
+        addChartMuseumRepo();
       } else {
-        installTurtlesRepo();
+        addTurtlesRepo();
       }
 
       if (isMigration) {
         // Used in Pre-migration: For Migration test; turtles will be installed from turtles-chart repo.
         // dev=true is only applicable for 2.13 or version test is upgrading to.
-        installTurtlesRepo();
+        addTurtlesRepo();
         // In Post-migration, chartmuseum repo will be used to install providers chart
       }
     })

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -1099,7 +1099,11 @@ Cypress.Commands.add('checkKubernetesResource', (clusterName = 'local', resource
 
     cy.setNamespace(namespace);
     // Sometimes if a resource does not exist in a namespace, the navigation menu won't be visible. So we navigate after a namespace has been set.
-    cy.clickNavMenu(resourcePath);
+    resourcePath.forEach(path => {
+      cy.wait(1000);
+      cy.get('nav').contains(path).click();
+    });
+
 
     cy.typeInFilter(resourceName);
     if (shouldExist) {

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -505,39 +505,43 @@ Cypress.Commands.add('addCloudCredsVMware', (name: string, vsphere_username: str
 });
 
 Cypress.Commands.add('addRepository', (repositoryName: string, repositoryURL: string, repositoryType: 'oci' | 'http' | 'git', repositoryBranch: string) => {
-  cy.contains('local')
-    .click();
+  cy.burgerMenuOperate('open');
+  cy.contains('local').click();
   cy.clickNavMenu(['Apps', 'Repositories'])
   // Make sure we are in the 'Repositories' screen (test failed here before)
   // Test fails sporadically here, screen stays in pending state forever
   // Ensuring "Loading..." overlay screen is not present.
   cy.contains('Loading...', {timeout: 35000}).should('not.exist');
-  cy.contains('header', 'Repositories')
-    .should('be.visible');
-  cy.contains('Create')
-    .should('be.visible');
+  cy.contains('header', 'Repositories').should('be.visible');
+  cy.contains('Create').should('be.visible');
 
-  cy.clickButton('Create');
-  cy.contains('Repository: Create')
-    .should('be.visible');
-  cy.typeValue('Name', repositoryName);
-  switch (repositoryType) {
-    case "git":
-      cy.contains('Git repository')
-        .click();
-      cy.typeValue('Git Repo URL', repositoryURL);
-      cy.typeValue('Git Branch', repositoryBranch);
-      break;
-    case "oci":
-      cy.contains('OCI Repository').click();
-      cy.typeValue('OCI Repository Host URL', repositoryURL);
-      break;
-    case "http":
-      cy.typeValue('Index URL', repositoryURL);
-      break;
-  }
+  // Check if the repository already exists; if it does not, then add it, otherwise simply refresh it and return
+  cy.typeInFilter(repositoryName);
+  cy.get('.sortable-table').then((row) => {
+    if (row.find('tr.no-results').length > 0) {
+      cy.clickButton('Create');
+      cy.contains('Repository: Create').should('be.visible');
+      cy.typeValue('Name', repositoryName);
+      switch (repositoryType) {
+        case "git":
+          cy.contains('Git repository').click();
+          cy.typeValue('Git Repo URL', repositoryURL);
+          cy.typeValue('Git Branch', repositoryBranch);
+          break;
+        case "oci":
+          cy.contains('OCI Repository').click();
+          cy.typeValue('OCI Repository Host URL', repositoryURL);
+          break;
+        case "http":
+          cy.typeValue('Index URL', repositoryURL);
+          break;
+      }
+      cy.clickButton('Create');
+    } else {
+      cy.task('suiteLog', `Repository ${repositoryName} already exists; skipping.`)
+    }
+  })
 
-  cy.clickButton('Create');
   // Make sure the repo is active before leaving
   // Always press Refresh button as workaround for https://github.com/rancher/rancher/issues/49671
   cy.wait(1000);
@@ -581,14 +585,9 @@ Cypress.Commands.add('checkChart', (clusterName, operation, chartName, namespace
 
   const getChartSelector = () => {
     if (isTurtlesChart) {
-      if (isRancherManagerVersion('2.12')) {
-        return isTurtlesDevChart && !isMigration ? 'item-card-cluster/chartmuseum-repo/rancher-turtles' : 'item-card-cluster/turtles-chart/rancher-turtles';
-      }
-
-      return isTurtlesDevChart ? 'item-card-cluster/chartmuseum-repo/rancher-turtles' : 'item-card-cluster/rancher-charts/rancher-turtles';
+      return isRancherManagerVersion('2.12') && isMigration ? 'item-card-cluster/turtles-chart/rancher-turtles' : isTurtlesDevChart ? 'item-card-cluster/chartmuseum-repo/rancher-turtles' : 'item-card-cluster/turtles-chart/rancher-turtles'
     }
 
-    // for >=2.13 we use an external repo to install providers chart, and for 2.12 there is no need to install it.
     if (isTurtlesProvidersChart) {
       return isRancherManagerVersion('2.13') && isUpgrade ? 'item-card-cluster/turtles-providers-chart/rancher-turtles-providers' : isTurtlesDevChart ? 'item-card-cluster/chartmuseum-repo/rancher-turtles-providers' : 'item-card-cluster/turtles-providers-chart/rancher-turtles-providers';
     }

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -538,7 +538,7 @@ Cypress.Commands.add('addRepository', (repositoryName: string, repositoryURL: st
       }
       cy.clickButton('Create');
     } else {
-      cy.task('suiteLog', `Repository ${repositoryName} already exists; skipping.`)
+      cy.task('suiteLog', `Repository ${repositoryName} already exists; skipping.`);
     }
   })
 

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -537,6 +537,8 @@ Cypress.Commands.add('addRepository', (repositoryName: string, repositoryURL: st
           break;
       }
       cy.clickButton('Create');
+      cy.wait(1000);
+      cy.typeInFilter(repositoryName);
     } else {
       cy.task('suiteLog', `Repository ${repositoryName} already exists; skipping.`);
     }
@@ -544,8 +546,6 @@ Cypress.Commands.add('addRepository', (repositoryName: string, repositoryURL: st
 
   // Make sure the repo is active before leaving
   // Always press Refresh button as workaround for https://github.com/rancher/rancher/issues/49671
-  cy.wait(1000);
-  cy.typeInFilter(repositoryName);
   cy.getBySel('sortable-table-0-action-button').click();
   cy.wait(1000);
   // On prime 2.13.0-alpha4 the refresh icon selector didn't change but parent <div> must be clicked

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -630,6 +630,13 @@ Cypress.Commands.add('checkChart', (clusterName, operation, chartName, namespace
         cy.getBySel('chart-versions').contains(options.version).first().click();
       }
       cy.url().should("contain", options.version);
+    } else {
+      // If a version is not provided, this ensures that latest chart version is selected.
+      if (isRancherManagerVersion('<=2.12')) {
+        cy.get('div.chart-content__right-bar__section--cVersion').first().click();
+      } else {
+        cy.getBySel('chart-versions').first().click();
+      }
     }
 
     if (isTurtlesChart && isUpdateOperation) {

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -29,7 +29,8 @@ import {
   isPrimeChannel,
   isRancherManagerVersion,
   isTurtlesDevChart,
-  isTurtlesPrimeBuild
+  isTurtlesPrimeBuild,
+  isUpgrade
 } from './utils';
 import {vars} from './variables'
 
@@ -580,23 +581,19 @@ Cypress.Commands.add('checkChart', (clusterName, operation, chartName, namespace
 
   const getChartSelector = () => {
     if (isTurtlesChart) {
-      if (isRancherManagerVersion('>=2.13')) {
-        return isTurtlesDevChart ? '"item-card-cluster/chartmuseum-repo/rancher-turtles"' : '"item-card-cluster/rancher-charts/rancher-turtles"';
-      }
-
       if (isRancherManagerVersion('2.12')) {
-        return isTurtlesDevChart && !isMigration ? '"item-card-cluster/chartmuseum-repo/rancher-turtles"' : '"item-card-cluster/turtles-chart/rancher-turtles"';
+        return isTurtlesDevChart && !isMigration ? 'item-card-cluster/chartmuseum-repo/rancher-turtles' : 'item-card-cluster/turtles-chart/rancher-turtles';
       }
 
-      return '"select-icon-grid-Rancher Turtles - the Cluster API Extension"';
+      return isTurtlesDevChart ? 'item-card-cluster/chartmuseum-repo/rancher-turtles' : 'item-card-cluster/rancher-charts/rancher-turtles';
     }
 
     // for >=2.13 we use an external repo to install providers chart, and for 2.12 there is no need to install it.
-    if (isTurtlesProvidersChart && isRancherManagerVersion('>=2.13')) {
-      return `"${vars.turtlesProvidersChartSelector}"`;
+    if (isTurtlesProvidersChart) {
+      return isRancherManagerVersion('2.13') && isUpgrade ? 'item-card-cluster/turtles-providers-chart/rancher-turtles-providers' : isTurtlesDevChart ? 'item-card-cluster/chartmuseum-repo/rancher-turtles-providers' : 'item-card-cluster/turtles-providers-chart/rancher-turtles-providers';
     }
 
-    return 'app-chart-cards-container';
+    return `item-card-cluster/rancher-charts/rancher-${chartName.toLowerCase()}`;
   };
 
   const performOperation = () => {
@@ -617,13 +614,8 @@ Cypress.Commands.add('checkChart', (clusterName, operation, chartName, namespace
     cy.getBySel('charts-header-title').should('be.visible');
     cy.typeInFilter(chartName, 'input[data-testid="charts-filter-input"]');
 
-    cy.getBySel(getChartSelector()).within(() => {
-      cy.contains(chartName, {timeout: 10000}).then($el => {
-        cy.wait(500);
-        cy.wrap($el).should('be.visible').click();
-      });
-    });
-    cy.contains(`Charts: ${chartName}`);
+    cy.getBySel(`"${getChartSelector()}"`).should('be.visible', {timeout: 1000}).click();
+    cy.contains('Charts:');
 
     if (options.version) {
       cy.get('body').invoke('text').then((bodyText) => {
@@ -632,8 +624,7 @@ Cypress.Commands.add('checkChart', (clusterName, operation, chartName, namespace
         }
       });
       // Select first of the matching listed version
-      cy.getBySel('chart-versions').first().click();
-      cy.contains(options.version).click();
+      cy.getBySel('chart-versions').contains(options.version).first().click();
       cy.url().should("contain", options.version);
     }
 

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -623,8 +623,13 @@ Cypress.Commands.add('checkChart', (clusterName, operation, chartName, namespace
           cy.contains('Show More').click();
         }
       });
+
       // Select first of the matching listed version
-      cy.getBySel('chart-versions').contains(options.version).first().click();
+      if (isRancherManagerVersion('<=2.12')) {
+        cy.get('div.chart-content__right-bar__section--cVersion').contains(options.version).first().click();
+      } else {
+        cy.getBySel('chart-versions').contains(options.version).first().click();
+      }
       cy.url().should("contain", options.version);
     }
 

--- a/tests/cypress/latest/support/utils.ts
+++ b/tests/cypress/latest/support/utils.ts
@@ -40,13 +40,6 @@ export const providersChartNeedsStgRegistry = (): boolean => {
   return (!isTurtlesDevChart) && (isPreRelease || isHeadBuild);
 }
 
-// Check if Rancher Turtles Providers chart should use staging registry chart name
-// Returns true for Rancher 2.13 alpha/rc builds
-// TODO: Remove this once https://github.com/rancher/rancher/issues/53882 and 53883 is fixed; staging registry is currently broken for everything
-export const needsProvidersStgChartName = (): boolean => {
-  return isRancherManagerVersion('2.13') && isPreRelease && !isTurtlesDevChart
-}
-
 export const isTurtlesPrimeBuild = (): boolean =>{
   return Cypress.expose("turtles_build_type") === "prime";
 }

--- a/tests/cypress/latest/support/variables.ts
+++ b/tests/cypress/latest/support/variables.ts
@@ -13,7 +13,7 @@ export const vars = {
   dockerAuthPasswordBase64: btoa(Cypress.expose("docker_auth_password")),
   turtlesProvidersHelmApp: 'rancher-turtles-providers',
   turtlesProvidersOCIRepo: providersChartNeedsStgRegistry() ? Cypress.expose('providers_stg_oci_repo') : Cypress.expose('providers_oci_repo'), // For alpha|rc|head builds, use stgregistry, for released versions, use regular registry.
-  turtlesProvidersChartName: 'turtles providers',
+  turtlesProvidersChartName: 'turtles providers',   // This name is very generic and does not match display name. This is done to avoid frequent failure due to rancher version and turtles providers mismatch on staging registry. Ref:
   kindVersion: isRancherManagerVersion('2.12') ? 'v1.33.4' : isRancherManagerVersion('2.13') ? 'v1.34.0' : 'v1.35.0',
   k8sVersion: isRancherManagerVersion('2.12') ? 'v1.33.4' : isRancherManagerVersion('2.13') ? 'v1.34.1' : 'v1.35.0',
   rke2Version: isRancherManagerVersion('2.12') ? 'v1.33.4+rke2r1' : isRancherManagerVersion('2.13') ? 'v1.34.1+rke2r1' : 'v1.35.0+rke2r1',

--- a/tests/cypress/latest/support/variables.ts
+++ b/tests/cypress/latest/support/variables.ts
@@ -13,7 +13,7 @@ export const vars = {
   dockerAuthPasswordBase64: btoa(Cypress.expose("docker_auth_password")),
   turtlesProvidersHelmApp: 'rancher-turtles-providers',
   turtlesProvidersOCIRepo: providersChartNeedsStgRegistry() ? Cypress.expose('providers_stg_oci_repo') : Cypress.expose('providers_oci_repo'), // For alpha|rc|head builds, use stgregistry, for released versions, use regular registry.
-  turtlesProvidersChartName: 'turtles providers',   // This name is very generic and does not match display name. This is done to avoid frequent failure due to rancher version and turtles providers mismatch on staging registry. Ref:
+  turtlesProvidersChartName: 'turtles providers',   // This name is very generic and does not match display name. This is done to avoid frequent failure due to rancher version and turtles providers mismatch on staging registry. Ref: https://github.com/rancher/rancher/issues/53882
   kindVersion: isRancherManagerVersion('2.12') ? 'v1.33.4' : isRancherManagerVersion('2.13') ? 'v1.34.0' : 'v1.35.0',
   k8sVersion: isRancherManagerVersion('2.12') ? 'v1.33.4' : isRancherManagerVersion('2.13') ? 'v1.34.1' : 'v1.35.0',
   rke2Version: isRancherManagerVersion('2.12') ? 'v1.33.4+rke2r1' : isRancherManagerVersion('2.13') ? 'v1.34.1+rke2r1' : 'v1.35.0+rke2r1',

--- a/tests/cypress/latest/support/variables.ts
+++ b/tests/cypress/latest/support/variables.ts
@@ -1,10 +1,4 @@
-import {
-  isRancherManagerVersion,
-  isTurtlesDevChart,
-  isUpgrade,
-  needsProvidersStgChartName,
-  providersChartNeedsStgRegistry
-} from './utils';
+import {isRancherManagerVersion, providersChartNeedsStgRegistry} from './utils';
 
 export const vars = {
   shortTimeout: 600000,
@@ -19,8 +13,7 @@ export const vars = {
   dockerAuthPasswordBase64: btoa(Cypress.expose("docker_auth_password")),
   turtlesProvidersHelmApp: 'rancher-turtles-providers',
   turtlesProvidersOCIRepo: providersChartNeedsStgRegistry() ? Cypress.expose('providers_stg_oci_repo') : Cypress.expose('providers_oci_repo'), // For alpha|rc|head builds, use stgregistry, for released versions, use regular registry.
-  turtlesProvidersChartName: needsProvidersStgChartName() ? 'rancher-turtles-providers' : 'Rancher Turtles Certified Providers', // TODO: Remove this once https://github.com/rancher/rancher/issues/53882 and 53883 is fixed; staging registry is currently broken for everything
-  turtlesProvidersChartSelector: isRancherManagerVersion('2.13') && isUpgrade ? 'item-card-cluster/turtles-providers-chart/rancher-turtles-providers' : isTurtlesDevChart ? 'item-card-cluster/chartmuseum-repo/rancher-turtles-providers' : 'item-card-cluster/turtles-providers-chart/rancher-turtles-providers',
+  turtlesProvidersChartName: 'turtles providers',
   kindVersion: isRancherManagerVersion('2.12') ? 'v1.33.4' : isRancherManagerVersion('2.13') ? 'v1.34.0' : 'v1.35.0',
   k8sVersion: isRancherManagerVersion('2.12') ? 'v1.33.4' : isRancherManagerVersion('2.13') ? 'v1.34.1' : 'v1.35.0',
   rke2Version: isRancherManagerVersion('2.12') ? 'v1.33.4+rke2r1' : isRancherManagerVersion('2.13') ? 'v1.34.1+rke2r1' : 'v1.35.0+rke2r1',


### PR DESCRIPTION
### What does this PR do?
1. Use `data-testid` selector to install charts instead of just chart name. Filtering using name is still required because of the long list of charts. If we do not filter and if the chart is towards the end of the list, it does not detect the `data-testid` without scrolling.
2. Use a generic `turtles providers` name in `variables.ts` that works with both display name and chart name to filter the providers chart.
3. Add documentation for migration, upgrade and switch tests in README.md
4. Modify `turtles_chart.spec.ts` turtles chart repo addition logic. `dev=false` is not supported for migration and  upgrade, so no logic has been added for that. Repo addition code has been moved to re-usable functions.
5. Modify `addRepository` function logic to check if a repository already exists before re-adding it. If it already exists, the function will refresh it and return.
6. Attempted to simplify `checkChart().getSelector()` nested-function logic for selecting locators. For 2.13 && (upgrade or migration), it will return the standard chart selector, otherwise it will check for `isTurtlesDevChart` bool and return accordingly.
7. Modified `checkChart` function to install the latest chart version even if no version is provided. Sometimes the default selected version is an old version, so we need to explicitly select the latest version. The version selection string has also been modified to work for both 2.12 and the rest.
8. Due to 3 and 5, chartmuseum repo addition logic has been removed from `tests/cypress/latest/e2e/post_upgrade_setup.spec.ts`.
9. Modify providers chart uninstallation detection string in `capd_rke2_nocaapf_clusterclass.spec.ts` and `capd_rke2_nocaapf_clusterclass.spec.ts` to work in case the registry did not load chart details correctly and used a generic name like `rancher-turtles-providers-109-111223` instead of `rancher-turtles-providers`.
10. Add a new `Notes` column to `.github/PULL_REQUEST_TEMPLATE.md` to add any additional notes for a run.


### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [ ] GitHub Actions (if applicable)

### Special notes for your reviewer:












<!-- e2e-result-start -->
### E2E Test Results:

| Run Name | Run Result | Notes |
|----------|------------|-------|
| [[4218] Rancher-head/2.14 - **@install @short** dev=true destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/25114275486) | ✅ Pass | |
| [[4225] Rancher-prime/2.13.4 - **@install @switch** dev=true destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/25118788519) | ❌ Fail | |
| [[4222] Rancher-head/2.14 - **@install @short** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/25118660771) | ✅ Pass | |
| [[4228] Rancher-head/2.14 - **@install @migration** dev=true destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/25147231309) | ✅ Pass | |
| [[4237] Rancher-head/2.14 - **@install @upgrade** dev=true destroy=false](https://github.com/rancher/rancher-turtles-e2e/actions/runs/25209984057) | ❌ Fail | |
| [[4249] Rancher-prime/2.13.5 - **@install @switch** dev=true destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/25307390458) | ❌ Fail | Failure is one-time `1) Verify core-cluster-api ConfigMap exists` |
| [[4248] Rancher-prime/2.14.1 - **@install @short** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/25307359580) | ✅ Pass | |
| [[4247] Rancher-head/2.14 - **@install @migration** dev=true destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/25307308444) | ✅ Pass | |
| [[4250] Rancher-head/2.14 - **@install @switch** dev=true destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/25309693644) | ❌ Fail | |
| [[4251] Rancher-latest/2.14.1 - **@install @short** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/25309716957) | ❌ Fail | Failure related to azure v2prov |
| [[4252] Rancher-head/2.14 - **@install @short** dev=true destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/25309811077) | ✅ Pass | |
| [[4250] Rancher-head/2.14 - **@install @switch** dev=true destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/25309693644) | ❌ Fail | |
| [[4253] Rancher-prime/2.13.5 - **@install @switch** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/25313080664) | ✅ Pass | |
<!-- e2e-result-end -->






























