### PR TITLE
Fix providers chart installation post-upgrade

### DIFF
--- a/tests/cypress/latest/e2e/post_upgrade_setup.spec.ts
+++ b/tests/cypress/latest/e2e/post_upgrade_setup.spec.ts
@@ -23,9 +23,4 @@ describe('Post Upgrade', {tags: '@upgrade'}, () => {
     cy.waitForAllRowsInState('Deployed', timeout);
   })
 
-  it("Add turtles-providers GitRepo", () => {
-    cy.task('log', "Adding chartmuseum repo for turtles-providers");
-    expect(chartMuseumRepo, "checking chartmuseum repo").to.not.be.empty;
-    cy.addRepository('chartmuseum-repo', `${chartMuseumRepo}:8080`, 'http', 'none');
-  })
 });

--- a/tests/cypress/latest/e2e/turtles_chart.spec.ts
+++ b/tests/cypress/latest/e2e/turtles_chart.spec.ts
@@ -65,8 +65,6 @@ describe('Install Turtles Chart - @install', {tags: '@install'}, () => {
       }
 
       if (isRancherManagerVersion('2.13') && isUpgrade) {
-        cy.task('log', "Removed chartmuseum-repo & Adding turtles-providers-chart repo");
-        cy.deleteKubernetesResource('local', ['Apps', 'Repositories'], 'chartmuseum-repo');
         // Used in Pre-upgrade: For Upgrade tests; providers will be installed from turtles-providers-chart repo
         addTurtlesProvidersRepo();
         // In Post-upgrade, providers will be installed using chartmuseum repo

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -654,7 +654,7 @@ Cypress.Commands.add('checkChart', (clusterName, operation, chartName, namespace
     cy.getBySel('btn-chart-install').click();
     cy.contains(operation + ': Step 1');
 
-    // Select namespace if an option is given
+    // Select namespace and name if an option is given
     cy.get('div.step__basic').then((step) => {
       const namespaceSelectorTestID = "name-ns-description-namespace"
       const namespaceRequired = step.find(`div[data-testid=${namespaceSelectorTestID}]`).length > 0

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -611,7 +611,11 @@ Cypress.Commands.add('checkChart', (clusterName, operation, chartName, namespace
 
     cy.clickNavMenu(['Apps', 'Charts']);
     cy.getBySel('charts-header-title').should('be.visible');
-    cy.typeInFilter(chartName, 'input[data-testid="charts-filter-input"]');
+
+    // turtles providers chart name is very generic and does not match display name.
+    // This is done to avoid frequent failure due to rancher version and turtles providers mismatch on staging registry. Ref: https://github.com/rancher/rancher/issues/53882
+    const chartFilterName = isTurtlesProvidersChart ? 'turtles providers' : chartName
+    cy.typeInFilter(chartFilterName, 'input[data-testid="charts-filter-input"]');
 
     cy.getBySel(`"${getChartSelector()}"`).should('be.visible', {timeout: 1000}).click();
     cy.contains('Charts:');
@@ -653,10 +657,16 @@ Cypress.Commands.add('checkChart', (clusterName, operation, chartName, namespace
     // Select namespace if an option is given
     cy.get('div.step__basic').then((step) => {
       const namespaceSelectorTestID = "name-ns-description-namespace"
-      const namespaceRequired = step.find(`div[data-testid=${namespaceSelectorTestID}]`).length
+      const namespaceRequired = step.find(`div[data-testid=${namespaceSelectorTestID}]`).length > 0
       if (namespaceRequired) {
         cy.setNamespace('All Namespaces', 'all_user')
         cy.getBySel(namespaceSelectorTestID).type(namespace + '{enter}');
+      }
+
+      const chartNameSelectorTestID = "NameNsDescriptionNameInput"
+      const nameRequired = step.find(`input[data-testid=${chartNameSelectorTestID}]`).length > 0
+      if (nameRequired) {
+        cy.getBySel(chartNameSelectorTestID).type(chartName);
       }
     });
 

--- a/tests/cypress/latest/support/variables.ts
+++ b/tests/cypress/latest/support/variables.ts
@@ -13,7 +13,7 @@ export const vars = {
   dockerAuthPasswordBase64: btoa(Cypress.expose("docker_auth_password")),
   turtlesProvidersHelmApp: 'rancher-turtles-providers',
   turtlesProvidersOCIRepo: providersChartNeedsStgRegistry() ? Cypress.expose('providers_stg_oci_repo') : Cypress.expose('providers_oci_repo'), // For alpha|rc|head builds, use stgregistry, for released versions, use regular registry.
-  turtlesProvidersChartName: 'turtles providers',   // This name is very generic and does not match display name. This is done to avoid frequent failure due to rancher version and turtles providers mismatch on staging registry. Ref: https://github.com/rancher/rancher/issues/53882
+  turtlesProvidersChartName: 'rancher-turtles-providers',
   kindVersion: isRancherManagerVersion('2.12') ? 'v1.33.4' : isRancherManagerVersion('2.13') ? 'v1.34.0' : 'v1.35.0',
   k8sVersion: isRancherManagerVersion('2.12') ? 'v1.33.4' : isRancherManagerVersion('2.13') ? 'v1.34.1' : 'v1.35.0',
   rke2Version: isRancherManagerVersion('2.12') ? 'v1.33.4+rke2r1' : isRancherManagerVersion('2.13') ? 'v1.34.1+rke2r1' : 'v1.35.0+rke2r1',


### PR DESCRIPTION
### What does this PR do?
This PR fixed providers chart installation post-upgrade by using the same `rancher-turtles-providers` name whenever required. It also removes chartmuseum repo removal and re-addition and solely relies on the `chartSelector` to return appropriate selector.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [ ] GitHub Actions (if applicable)

### Special notes for your reviewer:

<!-- e2e-result-start -->
### E2E Test Results:

| Run Name | Run Result | Notes |
|----------|------------|-------|
| [[4258] Rancher-head/2.14 - **@install @upgrade** dev=true destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/25325765263) | ❌ Fail | Failure is unrelated to changes in the PR |
| [[4262] Rancher-prime/2.14.1 - **@install** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/25360298842) | ✅ Pass | |
| [[4261] Rancher-head/2.14 - **@install @short** dev=true destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/25360284015) | ✅ Pass | |
<!-- e2e-result-end -->



