### PR TITLE
Use ginkgo cli version defined in go.mod to prevent version mismatch

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,6 +1,10 @@
-GINKGO_CLI_VERSION:=v2.28.1
+# Use same version of ginkgo cli as the one used in go.mod to avoid version mismatch issues
+GINKGO_CLI_VERSION:=$(shell go list -m -f '{{.Version}}' github.com/onsi/ginkgo/v2)
 
 deps:
+	@echo "--------------------------------------------------"
+	@echo "Current Ginkgo CLI Version: $(GINKGO_CLI_VERSION)"
+	@echo "--------------------------------------------------"
 	@go install github.com/onsi/ginkgo/v2/ginkgo@$(GINKGO_CLI_VERSION)
 	@go mod tidy
 


### PR DESCRIPTION
### What does this PR do?
Dependabot bumped ginkgo in `go.mod` today but we were using hardcoded version in Makefile so our runs were producing these messages:
```
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.28.1
  Mismatched package versions found:
    2.28.2 used by e2e
```
Ref. https://github.com/rancher/rancher-turtles-e2e/actions/runs/25046060524/job/73361444294#step:24:111

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [x] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions (if applicable)

### Special notes for your reviewer:

<!-- e2e-result-start -->
### E2E Test Results:

| Run Name | Run Result | Comment |
|----------|------------| --- |
| [[4207] Rancher-head/2.14 - **@install** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/25106378268) | ❌ Fail | the ginkgo part passed 
<img width="659" height="209" alt="image" src="https://github.com/user-attachments/assets/4bfe7a6e-c1d2-4344-9658-14527708a096" />

<!-- e2e-result-end -->
