### PR TITLE
[updatecli] Bump k3s installer

### DIFF
--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -35,7 +35,7 @@ const (
 	k3sInstallerFile    = "k3s-install.sh"
 	k3sInstallerVersion = "v1.36.0+k3s1"
 	k3sInstallerURL     = "https://raw.githubusercontent.com/k3s-io/k3s/" + k3sInstallerVersion + "/install.sh"
-	k3sInstallerSHA256  = "8598e002e61d658fed7b7542fc6d2c66d8da6eae69e088830105d2ee1ffb6d91"
+	k3sInstallerSHA256  = "46177d4c99440b4c0311b67233823a8e8a2fc09693f6c89af1a7161e152fbfad"
 )
 
 func sha256File(filePath string) (string, error) {

--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	k3sInstallerFile    = "k3s-install.sh"
-	k3sInstallerVersion = "v1.35.4+k3s1"
+	k3sInstallerVersion = "v1.36.0+k3s1"
 	k3sInstallerURL     = "https://raw.githubusercontent.com/k3s-io/k3s/" + k3sInstallerVersion + "/install.sh"
 	k3sInstallerSHA256  = "8598e002e61d658fed7b7542fc6d2c66d8da6eae69e088830105d2ee1ffb6d91"
 )


### PR DESCRIPTION



<Actions>
    <action id="bc308357a13af12c0f2ba64d370c763fc0231a051f2b98c63d47810c3b010093">
        <h3>[updatecli] Bump k3s installer</h3>
        <details id="0af3d691ff65a61b24448519bdf0373104eb6106e6f1036e0841b9a5700e8ad0">
            <summary>Update k3sInstallerSHA256</summary>
            <p>1 file(s) updated with &#34;$1$2\&#34;46177d4c99440b4c0311b67233823a8e8a2fc09693f6c89af1a7161e152fbfad\&#34;&#34;:&#xA;&#xA;* tests/e2e/install_test.go&#xA;</p>
        </details>
        <details id="c5c7365dd3f6a20e071c8e455e157ef295c3d83cec9775b1fab1a69808a9c50b">
            <summary>Update k3sInstallerVersion</summary>
            <p>1 file(s) updated with &#34;$1$2\&#34;v1.36.0+k3s1\&#34;&#34;:&#xA;&#xA;* tests/e2e/install_test.go&#xA;</p>
            <details>
                <summary>v1.36.0+k3s1</summary>
                <pre>&lt;!-- v1.36.0+k3s1 --&gt;&#xD;&#xA;&#xD;&#xA;This release updates Kubernetes to v1.36.0, and fixes a number of issues.&#xD;&#xA;&#xD;&#xA;For more details on what&#39;s new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.36.md#changelog-since-v1350).&#xD;&#xA;&#xD;&#xA;## Changes since v1.35.0+k3s1:&#xD;&#xA;&#xD;&#xA;* Add firewall section to check-config.sh [(#13234)](https://github.com/k3s-io/k3s/pull/13234)&#xD;&#xA;* Update golangci-lint and re-enable CI linting step [(#13343)](https://github.com/k3s-io/k3s/pull/13343)&#xD;&#xA;* Enable secret encryption on existing clusters [(#13370)](https://github.com/k3s-io/k3s/pull/13370)&#xD;&#xA;* Use Get, not Head for channel page [(#13402)](https://github.com/k3s-io/k3s/pull/13402)&#xD;&#xA;* Replace temporary etcd server with raw mvcc store access [(#13368)](https://github.com/k3s-io/k3s/pull/13368)&#xD;&#xA;* Remove flannel external-ip annotations when disabled [(#13431)](https://github.com/k3s-io/k3s/pull/13431)&#xD;&#xA;* Bump local path provisioner to v0.0.34 [(#13430)](https://github.com/k3s-io/k3s/pull/13430)&#xD;&#xA;* Publish GA images to staging registry [(#13438)](https://github.com/k3s-io/k3s/pull/13438)&#xD;&#xA;* Fix atomic write in WriteSubnetFile [(#13380)](https://github.com/k3s-io/k3s/pull/13380)&#xD;&#xA;* Bump expr-lang/expr [(#13440)](https://github.com/k3s-io/k3s/pull/13440)&#xD;&#xA;* Bump spegel to v0.6.0 [(#13198)](https://github.com/k3s-io/k3s/pull/13198)&#xD;&#xA;* Update longhorn version in integration test from v1.4.0 to v1.10.1 [(#13443)](https://github.com/k3s-io/k3s/pull/13443)&#xD;&#xA;* Remove download/generate from vulncheck [(#13445)](https://github.com/k3s-io/k3s/pull/13445)&#xD;&#xA;* Add Momentum Coach AI to K3S adopters list [(#13467)](https://github.com/k3s-io/k3s/pull/13467)&#xD;&#xA;  * NONE&#xD;&#xA;* Move to rootlesskit v2 [(#13486)](https://github.com/k3s-io/k3s/pull/13486)&#xD;&#xA;* Fix CVE-2025-54410: Update docker/docker to v25.0.13 [(#13473)](https://github.com/k3s-io/k3s/pull/13473)&#xD;&#xA;* Bump etcd to v3.6.7 [(#13495)](https://github.com/k3s-io/k3s/pull/13495)&#xD;&#xA;* Add Percona and Solanica to k3s adopters [(#13510)](https://github.com/k3s-io/k3s/pull/13510)&#xD;&#xA;* Fix restart of control-plane-only nodes attempting to reconcile from local datastore [(#13534)](https://github.com/k3s-io/k3s/pull/13534)&#xD;&#xA;* Fix spegel filter for wildcards [(#13527)](https://github.com/k3s-io/k3s/pull/13527)&#xD;&#xA;* Add IPv6 loopback to kubelet-serving cert [(#13532)](https://github.com/k3s-io/k3s/pull/13532)&#xD;&#xA;* Fix handling of empty token file [(#13529)](https://github.com/k3s-io/k3s/pull/13529)&#xD;&#xA;* Use channel.yaml instead of curling for stable for kubectl install [(#13531)](https://github.com/k3s-io/k3s/pull/13531)&#xD;&#xA;* Fix VPN node IP not being applied to kubelet [(#13457)](https://github.com/k3s-io/k3s/pull/13457)&#xD;&#xA;* Bump scorecard checkout to match all other versions [(#13568)](https://github.com/k3s-io/k3s/pull/13568)&#xD;&#xA;* Explicitly close mvcc backend to fix high CPU on initial etcd server after restart [(#13569)](https://github.com/k3s-io/k3s/pull/13569)&#xD;&#xA;* Support commit builds via GHA artifacts [(#13559)](https://github.com/k3s-io/k3s/pull/13559)&#xD;&#xA;* Bump metrics-server to v0.8.1 [(#13594)](https://github.com/k3s-io/k3s/pull/13594)&#xD;&#xA;* Add registry prefix to image-list file [(#13603)](https://github.com/k3s-io/k3s/pull/13603)&#xD;&#xA;* Fix removal of init node via annotation [(#13624)](https://github.com/k3s-io/k3s/pull/13624)&#xD;&#xA;* Make artifact URL prefix configurable [(#13367)](https://github.com/k3s-io/k3s/pull/13367)&#xD;&#xA;  * Added INSTALL_K3S_ARTIFACT_URL to donwload K3s binary from a different URL&#xD;&#xA;* Install binutils-gold only for arm64 builds [(#13654)](https://github.com/k3s-io/k3s/pull/13654)&#xD;&#xA;* Rootlesskit Revert + Test Fixes [(#13681)](https://github.com/k3s-io/k3s/pull/13681)&#xD;&#xA;* Improve resilience of datastore bootstrap reconcile from etcd [(#13677)](https://github.com/k3s-io/k3s/pull/13677)&#xD;&#xA;* Assign github.event to env first [(#13715)](https://github.com/k3s-io/k3s/pull/13715)&#xD;&#xA;* Config: Add default imports to containerd base templates [(#13680)](https://github.com/k3s-io/k3s/pull/13680)&#xD;&#xA;  * Containerd config generated by k3s now includes `imports` pointing at versioned drop-in directories: `config.toml.d` for v2 config and `config-v3.toml.d` for v3 (e.g. `/var/lib/rancher/k3s/agent/etc/containerd/config.toml.d/*.toml` and `.../config-v3.toml.d/*.toml`). Additional `.toml` files in the matching directory are automatically loaded by containerd. Use these directories for drop-in config (e.g. proxy plugins, custom runtimes, or debug settings) without modifying the main config or custom templates.&#xD;&#xA;* Add nix-snapshotter support to the embedded containerd [(#13676)](https://github.com/k3s-io/k3s/pull/13676)&#xD;&#xA;  * Add nix-snapshotter plugin to the embedded containerd to enable rootless k3s + nix-snapshotter&#xD;&#xA;* Do not create etcd name file if etcd is not in use [(#13727)](https://github.com/k3s-io/k3s/pull/13727)&#xD;&#xA;* Bump rancher/mirrored-coredns-coredns image version [(#13743)](https://github.com/k3s-io/k3s/pull/13743)&#xD;&#xA;* Update packages to remove unmaintained dependencies [(#13724)](https://github.com/k3s-io/k3s/pull/13724)&#xD;&#xA;* Save cluster state before reencyrpting secrets with newly created key [(#13764)](https://github.com/k3s-io/k3s/pull/13764)&#xD;&#xA;* Bump go.opentelemetry.io/otel/sdk from 1.39.0 to 1.40.0 [(#13713)](https://github.com/k3s-io/k3s/pull/13713)&#xD;&#xA;* Bump github.com/docker/cli from 28.3.2+incompatible to 29.2.0+incompatible [(#13730)](https://github.com/k3s-io/k3s/pull/13730)&#xD;&#xA;* Build(deps): bump github.com/pion/dtls/v3 from 3.0.6 to 3.0.11 [(#13645)](https://github.com/k3s-io/k3s/pull/13645)&#xD;&#xA;* Use etcd-snapshot-retention as default for s3 if etcd-s3-retention is not set [(#13770)](https://github.com/k3s-io/k3s/pull/13770)&#xD;&#xA;* Install.sh: Simplify handling for fedora rpm-ostree based distributions [(#13712)](https://github.com/k3s-io/k3s/pull/13712)&#xD;&#xA;* Bump cni plugins to v1.9.1 [(#13817)](https://github.com/k3s-io/k3s/pull/13817)&#xD;&#xA;* Simplify snapshot compress/decompress logic [(#13826)](https://github.com/k3s-io/k3s/pull/13826)&#xD;&#xA;* Fix typo: overriden -&gt; overridden in snapshot_handler.go [(#13847)](https://github.com/k3s-io/k3s/pull/13847)&#xD;&#xA;* Fix: typo in etcd membership error message [(#13848)](https://github.com/k3s-io/k3s/pull/13848)&#xD;&#xA;* Bump helm-controller for job race fix [(#13853)](https://github.com/k3s-io/k3s/pull/13853)&#xD;&#xA;* Add context to controller event recorders [(#13856)](https://github.com/k3s-io/k3s/pull/13856)&#xD;&#xA;* Dapper is kill [(#13860)](https://github.com/k3s-io/k3s/pull/13860)&#xD;&#xA;* Add sipgate to the list of adopters [(#13881)](https://github.com/k3s-io/k3s/pull/13881)&#xD;&#xA;* Add Rocket Technologies to the list of adopters [(#13890)](https://github.com/k3s-io/k3s/pull/13890)&#xD;&#xA;* Pin govulncheck GHA version [(#13887)](https://github.com/k3s-io/k3s/pull/13887)&#xD;&#xA;* Verify sha256sum for kubelet, vagrant zip and go binary [(#13889)](https://github.com/k3s-io/k3s/pull/13889)&#xD;&#xA;* Check the k3s-root sha256sum [(#13888)](https://github.com/k3s-io/k3s/pull/13888)&#xD;&#xA;* Build(deps): bump github.com/go-jose/go-jose/v4 from 4.1.3 to 4.1.4 [(#13891)](https://github.com/k3s-io/k3s/pull/13891)&#xD;&#xA;* Fix reproducibility of embedded data tarball [(#13875)](https://github.com/k3s-io/k3s/pull/13875)&#xD;&#xA;* Build(deps): bump github.com/buger/jsonparser from 1.1.1 to 1.1.2 [(#13837)](https://github.com/k3s-io/k3s/pull/13837)&#xD;&#xA;* Build(deps): bump github.com/nats-io/nats-server/v2 from 2.12.2 to 2.12.6 [(#13852)](https://github.com/k3s-io/k3s/pull/13852)&#xD;&#xA;* Fix S3 test to account for change to s3mock [(#13906)](https://github.com/k3s-io/k3s/pull/13906)&#xD;&#xA;* Bump runc/spegel/helm-controller/kine [(#13909)](https://github.com/k3s-io/k3s/pull/13909)&#xD;&#xA;  * Bump runc to v1.4.2&#xD;&#xA;  * Bump spegel to v0.6.0-k3s2&#xD;&#xA;  * Bump helm-controller to v0.17.1&#xD;&#xA;  * Bump kine to v0.14.16&#xD;&#xA;* Fix embedded executor VPN config injection [(#13920)](https://github.com/k3s-io/k3s/pull/13920)&#xD;&#xA;* Bump containerd to v2.2.3 [(#13931)](https://github.com/k3s-io/k3s/pull/13931)&#xD;&#xA;* Bump flannel to v0.28.4 [(#13937)](https://github.com/k3s-io/k3s/pull/13937)&#xD;&#xA;* Immutable release changes [(#13902)](https://github.com/k3s-io/k3s/pull/13902)&#xD;&#xA;* Bump Traefik to 3.6.13 [(#13969)](https://github.com/k3s-io/k3s/pull/13969)&#xD;&#xA;* Switch from draft to pre-release [(#13951)](https://github.com/k3s-io/k3s/pull/13951)&#xD;&#xA;* Fix SANs added from comma-separated node-external-ip list [(#13989)](https://github.com/k3s-io/k3s/pull/13989)&#xD;&#xA;* Fix docker dualstack test [(#13994)](https://github.com/k3s-io/k3s/pull/13994)&#xD;&#xA;* Bump klipper-helm image for revision check fix [(#13995)](https://github.com/k3s-io/k3s/pull/13995)&#xD;&#xA;* Bump upstream to v1.36 [(#13986)](https://github.com/k3s-io/k3s/pull/13986)&#xD;&#xA;* Fix kubectl exec when using docker [(#14021)](https://github.com/k3s-io/k3s/pull/14021)&#xD;&#xA;&#xD;&#xA;&#xD;&#xA;## Embedded Component Versions&#xD;&#xA;| Component | Version |&#xD;&#xA;|---|---|&#xD;&#xA;| Kubernetes | [v1.36.0](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.36.md#v1360) |&#xD;&#xA;| Kine | [v0.14.16](https://github.com/k3s-io/kine/releases/tag/v0.14.16) |&#xD;&#xA;| SQLite | [3.51.3](https://sqlite.org/releaselog/3_51_3.html) |&#xD;&#xA;| Etcd | [v3.6.7-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.6.7-k3s1) |&#xD;&#xA;| Containerd | [v2.2.3-k3s1](https://github.com/k3s-io/containerd/releases/tag/v2.2.3-k3s1) |&#xD;&#xA;| Runc | [v1.4.2](https://github.com/opencontainers/runc/releases/tag/v1.4.2) |&#xD;&#xA;| Flannel | [v0.28.4](https://github.com/flannel-io/flannel/releases/tag/v0.28.4) | &#xD;&#xA;| Metrics-server | [v0.8.1](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.1) |&#xD;&#xA;| Traefik | [v3.6.13](https://github.com/traefik/traefik/releases/tag/v3.6.13) |&#xD;&#xA;| CoreDNS | [v1.14.2](https://github.com/coredns/coredns/releases/tag/v1.14.2) | &#xD;&#xA;| Helm-controller | [v0.17.1](https://github.com/k3s-io/helm-controller/releases/tag/v0.17.1) |&#xD;&#xA;| Local-path-provisioner | [v0.0.35](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.35) |&#xD;&#xA;&#xD;&#xA;## Helpful Links&#xD;&#xA;As always, we welcome and appreciate feedback from our community of users. Please feel free to:&#xD;&#xA;- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)&#xD;&#xA;- [Join our Slack channel](https://slack.rancher.io/)&#xD;&#xA;- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.&#xD;&#xA;- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)&#xD;&#xA;</pre>
            </details>
        </details>
        <a href="https://github.com/rancher/rancher-turtles-e2e/actions/runs/25588022352">GitHub Action workflow link</a>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50" />
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>



<!-- e2e-result-start -->
### E2E Test Results:

| Run Name | Run Result | Notes |
|----------|------------|-------|
| [[4303] Rancher-head/2.14 - **@install** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/25652878746) | ✅ Pass | |
| [[4305] Rancher-prime/2.12.9 - **@install** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/25653794281) | ✅ Pass | |
<!-- e2e-result-end -->

