### PR TITLE
Turtles branch refactor

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -347,6 +347,8 @@ jobs:
             echo "TURTLES_BRANCH=release-0.24" >> ${GITHUB_ENV}
           elif [[ "${{ env.RANCHER_VERSION }}" =~ 2.13 && ! "${{ inputs.grep_test_by_tag }}" =~ "@upgrade" ]]; then
             echo "TURTLES_BRANCH=release/v0.25" >> ${GITHUB_ENV}
+          elif [[ "${{ env.RANCHER_VERSION }}" =~ 2.14 ]]; then
+            echo "TURTLES_BRANCH=release/v0.26" >> ${GITHUB_ENV}
           elif [[ "${{ inputs.grep_test_by_tag }}" =~ "@migration" ]]; then
             echo "TURTLES_BRANCH=release/v0.25" >> ${GITHUB_ENV}
           elif [[ "${{ inputs.grep_test_by_tag }}" =~ "@upgrade" ]]; then

--- a/tests/cypress/latest/e2e/providers_setup.spec.ts
+++ b/tests/cypress/latest/e2e/providers_setup.spec.ts
@@ -77,12 +77,12 @@ describe('Enable CAPI Providers', () => {
       azure: 'v1.21.0'
     },
     'prod-v2.14': {
-      capi: 'v1.12.2',
+      capi: 'v1.12.7',
       rke2: 'v0.24.4',
-      kubeadm: 'v1.12.2',
+      kubeadm: 'v1.12.7',
       fleet: 'v0.14.1',
       vsphere: 'v1.15.2',
-      amazon: 'v2.10.1',
+      amazon: 'v2.11.1',
       google: 'v1.11.1',
       azure: 'v1.22.0'
     },
@@ -107,9 +107,9 @@ describe('Enable CAPI Providers', () => {
       azure: 'v1.21.0'
     },
     'dev-v2.14': {
-      capi: 'v1.12.2',
+      capi: 'v1.12.7',
       rke2: 'v0.24.4',
-      kubeadm: 'v1.12.2',
+      kubeadm: 'v1.12.7',
       fleet: 'v0.14.1',
       vsphere: 'v1.15.2',
       amazon: 'v2.11.1',
@@ -117,14 +117,14 @@ describe('Enable CAPI Providers', () => {
       azure: 'v1.22.0'
     },
     'dev-v2.15': {
-      capi: 'v1.12.2',
+      capi: 'v1.13.1',
       rke2: 'v0.24.4',
-      kubeadm: 'v1.12.2',
-      fleet: 'v0.14.1',
-      vsphere: 'v1.15.2',
+      kubeadm: 'v1.13.1',
+      fleet: 'v0.15.0',
+      vsphere: 'v1.16.1',
       amazon: 'v2.11.1',
-      google: 'v1.11.1',
-      azure: 'v1.22.0'
+      google: 'v1.11.2',
+      azure: 'v1.24.0'
     }
   }
 

--- a/tests/cypress/latest/support/variables.ts
+++ b/tests/cypress/latest/support/variables.ts
@@ -4,7 +4,7 @@ export const vars = {
   shortTimeout: 600000,
   fullTimeout: 1500000,
   branch: Cypress.expose('turtles_branch'),
-  classBranch: isRancherManagerVersion('2.12') ? 'release-0.24' : isRancherManagerVersion('2.13') ? 'release/v0.25' : Cypress.expose('turtles_branch'),
+  classBranch: isRancherManagerVersion('2.12') ? 'release-0.24' : isRancherManagerVersion('2.13') ? 'release/v0.25' : isRancherManagerVersion('2.14') ? 'release/v0.26' : Cypress.expose('turtles_branch'),
   capiClustersNS: 'capi-clusters',
   capiClassesNS: 'capi-classes',
   repoUrl: 'https://github.com/rancher/rancher-turtles-e2e',


### PR DESCRIPTION
### What does this PR do?
- Turtles `main` branch is now pointing to Rancher 2.15, this PR changes the branch references
- Bump providers versions

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes - Failing nightly CI

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [ ] Added/Modified Qase IDs
- [x] GitHub Actions:
:green_circle: [2.14 @short](https://github.com/rancher/rancher-turtles-e2e/actions/runs/26040514789/job/76589656071)
:orange_circle: [2.15 @short](https://github.com/rancher/rancher-turtles-e2e/actions/runs/26040533872) (v2prov failure expected on CAPI 1.13)

### Special notes for your reviewer:

<!-- e2e-result-start -->
### E2E Test Results:

| Run Name | Run Result | Notes |
|----------|------------|-------|
<!-- e2e-result-end -->
