### PR TITLE
[updatecli] Bump Helm stack

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -306,7 +306,7 @@ jobs:
       - name: Install helm
         run: |
           HELM_VERSION="3.21.0"
-          HELM_SHA256="258e830a9e613c8a7a302d6059b4bb3b9758f2f3e1bb8ea0d707ce10a9a72fea"
+          HELM_SHA256="0093eb572e3d2380f094df162ddb525e219249de88957afe24cfbb19632acd36"
           curl -sk https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz -o helm.tar.gz
           echo "${HELM_SHA256}  helm.tar.gz" | sha256sum -c -
           sudo tar -xzf helm.tar.gz --strip-components=1 -C /usr/local/bin/ linux-amd64/helm && rm helm.tar.gz

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -305,7 +305,7 @@ jobs:
           password: ${{ secrets.docker_auth_password }}
       - name: Install helm
         run: |
-          HELM_VERSION="3.20.2"
+          HELM_VERSION="3.21.0"
           HELM_SHA256="258e830a9e613c8a7a302d6059b4bb3b9758f2f3e1bb8ea0d707ce10a9a72fea"
           curl -sk https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz -o helm.tar.gz
           echo "${HELM_SHA256}  helm.tar.gz" | sha256sum -c -


### PR DESCRIPTION



<Actions>
    <action id="d4271afe8f58573b28289884a1c8859d4c29d4abd1f0d09d8f05af758035285f">
        <h3>[updatecli] Bump Helm stack</h3>
        <details id="546c528066bb65923088b9abe20aeced998982325838358dfd396721e4715c3c">
            <summary>Update HELM_SHA256</summary>
            <p>1 file(s) updated with &#34;HELM_SHA256=\&#34;0093eb572e3d2380f094df162ddb525e219249de88957afe24cfbb19632acd36\&#34;&#34;:&#xA;&#xA;* .github/workflows/master-e2e.yaml&#xA;</p>
        </details>
        <details id="6ae61a818667abb123484ceaf5ef5b7973616224d29131cbee8e03330c381b35">
            <summary>Update HELM_VERSION</summary>
            <p>1 file(s) updated with &#34;HELM_VERSION=\&#34;3.21.0\&#34;&#34;:&#xA;&#xA;* .github/workflows/master-e2e.yaml&#xA;</p>
            <details>
                <summary>v3.21.0</summary>
                <pre>Helm v3.21.0 is a feature release. Users are encouraged to upgrade for the best experience.&#xD;&#xA;&#xD;&#xA;&gt; [!WARNING]&#xD;&#xA;&gt; Helm v3 is approaching end-of-life. Please update to Helm v4.&#xD;&#xA;&#xD;&#xA;The community keeps growing, and we&#39;d love to see you there!&#xD;&#xA;&#xD;&#xA;- Join the discussion in [Kubernetes Slack](https://kubernetes.slack.com):&#xD;&#xA;  -  for questions and just to hang out&#xD;&#xA;  -  for discussing PRs, code, and bugs&#xD;&#xA;- Hang out at the Public Developer Call: Thursday, 9:30 Pacific via [Zoom](https://zoom.us/j/696660622)&#xD;&#xA;- Test, debug, and contribute charts: [ArtifactHub/packages](https://artifacthub.io/packages/search?kind=0)&#xD;&#xA;&#xD;&#xA;## Notable Changes&#xD;&#xA;&#xD;&#xA;- Kubernetes client libraries to v1.36&#xD;&#xA;- notable changes here&#xD;&#xA;&#xD;&#xA;## Installation and Upgrading&#xD;&#xA;&#xD;&#xA;Download Helm v3.21.0. The common platform binaries are here:&#xD;&#xA;&#xD;&#xA;- [MacOS amd64](https://get.helm.sh/helm-v3.21.0-darwin-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.21.0-darwin-amd64.tar.gz.sha256sum) / 8bc0c1f85f8738cc3cda4a2cc73047145bcdcb1f4d9cdcc29073037bfb22fa2e)&#xD;&#xA;- [MacOS arm64](https://get.helm.sh/helm-v3.21.0-darwin-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.21.0-darwin-arm64.tar.gz.sha256sum) / 68bfbdc022c543a2a022597b20298216877e98abe6e4a345d3ecf114d79cae5f)&#xD;&#xA;- [Linux amd64](https://get.helm.sh/helm-v3.21.0-linux-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.21.0-linux-amd64.tar.gz.sha256sum) / 0093eb572e3d2380f094df162ddb525e219249de88957afe24cfbb19632acd36)&#xD;&#xA;- [Linux arm](https://get.helm.sh/helm-v3.21.0-linux-arm.tar.gz) ([checksum](https://get.helm.sh/helm-v3.21.0-linux-arm.tar.gz.sha256sum) / d310ac387324538a37192e8e13628eb1def2596bbac6b6481ae20d8d5e3532bd)&#xD;&#xA;- [Linux arm64](https://get.helm.sh/helm-v3.21.0-linux-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.21.0-linux-arm64.tar.gz.sha256sum) / 8de5a0c9a47431e59fd560e91e0779c8cf9316c383da7efb84128a4c339ecb2d)&#xD;&#xA;- [Linux i386](https://get.helm.sh/helm-v3.21.0-linux-386.tar.gz) ([checksum](https://get.helm.sh/helm-v3.21.0-linux-386.tar.gz.sha256sum) / fc85f14c9ce7e6a48a2b19a97edbc5529ed7aa2bc10f3d2c241e1c2ef12ccd22)&#xD;&#xA;- [Linux ppc64le](https://get.helm.sh/helm-v3.21.0-linux-ppc64le.tar.gz) ([checksum](https://get.helm.sh/helm-v3.21.0-linux-ppc64le.tar.gz.sha256sum) / e2dced0f903acda417f879012c7e09ca461000e26a04e8f7a1cfe0dcf495f62c)&#xD;&#xA;- [Linux s390x](https://get.helm.sh/helm-v3.21.0-linux-s390x.tar.gz) ([checksum](https://get.helm.sh/helm-v3.21.0-linux-s390x.tar.gz.sha256sum) / a176d7460a615b8df5b1a58ecf09fcc731c7733ca4cf10116cf198575b0371b5)&#xD;&#xA;- [Linux riscv64](https://get.helm.sh/helm-v3.21.0-linux-riscv64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.21.0-linux-riscv64.tar.gz.sha256sum) / 4935c95c55bc5c3357143698a87185e17a39de9b6148dfd6cce0fc11859dbfeb)&#xD;&#xA;- [Windows amd64](https://get.helm.sh/helm-v3.21.0-windows-amd64.zip) ([checksum](https://get.helm.sh/helm-v3.21.0-windows-amd64.zip.sha256sum) / 3ea6b8383e6c0b7ce45d06a5746313b8e9225edd88d42f4f64582ff3792d7b55)&#xD;&#xA;- [Windows arm64](https://get.helm.sh/helm-v3.21.0-windows-arm64.zip) ([checksum](https://get.helm.sh/helm-v3.21.0-windows-arm64.zip.sha256sum) / 90d8c87e07267e6c71e678c9e33dd11cc121789c823ccc380de9d1dd521c8cba)&#xD;&#xA;&#xD;&#xA;This release was signed by @gjenkins8 with key `BF88 8333 D96A 1C18 E268 2AAE D79D 67C9 EC01 6739`, which can be found at https://keys.openpgp.org/vks/v1/by-fingerprint/BF888333D96A1C18E2682AAED79D67C9EC016739. Please use the attached signatures for verifying this release using gpg.&#xD;&#xA;&#xD;&#xA;The [Quickstart Guide](https://helm.sh/docs/intro/quickstart/) will get you going from there. For **upgrade instructions** or detailed installation notes, check the [install guide](https://helm.sh/docs/intro/install/). You can also use a [script to install](https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3) on any system with `bash`.&#xD;&#xA;&#xD;&#xA;## What&#39;s Next&#xD;&#xA;&#xD;&#xA;- 3.21.1 will contain only bug fixes.&#xD;&#xA;- 3.22.0 is the next feature release for Kubernetes v1.37&#xD;&#xA;&#xD;&#xA;## Changelog&#xD;&#xA;&#xD;&#xA;- [v3] Bump to version v3.21 e0878d41b711792be60777fd65ad23a101e6b85f (George Jenkins)&#xD;&#xA;- fix: upgrade opentelemetry packages to patch CVEs 13d5fc4ae0e7222e1af8796ff4fa467b52208471 (Terry Howe)&#xD;&#xA;- fix: Chart dot-name path bug 2552884e3bc1b763c3901c5ea7240b59ef6791f1 (George Jenkins)&#xD;&#xA;- fix: pin codeql-action/upload-sarif to commit SHA in scorecards workflow ec05dd5f0481c2de3a41a554adf3c52a6a2a9bb6 (Terry Howe)&#xD;&#xA;- add image index test b0dfec5af4d7f642d8dea3b9058856541fe5017c (Pedro Tôrres)&#xD;&#xA;- fix pulling charts from OCI indices e629995c5d65ec2d5095ecd6d094bf85d02b3266 (Pedro Tôrres)&#xD;&#xA;- chore(deps): bump the k8s-io group with 7 updates 9c854fbd937ae0efe0e0a5063e7449d8973a85fd (dependabot[bot])&#xD;&#xA;- chore(deps): bump golang.org/x/crypto from 0.47.0 to 0.48.0 a692247486fb6893f00af65fdfb05da538c7b1d5 (dependabot[bot])&#xD;&#xA;- chore(deps): bump golang.org/x/term from 0.39.0 to 0.40.0 9f2a7f696a3e0be43ff9f55ade1dc89c76c6e903 (dependabot[bot])&#xD;&#xA;- chore(deps): bump github.com/lib/pq from 1.11.1 to 1.11.2 79f039be716a0a48d354ffaaf97179bb4fae9d64 (dependabot[bot])&#xD;&#xA;- chore(deps): bump golang.org/x/text from 0.33.0 to 0.34.0 45210d597d7941ebe900bd8f317c0a62aa777395 (dependabot[bot])&#xD;&#xA;- Remove refactorring changes from coalesce_test.go e2df39fc0b3e713df923a7ae64412e327f6e1022 (Evans Mungai)&#xD;&#xA;- Fix import 97affe067aa1e39fe6552c0d46de749f02063183 (Evans Mungai)&#xD;&#xA;- Update pkg/chart/common/util/coalesce_test.go c264166ec6bbf61c400a3457fae87fa058487e76 (Evans Mungai)&#xD;&#xA;- Fix lint warning d409df87ff6c2cbe17cc465b93ce646003b71d28 (Evans Mungai)&#xD;&#xA;- Preserve nil values in chart already 6fdd1017cebc284f7d545c04dd2c8f2d350d69d2 (Evans Mungai)&#xD;&#xA;- fix(values): preserve nil values when chart default is empty map b13743c8d4ef5488f40148af1d6ccd35ee9b97e3 (Evans Mungai)&#xD;&#xA;- chore(deps): bump github.com/lib/pq from 1.10.9 to 1.11.1 703999db8484985f4cafe000a610f10d688b2456 (dependabot[bot])&#xD;&#xA;- chore(deps): bump golang.org/x/crypto from 0.46.0 to 0.47.0 a04be9699efe5c26827397d7004b3490ad4ef029 (dependabot[bot])&#xD;&#xA;&#xD;&#xA;## New Contributors&#xD;&#xA;* @KrzysztofDziankowski made their first contribution in https://github.com/helm/helm/pull/31829&#xD;&#xA;&#xD;&#xA;**Full Changelog**: https://github.com/helm/helm/compare/v3.20.0...v3.21.0</pre>
            </details>
        </details>
        <a href="https://github.com/rancher/rancher-turtles-e2e/actions/runs/25949468014">GitHub Action workflow link</a>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50" />
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>



<!-- e2e-result-start -->
### E2E Test Results:

| Run Name | Run Result | Notes |
|----------|------------|-------|
| [[4381] Rancher-head/2.14 - **@install** dev=true destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/26020488997) | ✅ Pass | |
<!-- e2e-result-end -->
