### PR TITLE
Upgrade EKS test to v1.35.0

### DIFF
--- a/tests/cypress/latest/e2e/capa_eks_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capa_eks_clusterclass.spec.ts
@@ -5,6 +5,7 @@ import {vars} from '../support/variables';
 
 Cypress.config();
 describe('Import CAPA EKS Class-Cluster', {tags: '@full'}, () => {
+  let appVersion: string;
   const timeout = vars.fullTimeout
   const classNamePrefix = 'aws-eks'
   const clusterName = getClusterName(classNamePrefix)
@@ -27,7 +28,6 @@ describe('Import CAPA EKS Class-Cluster', {tags: '@full'}, () => {
     })
     );
 
-    // TODO: Create Provider via UI, ref: capi-ui-extension/issues/128
     qase(343, it('Create AWS CAPIProvider & AWSClusterStaticIdentity', () => {
       if (isRancherManagerVersion('<2.13')) {
         cy.removeCAPIResource('Providers', providerName);
@@ -52,6 +52,7 @@ describe('Import CAPA EKS Class-Cluster', {tags: '@full'}, () => {
       it('Import CAPA EKS class-cluster using YAML', () => {
         cy.readFile(classClusterFileName).then((data) => {
           data = data.replace(/replace_cluster_name/g, clusterName)
+          data = data.replace(/replace_eksVersion/g, vars.eksVersion)
           cy.importYAML(data, vars.capiClustersNS)
         });
         // Check CAPI cluster using its name
@@ -83,9 +84,14 @@ describe('Import CAPA EKS Class-Cluster', {tags: '@full'}, () => {
   context('[CLUSTER-OPERATIONS]', () => {
     qase(126,
       it('Install App on imported cluster', {retries: 1}, () => {
+        if (isAPIv1beta1) {
+          appVersion = '108.0'
+        } else {
+          appVersion = ''
+        }
         // Chart version 109.0.0 (Rancher 2.14) requires k8s version >=1.33
         // Ref: https://github.com/rancher/turtles/issues/2247
-        cy.checkChart(clusterName, 'Install', 'Logging', 'cattle-logging-system', {version: '108.0'});
+        cy.checkChart(clusterName, 'Install', 'Logging', 'cattle-logging-system', {version: appVersion});
       })
     );
 
@@ -95,6 +101,7 @@ describe('Import CAPA EKS Class-Cluster', {tags: '@full'}, () => {
 
         // workaround; these values need to be re-replaced before applying the scaling changes
         data = data.replace(/replace_cluster_name/g, clusterName)
+        data = data.replace(/replace_eksVersion/g, vars.eksVersion)
         cy.importYAML(data, vars.capiClustersNS)
       })
 

--- a/tests/cypress/latest/e2e/providers_setup.spec.ts
+++ b/tests/cypress/latest/e2e/providers_setup.spec.ts
@@ -78,7 +78,7 @@ describe('Enable CAPI Providers', () => {
     },
     'prod-v2.14': {
       capi: 'v1.12.2',
-      rke2: 'v0.24.3',
+      rke2: 'v0.24.4',
       kubeadm: 'v1.12.2',
       fleet: 'v0.14.1',
       vsphere: 'v1.15.2',
@@ -108,7 +108,7 @@ describe('Enable CAPI Providers', () => {
     },
     'dev-v2.14': {
       capi: 'v1.12.2',
-      rke2: 'v0.24.3',
+      rke2: 'v0.24.4',
       kubeadm: 'v1.12.2',
       fleet: 'v0.14.1',
       vsphere: 'v1.15.2',
@@ -118,7 +118,7 @@ describe('Enable CAPI Providers', () => {
     },
     'dev-v2.15': {
       capi: 'v1.12.2',
-      rke2: 'v0.24.3',
+      rke2: 'v0.24.4',
       kubeadm: 'v1.12.2',
       fleet: 'v0.14.1',
       vsphere: 'v1.15.2',

--- a/tests/cypress/latest/fixtures/aws/capa-eks-class-cluster.yaml
+++ b/tests/cypress/latest/fixtures/aws/capa-eks-class-cluster.yaml
@@ -13,7 +13,7 @@ spec:
     classRef:
       name: aws-eks-example
       namespace: capi-classes
-    version: v1.32.0 #https://github.com/rancher/turtles/blob/main/test/e2e/config/operator.yaml#L61
+    version: replace_eksVersion 
     variables:
       - name: region
         value: ap-south-2

--- a/tests/cypress/latest/support/variables.ts
+++ b/tests/cypress/latest/support/variables.ts
@@ -1,4 +1,4 @@
-import {isRancherManagerVersion, providersChartNeedsStgRegistry} from './utils';
+import {isAPIv1beta1, isRancherManagerVersion, providersChartNeedsStgRegistry} from './utils';
 
 export const vars = {
   shortTimeout: 600000,
@@ -14,6 +14,7 @@ export const vars = {
   turtlesProvidersHelmApp: 'rancher-turtles-providers',
   turtlesProvidersOCIRepo: providersChartNeedsStgRegistry() ? Cypress.expose('providers_stg_oci_repo') : Cypress.expose('providers_oci_repo'), // For alpha|rc|head builds, use stgregistry, for released versions, use regular registry.
   turtlesProvidersChartName: 'rancher-turtles-providers',
+  eksVersion: isAPIv1beta1 ? 'v1.32.0' : 'v1.35.0',
   kindVersion: isRancherManagerVersion('2.12') ? 'v1.33.4' : isRancherManagerVersion('2.13') ? 'v1.34.0' : 'v1.35.0',
   k8sVersion: isRancherManagerVersion('2.12') ? 'v1.33.4' : isRancherManagerVersion('2.13') ? 'v1.34.1' : 'v1.35.0',
   rke2Version: isRancherManagerVersion('2.12') ? 'v1.33.4+rke2r1' : isRancherManagerVersion('2.13') ? 'v1.34.1+rke2r1' : 'v1.35.0+rke2r1',


### PR DESCRIPTION
### What does this PR do?
- Upgrade eks version to 1.35
- Bump CAPRKE2 version

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #512 

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [ ] Added/Modified Qase IDs
- [ ] GitHub Actions (if applicable)

### Special notes for your reviewer:

<!-- e2e-result-start -->
### E2E Test Results:

| Run Name | Run Result | Notes |
|----------|------------|-------|
| [[4369] Rancher-head/2.13 - **@install @eks** dev=true destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/25908921092) | ✅ Pass | |
| [[4370] Rancher-head/2.14 - **@install @eks** dev=true destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/25909380128) | ✅ Pass | |
<!-- e2e-result-end -->


