### PR TITLE
Refactor RancherClusterDeletion & add Re-import cluster test

### DIFF
--- a/tests/cypress/latest/e2e/capa_eks_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capa_eks_clusterclass.spec.ts
@@ -1,6 +1,6 @@
 import '../support/commands';
 import {getClusterName, isAPIv1beta1, isRancherManagerVersion, skipClusterDeletion} from '../support/utils';
-import {capaResourcesCleanup, capiClusterDeletion, importedRancherClusterDeletion} from "../support/cleanup_support";
+import {capaResourcesCleanup, capiClusterDeletion, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
 import {vars} from '../support/variables';
 
 Cypress.config();
@@ -104,11 +104,10 @@ describe('Import CAPA EKS Class-Cluster', {tags: '@full'}, () => {
       cy.checkCAPIClusterActive(clusterName);
     })
 
-    it('Remove imported CAPA cluster from Rancher Manager', {retries: 1}, () => {
+    it('Remove imported CAPA cluster from Rancher Manager', () => {
       // Delete the imported cluster
       // Ensure that the provisioned CAPI cluster still exists
-      // this check can fail, ref: https://github.com/rancher/turtles/issues/1587
-      importedRancherClusterDeletion(clusterName);
+      importedRancherv3ClusterDeletion(clusterName);
     })
   })
 

--- a/tests/cypress/latest/e2e/capa_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capa_kubeadm_clusterclass.spec.ts
@@ -1,6 +1,6 @@
 import '../support/commands';
 import {getClusterName, isAPIv1beta1, isRancherManagerVersion, skipClusterDeletion} from '../support/utils';
-import {capaResourcesCleanup, capiClusterDeletion, importedRancherClusterDeletion} from "../support/cleanup_support";
+import {capaResourcesCleanup, capiClusterDeletion, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
 import {vars} from '../support/variables';
 
 Cypress.config();
@@ -109,11 +109,10 @@ describe('Import CAPA Kubeadm Class-Cluster', {tags: '@full'}, () => {
       cy.checkCAPIClusterActive(clusterName);
     })
 
-    it('Remove imported CAPA cluster from Rancher Manager', {retries: 1}, () => {
+    it('Remove imported CAPA cluster from Rancher Manager', () => {
       // Delete the imported cluster
       // Ensure that the provisioned CAPI cluster still exists
-      // this check can fail, ref: https://github.com/rancher/turtles/issues/1587
-      importedRancherClusterDeletion(clusterName);
+      importedRancherv3ClusterDeletion(clusterName);
     })
   })
 

--- a/tests/cypress/latest/e2e/capa_rke2_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capa_rke2_clusterclass.spec.ts
@@ -1,6 +1,6 @@
 import '../support/commands';
 import {getClusterName, isAPIv1beta1, isRancherManagerVersion, skipClusterDeletion} from '../support/utils';
-import {capaResourcesCleanup, capiClusterDeletion, importedRancherClusterDeletion} from "../support/cleanup_support";
+import {capaResourcesCleanup, capiClusterDeletion, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
 import {vars} from '../support/variables';
 
 Cypress.config();
@@ -114,7 +114,7 @@ describe('Import CAPA RKE2 Class-Cluster', {tags: '@full'}, () => {
       // Delete the imported cluster
       // Ensure that the provisioned CAPI cluster still exists
       // this check can fail, ref: https://github.com/rancher/turtles/issues/1587
-      importedRancherClusterDeletion(clusterName);
+      importedRancherv3ClusterDeletion(clusterName);
     })
   })
 

--- a/tests/cypress/latest/e2e/capd_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capd_kubeadm_clusterclass.spec.ts
@@ -13,7 +13,7 @@ limitations under the License.
 
 import '../support/commands';
 import {getClusterName, isAPIv1beta1, isRancherManagerVersion, skipClusterDeletion} from '../support/utils';
-import {capiClusterDeletion, importedRancherClusterDeletion} from "../support/cleanup_support";
+import {capiClusterDeletion, importedRancherv3ClusterDeletion, reImportRancherv3Cluster} from "../support/cleanup_support";
 import {vars} from '../support/variables';
 
 Cypress.config();
@@ -142,11 +142,18 @@ describe('Import CAPD Kubeadm Class-Cluster', {tags: '@short'}, () => {
       })
     );
 
-    xit('Remove imported CAPD cluster from Rancher Manager', {retries: 1}, () => {
+    it('Remove imported CAPD cluster from Rancher Manager', () => {
       // Delete the imported cluster
       // Ensure that the provisioned CAPI cluster still exists
-      // this check can fail, ref: https://github.com/rancher/turtles/issues/1587
-      importedRancherClusterDeletion(clusterName);
+      importedRancherv3ClusterDeletion(clusterName);
+    })
+
+    it('Re-import the CAPD cluster and remove from Rancher Manager', () => {
+      reImportRancherv3Cluster(clusterName);
+
+      // Delete the imported cluster
+      // Ensure that the provisioned CAPI cluster still exists
+      importedRancherv3ClusterDeletion(clusterName);
     })
   })
 

--- a/tests/cypress/latest/e2e/capd_rke2_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capd_rke2_clusterclass.spec.ts
@@ -20,7 +20,7 @@ import {
   turtlesNamespace
 } from '../support/utils';
 import {Question} from '../support/structs';
-import {capdResourcesCleanup, capiClusterDeletion, importedRancherClusterDeletion} from "../support/cleanup_support";
+import {capdResourcesCleanup, capiClusterDeletion, importedRancherv3ClusterDeletion, reImportRancherv3Cluster} from "../support/cleanup_support";
 import {vars} from '../support/variables';
 
 
@@ -142,11 +142,18 @@ describe('Import CAPD RKE2 Class-Cluster', {tags: '@short'}, () => {
     );
     }
 
-    it('Remove imported CAPD cluster from Rancher Manager', {retries: 1}, () => {
+    it('Remove imported CAPD cluster from Rancher Manager', () => {
       // Delete the imported cluster
       // Ensure that the provisioned CAPI cluster still exists
-      // this check can fail, ref: https://github.com/rancher/turtles/issues/1587
-      importedRancherClusterDeletion(clusterName);
+      importedRancherv3ClusterDeletion(clusterName);
+    })
+
+    it('Re-import the CAPD cluster and remove from Rancher Manager', () => {
+      reImportRancherv3Cluster(clusterName);
+
+      // Delete the imported cluster
+      // Ensure that the provisioned CAPI cluster still exists
+      importedRancherv3ClusterDeletion(clusterName);
     })
   })
 

--- a/tests/cypress/latest/e2e/capd_rke2_fleet_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capd_rke2_fleet_clusterclass.spec.ts
@@ -14,7 +14,7 @@ limitations under the License.
 import '../support/commands';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import {isUseCAAPFSupported, skipClusterDeletion} from '../support/utils';
-import {capdResourcesCleanup, capiClusterDeletion, importedRancherClusterDeletion} from "../support/cleanup_support";
+import {capdResourcesCleanup, capiClusterDeletion, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
 import {vars} from '../support/variables';
 
 Cypress.config();
@@ -100,11 +100,10 @@ describe('Import CAPD RKE2 (Default CNI) Class-Cluster using Fleet', {tags: '@sh
       cy.checkChart(clusterName, 'Install', 'Logging', 'cattle-logging-system');
     })
 
-    it('Remove imported CAPD cluster from Rancher Manager', {retries: 1}, () => {
+    it('Remove imported CAPD cluster from Rancher Manager', () => {
       // Delete the imported cluster
       // Ensure that the provisioned CAPI cluster still exists
-      // this check can fail, ref: https://github.com/rancher/turtles/issues/1587
-      importedRancherClusterDeletion(clusterName);
+      importedRancherv3ClusterDeletion(clusterName);
     })
   })
 

--- a/tests/cypress/latest/e2e/capd_rke2_migration_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capd_rke2_migration_clusterclass.spec.ts
@@ -13,7 +13,7 @@ limitations under the License.
 
 import '../support/commands';
 import {getClusterName, isRancherManagerVersion, turtlesNamespace} from '../support/utils';
-import {capdResourcesCleanup, capiClusterDeletion, importedRancherClusterDeletion} from "../support/cleanup_support";
+import {capdResourcesCleanup, capiClusterDeletion, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
 import {vars} from '../support/variables';
 
 Cypress.config();
@@ -162,11 +162,10 @@ describe('Import CAPD RKE2 Class-Cluster for Migration', {tags: '@migration'}, (
         cy.checkCAPIClusterActive(clusterName);
       })
 
-      it('Remove imported CAPD cluster from Rancher Manager and Delete the CAPD cluster', {retries: 1}, () => {
+      it('Remove imported CAPD cluster from Rancher Manager and Delete the CAPD cluster', () => {
         // Delete the imported cluster
         // Ensure that the provisioned CAPI cluster still exists
-        // this check can fail, ref: https://github.com/rancher/turtles/issues/1587
-        importedRancherClusterDeletion(clusterName);
+        importedRancherv3ClusterDeletion(clusterName);
         // Remove CAPI Resources related to the cluster
         capiClusterDeletion(clusterName, timeout);
       })

--- a/tests/cypress/latest/e2e/capd_rke2_nocaapf_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capd_rke2_nocaapf_clusterclass.spec.ts
@@ -1,7 +1,7 @@
 import '../support/commands';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import {isUseCAAPFSupported, skipClusterDeletion, turtlesNamespace} from '../support/utils';
-import {capdResourcesCleanup, capiClusterDeletion, importedRancherClusterDeletion} from "../support/cleanup_support";
+import {capdResourcesCleanup, capiClusterDeletion, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
 import {vars} from '../support/variables';
 
 Cypress.config();
@@ -127,11 +127,10 @@ describe('Import CAPD RKE2 (Default CNI & No-Caapf) Class-Cluster using Fleet', 
       cy.checkChart(clusterName, 'Install', 'Logging', 'cattle-logging-system');
     })
 
-    it('Remove imported CAPD cluster from Rancher Manager', {retries: 1}, () => {
+    it('Remove imported CAPD cluster from Rancher Manager', () => {
       // Delete the imported cluster
       // Ensure that the provisioned CAPI cluster still exists
-      // this check can fail, ref: https://github.com/rancher/turtles/issues/1587
-      importedRancherClusterDeletion(clusterName);
+      importedRancherv3ClusterDeletion(clusterName);
     })
   })
 

--- a/tests/cypress/latest/e2e/capd_rke2_upgrade_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capd_rke2_upgrade_clusterclass.spec.ts
@@ -1,6 +1,6 @@
 import '../support/commands';
 import {getClusterName, isRancherManagerVersion, isAPIv1beta1} from '../support/utils';
-import {capdResourcesCleanup, capiClusterDeletion, importedRancherClusterDeletion} from "../support/cleanup_support";
+import {capdResourcesCleanup, capiClusterDeletion, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
 import {vars} from '../support/variables';
 
 Cypress.config();
@@ -147,11 +147,10 @@ describe('Import CAPD RKE2 Class-Cluster for Upgrade', {tags: '@upgrade'}, () =>
         cy.checkChart(clusterName, 'Install', 'Logging', 'cattle-logging-system');
       })
 
-      it('Remove imported CAPD cluster from Rancher Manager and Delete the CAPD cluster', {retries: 1}, () => {
+      it('Remove imported CAPD cluster from Rancher Manager and Delete the CAPD cluster', () => {
         // Delete the imported cluster
         // Ensure that the provisioned CAPI cluster still exists
-        // this check can fail, ref: https://github.com/rancher/turtles/issues/1587
-        importedRancherClusterDeletion(clusterName);
+        importedRancherv3ClusterDeletion(clusterName);
         // Remove CAPI Resources related to the cluster
         capiClusterDeletion(clusterName, timeout);
       })

--- a/tests/cypress/latest/e2e/capg_gke_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capg_gke_clusterclass.spec.ts
@@ -1,7 +1,7 @@
 import '../support/commands';
 
 import {getClusterName, isRancherManagerVersion, skipClusterDeletion} from '../support/utils';
-import {capiClusterDeletion, importedRancherClusterDeletion} from "../support/cleanup_support";
+import {capiClusterDeletion, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
 import {vars} from '../support/variables';
 
 
@@ -86,11 +86,10 @@ describe('Import CAPG GKE Class-Cluster', {tags: '@full'}, () => {
     );
 
     qase('403',
-      it('Remove imported CAPG cluster from Rancher Manager', {retries: 1}, () => {
+      it('Remove imported CAPG cluster from Rancher Manager',() => {
       // Delete the imported cluster
       // Ensure that the provisioned CAPI cluster still exists
-      // this check can fail, ref: https://github.com/rancher/turtles/issues/1587
-      importedRancherClusterDeletion(clusterName);
+      importedRancherv3ClusterDeletion(clusterName);
     })
     );
   })

--- a/tests/cypress/latest/e2e/capg_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capg_kubeadm_clusterclass.spec.ts
@@ -1,6 +1,6 @@
 import '../support/commands';
 import {getClusterName, isAPIv1beta1, skipClusterDeletion} from '../support/utils';
-import {capiClusterDeletion, importedRancherClusterDeletion} from "../support/cleanup_support";
+import {capiClusterDeletion, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
 import {vars} from '../support/variables';
 
 Cypress.config();
@@ -102,11 +102,10 @@ describe('Import CAPG Kubeadm Class-Cluster', {tags: '@full'}, () => {
       cy.checkCAPIClusterActive(clusterName);
     })
 
-    it('Remove imported CAPG cluster from Rancher Manager', {retries: 1}, () => {
+    it('Remove imported CAPG cluster from Rancher Manager', () => {
       // Delete the imported cluster
       // Ensure that the provisioned CAPI cluster still exists
-      // this check can fail, ref: https://github.com/rancher/turtles/issues/1587
-      importedRancherClusterDeletion(clusterName);
+      importedRancherv3ClusterDeletion(clusterName);
     })
   })
 

--- a/tests/cypress/latest/e2e/capv_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capv_kubeadm_clusterclass.spec.ts
@@ -1,7 +1,7 @@
 import '../support/commands';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import {isAPIv1beta1, isRancherManagerVersion, skipClusterDeletion} from '../support/utils';
-import {capiClusterDeletion, capvResourcesCleanup, importedRancherClusterDeletion} from "../support/cleanup_support";
+import {capiClusterDeletion, capvResourcesCleanup, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
 import {vars} from '../support/variables';
 
 Cypress.config();
@@ -115,11 +115,10 @@ describe('Import CAPV Kubeadm Class-Cluster', {tags: '@vsphere'}, () => {
       cy.checkChart(clusterName, 'Install', 'Logging', 'cattle-logging-system');
     })
 
-    it('Remove imported CAPV cluster from Rancher Manager', {retries: 1}, () => {
+    it('Remove imported CAPV cluster from Rancher Manager', () => {
       // Delete the imported cluster
       // Ensure that the provisioned CAPI cluster still exists
-      // this check can fail, ref: https://github.com/rancher/turtles/issues/1587
-      importedRancherClusterDeletion(clusterName);
+      importedRancherv3ClusterDeletion(clusterName);
     })
   })
 

--- a/tests/cypress/latest/e2e/capv_rke2_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capv_rke2_clusterclass.spec.ts
@@ -1,7 +1,7 @@
 import '../support/commands';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
 import {isAPIv1beta1, isRancherManagerVersion, skipClusterDeletion} from '../support/utils';
-import {capiClusterDeletion, capvResourcesCleanup, importedRancherClusterDeletion} from "../support/cleanup_support";
+import {capiClusterDeletion, capvResourcesCleanup, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
 import {vars} from '../support/variables';
 
 Cypress.config();
@@ -205,11 +205,10 @@ describe('Import CAPV RKE2 Class-Cluster', {tags: '@vsphere'}, () => {
       cy.checkChart(clusterName, 'Install', 'Logging', 'cattle-logging-system');
     })
 
-    it('Remove imported CAPV cluster from Rancher Manager', {retries: 1}, () => {
+    it('Remove imported CAPV cluster from Rancher Manager', () => {
       // Delete the imported cluster
       // Ensure that the provisioned CAPI cluster still exists
-      // this check can fail, ref: https://github.com/rancher/turtles/issues/1587
-      importedRancherClusterDeletion(clusterName);
+      importedRancherv3ClusterDeletion(clusterName);
     })
   })
 

--- a/tests/cypress/latest/e2e/capz_aks_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capz_aks_clusterclass.spec.ts
@@ -1,6 +1,6 @@
 import '../support/commands';
 import {getClusterName, isAPIv1beta1, skipClusterDeletion} from '../support/utils';
-import {capiClusterDeletion, capzResourcesCleanup, importedRancherClusterDeletion} from "../support/cleanup_support";
+import {capiClusterDeletion, capzResourcesCleanup, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
 import {vars} from '../support/variables';
 
 Cypress.config();
@@ -77,7 +77,7 @@ describe('Import CAPZ AKS Class-Cluster', {tags: '@full'}, () => {
       // Delete the imported cluster
       // Ensure that the provisioned CAPI cluster still exists
       // this check can fail, ref: https://github.com/rancher/turtles/issues/1587
-      importedRancherClusterDeletion(clusterName);
+      importedRancherv3ClusterDeletion(clusterName);
     })
   })
 

--- a/tests/cypress/latest/e2e/capz_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capz_kubeadm_clusterclass.spec.ts
@@ -1,6 +1,6 @@
 import '../support/commands';
 import {getClusterName, isAPIv1beta1, skipClusterDeletion} from '../support/utils';
-import {capiClusterDeletion, capzResourcesCleanup, importedRancherClusterDeletion} from "../support/cleanup_support";
+import {capiClusterDeletion, capzResourcesCleanup, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
 import {vars} from '../support/variables';
 
 Cypress.config();
@@ -99,11 +99,10 @@ describe('Import CAPZ Kubeadm Class-Cluster', {tags: '@full'}, () => {
       cy.checkCAPIClusterActive(clusterName);
     })
 
-    it('Remove imported CAPZ cluster from Rancher Manager', {retries: 1}, () => {
+    it('Remove imported CAPZ cluster from Rancher Manager', () => {
       // Delete the imported cluster
       // Ensure that the provisioned CAPI cluster still exists
-      // this check can fail, ref: https://github.com/rancher/turtles/issues/1587
-      importedRancherClusterDeletion(clusterName);
+      importedRancherv3ClusterDeletion(clusterName);
     })
   })
 

--- a/tests/cypress/latest/e2e/capz_rke2_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capz_rke2_clusterclass.spec.ts
@@ -1,6 +1,6 @@
 import '../support/commands';
 import {getClusterName, isAPIv1beta1, skipClusterDeletion} from '../support/utils';
-import {capiClusterDeletion, capzResourcesCleanup, importedRancherClusterDeletion} from "../support/cleanup_support";
+import {capiClusterDeletion, capzResourcesCleanup, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
 import {vars} from '../support/variables';
 
 Cypress.config();
@@ -106,11 +106,10 @@ describe('Import CAPZ RKE2 Class-Cluster', {tags: '@full'}, () => {
       cy.checkCAPIClusterActive(clusterName);
     })
 
-    it('Remove imported CAPZ cluster from Rancher Manager', {retries: 1}, () => {
+    it('Remove imported CAPZ cluster from Rancher Manager', () => {
       // Delete the imported cluster
       // Ensure that the provisioned CAPI cluster still exists
-      // this check can fail, ref: https://github.com/rancher/turtles/issues/1587
-      importedRancherClusterDeletion(clusterName);
+      importedRancherv3ClusterDeletion(clusterName);
     })
 
   })

--- a/tests/cypress/latest/e2e/providers_setup.spec.ts
+++ b/tests/cypress/latest/e2e/providers_setup.spec.ts
@@ -112,7 +112,7 @@ describe('Enable CAPI Providers', () => {
       kubeadm: 'v1.12.2',
       fleet: 'v0.14.1',
       vsphere: 'v1.15.2',
-      amazon: 'v2.10.1',
+      amazon: 'v2.11.1',
       google: 'v1.11.1',
       azure: 'v1.22.0'
     },
@@ -122,7 +122,7 @@ describe('Enable CAPI Providers', () => {
       kubeadm: 'v1.12.2',
       fleet: 'v0.14.1',
       vsphere: 'v1.15.2',
-      amazon: 'v2.10.1',
+      amazon: 'v2.11.1',
       google: 'v1.11.1',
       azure: 'v1.22.0'
     }

--- a/tests/cypress/latest/support/cleanup_support.ts
+++ b/tests/cypress/latest/support/cleanup_support.ts
@@ -1,7 +1,16 @@
-export function importedRancherClusterDeletion(clusterName: string) {
-  // Delete the imported cluster from Cluster Management
-  cy.deleteCluster(clusterName);
+import {vars} from '../support/variables';
 
+export const v3ClusterDeleteCommand = (clusterName: string): string => {
+  return `kubectl delete clusters.management.cattle.io -l cluster-api.cattle.io/capi-cluster-owner=${clusterName} -l cluster-api.cattle.io/capi-cluster-owner-ns=${vars.capiClustersNS}`;
+};
+
+export const reImportClusterPatchCommand = (clusterName: string): string => {
+  return `kubectl -n ${vars.capiClustersNS} patch clusters.cluster.x-k8s.io ${clusterName} --type="json" -p='[{"op":"remove","path":"/metadata/annotations/imported"}]'`;
+};
+
+export function importedRancherv3ClusterDeletion(clusterName: string) {
+  // Delete the imported mgmt v3 cluster from Cluster Management using kubectl
+  cy.kubectlExecute(v3ClusterDeleteCommand(clusterName));
 
   // Ensure the cluster is not available on the home page
   cy.goToHome();
@@ -9,6 +18,28 @@ export function importedRancherClusterDeletion(clusterName: string) {
 
   // Ensure that the provisioned cluster/ CAPI resource related to the cluster still exists
   cy.checkCAPIClusterProvisioned(clusterName);
+
+  // Check the annotation is set on CAPI cluster
+  cy.viewCAPIClusterYAML(clusterName);
+  cy.get('.CodeMirror').then((editor) => {
+    // @ts-expect-error known error with CodeMirror
+    const text = editor[0].CodeMirror.getValue();
+    expect(text).to.include("imported: 'true'");
+  });
+}
+
+export function reImportRancherv3Cluster(clusterName: string) {
+  // Re-import the deleted mgmt v3 cluster in Cluster Management using kubectl
+  cy.kubectlExecute(reImportClusterPatchCommand(clusterName));
+
+  // Check child cluster is auto-imported
+  // This is checked by ensuring the cluster is available in navigation menu
+  cy.goToHome();
+  cy.contains(clusterName).should('exist');
+
+  // Check cluster is Active
+  cy.searchCluster(clusterName);
+  cy.contains(new RegExp('Active.*' + clusterName), {timeout: vars.shortTimeout});
 }
 
 export function capiClusterDeletion(clusterName: string, timeout: number, clusterRepoName?: string, extraDeleteSteps: boolean = false) {

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -1372,6 +1372,19 @@ Cypress.Commands.add('checkExternalFleetAnnotation', (clusterName, required = tr
   });
 });
 
+// Command to execute on kubectl shell
+Cypress.Commands.add('kubectlExecute', (command) => {
+  cy.searchCluster('local');
+  cy.getBySel('sortable-table-0-action-button').click();
+  cy.get('i.icon.group-icon.icon-terminal').should('be.visible').click();
+  cy.contains('Connected').should('be.visible');
+  cy.get('.shell-body')
+    .type(command, {parseSpecialCharSequences: false})
+    .type('{enter}');
+  cy.wait(2000);
+  cy.getBySel('wm-tab-close-button').click();
+});
+
 // TODO: Add assertFunc(text: string) param
 Cypress.Commands.add('viewCAPIClusterYAML', (clusterName) => {
   // Check CAPI cluster using its name

--- a/tests/cypress/latest/support/e2e.ts
+++ b/tests/cypress/latest/support/e2e.ts
@@ -87,6 +87,7 @@ declare global {
       createDockerAuthSecret(): Chainable<Element>;
       checkExternalFleetAnnotation(clustername: string, required?: boolean): Chainable<Element>;
       viewCAPIClusterYAML(clustername: string): Chainable<Element>;
+      kubectlExecute(command: string): Chainable<Element>;
       // Functions declared in capz_support.js
       createAzureClusterIdentity(clientID: string, tenantID: string, clientSecret: string): Chainable<Element>;
       createAzureASOCredential(clientID: string, tenantID: string, clientSecret: string, subscriptionID: string): Chainable<Element>;


### PR DESCRIPTION
### What does this PR do?
- Refactor importedRancherClusterDeletion to delete Rancher v3 cluster
- Adds re-import CAPi cluster test
- Adds kubectlExecute function

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions:
:green_circle: [@short](https://github.com/rancher/rancher-turtles-e2e/actions/runs/25676973438)

### Special notes for your reviewer:

<!-- e2e-result-start -->
### E2E Test Results:

| Run Name | Run Result | Notes |
|----------|------------|-------|
| [[4315] Rancher-head/2.14 - **@install @vsphere** dev=true destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/25676997096) | ❌ Fail | |
<!-- e2e-result-end -->

