### PR TITLE
[updatecli] Bump Logging stack

### DIFF
--- a/.github/scripts/collect-rancher-logs.sh
+++ b/.github/scripts/collect-rancher-logs.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 # Variables
 
 # Rancher support-tools log collector (pinned by commit + checksum)
-RANCHER_LOG_COLLECTER_COMMIT="e946a0cdd4f9706116e3335e8df2360d048535d6"
+RANCHER_LOG_COLLECTER_COMMIT="51ff3e7ef2b8dba1fde5f523b362d7c9f14b29f3"
 RANCHER_LOG_COLLECTER_PATH="collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh"
 RANCHER_LOG_COLLECTER="https://raw.githubusercontent.com/rancherlabs/support-tools/${RANCHER_LOG_COLLECTER_COMMIT}/${RANCHER_LOG_COLLECTER_PATH}"
 RANCHER_LOG_COLLECTER_SHA256="be356abe5b062c68dd5033ec4fd1f4044a67bc323d5f69eac8f8148e88084920"

--- a/.github/scripts/collect-rancher-logs.sh
+++ b/.github/scripts/collect-rancher-logs.sh
@@ -13,7 +13,7 @@ RANCHER_LOG_COLLECTER_SHA256="be356abe5b062c68dd5033ec4fd1f4044a67bc323d5f69eac8
 # RANCHER_LOG_COLLECTER_SHA256="$(curl -sSfL "${RANCHER_LOG_COLLECTER}" | sha256sum | awk '{print $1}')"
 
 # crust-gather installer (pinned by tag + checksum)
-CRUST_GATHER_INSTALLER_VERSION="v0.15.0"
+CRUST_GATHER_INSTALLER_VERSION="v0.15.1"
 CRUST_GATHER_INSTALLER="https://raw.githubusercontent.com/crust-gather/crust-gather/refs/tags/${CRUST_GATHER_INSTALLER_VERSION}/install.sh"
 CRUST_GATHER_INSTALLER_SHA256="b51cb2f18a7452e70b0d0f3090428a46ed97257ed0572c808f06e30885c29e4b"
 # To refresh SHA256:

--- a/.github/scripts/collect-rancher-logs.sh
+++ b/.github/scripts/collect-rancher-logs.sh
@@ -8,7 +8,7 @@ set -eo pipefail
 RANCHER_LOG_COLLECTER_COMMIT="51ff3e7ef2b8dba1fde5f523b362d7c9f14b29f3"
 RANCHER_LOG_COLLECTER_PATH="collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh"
 RANCHER_LOG_COLLECTER="https://raw.githubusercontent.com/rancherlabs/support-tools/${RANCHER_LOG_COLLECTER_COMMIT}/${RANCHER_LOG_COLLECTER_PATH}"
-RANCHER_LOG_COLLECTER_SHA256="be356abe5b062c68dd5033ec4fd1f4044a67bc323d5f69eac8f8148e88084920"
+RANCHER_LOG_COLLECTER_SHA256="9cb953c3636737201a4343317fe91d8f7463cf7e69c3ea411d54a8cc5a12d50a"
 # To refresh SHA256:
 # RANCHER_LOG_COLLECTER_SHA256="$(curl -sSfL "${RANCHER_LOG_COLLECTER}" | sha256sum | awk '{print $1}')"
 


### PR DESCRIPTION



<Actions>
    <action id="fdc5aa0d7e06cc670109465f997bff0f67b8c13799d4afda24e5278dca1fc741">
        <h3>[updatecli] Bump Logging stack</h3>
        <details id="01e7e68cb41d692733c759ca1c9c1a7e09b47ffc6a494d68b6ab6dadf6d0a9f6">
            <summary>Update RANCHER_LOG_COLLECTER_COMMIT</summary>
            <p>1 file(s) updated with &#34;RANCHER_LOG_COLLECTER_COMMIT=\&#34;51ff3e7ef2b8dba1fde5f523b362d7c9f14b29f3\&#34;&#34;:&#xA;&#xA;* .github/scripts/collect-rancher-logs.sh&#xA;</p>
        </details>
        <details id="0eed0951f0365cba215f9242c789286595d10da091b6b387b4061dfb93990980">
            <summary>Update CRUST_GATHER_INSTALLER_VERSION</summary>
            <p>1 file(s) updated with &#34;CRUST_GATHER_INSTALLER_VERSION=\&#34;v0.15.1\&#34;&#34;:&#xA;&#xA;* .github/scripts/collect-rancher-logs.sh&#xA;</p>
            <details>
                <summary>v0.15.1</summary>
                <pre># New features&#xD;&#xA;- Headlamp integration 🎉: https://github.com/kubernetes-sigs/headlamp&#xD;&#xA;&#xD;&#xA;&lt;img width=&#34;782&#34; height=&#34;441&#34; alt=&#34;headlamp-small&#34; src=&#34;https://github.com/user-attachments/assets/0cd7c70b-1e3c-4e17-a1aa-5c8614f0e8de&#34; /&gt;&#xD;&#xA;&#xD;&#xA;## What&#39;s Changed&#xD;&#xA;* Bump rmcp from 1.6.0 to 1.7.0 by @dependabot[bot] in https://github.com/crust-gather/crust-gather/pull/470&#xD;&#xA;* Bump kube-cel from 0.5.3 to 0.5.4 in the dependencies group by @dependabot[bot] in https://github.com/crust-gather/crust-gather/pull/471&#xD;&#xA;* Bump pin-project from 1.1.12 to 1.1.13 by @dependabot[bot] in https://github.com/crust-gather/crust-gather/pull/472&#xD;&#xA;* headlamp integration changes by @Danil-Grigorev in https://github.com/crust-gather/crust-gather/pull/474&#xD;&#xA;* Bump actix-ws from 0.3.1 to 0.4.0 by @dependabot[bot] in https://github.com/crust-gather/crust-gather/pull/476&#xD;&#xA;* Bump tar from 0.4.45 to 0.4.46 in the zip group by @dependabot[bot] in https://github.com/crust-gather/crust-gather/pull/475&#xD;&#xA;&#xD;&#xA;&#xD;&#xA;**Full Changelog**: https://github.com/crust-gather/crust-gather/compare/v0.15.0...v0.15.1</pre>
            </details>
        </details>
        <details id="711c2be3606875e78c8aee49b71d89b08fec39ff4704c369395d9d1afd69f2a2">
            <summary>Update RANCHER_LOG_COLLECTER_SHA256</summary>
            <p>1 file(s) updated with &#34;RANCHER_LOG_COLLECTER_SHA256=\&#34;9cb953c3636737201a4343317fe91d8f7463cf7e69c3ea411d54a8cc5a12d50a\&#34;&#34;:&#xA;&#xA;* .github/scripts/collect-rancher-logs.sh&#xA;</p>
        </details>
        <a href="https://github.com/rancher/rancher-turtles-e2e/actions/runs/26427487056">GitHub Action workflow link</a>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50" />
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>



<!-- e2e-result-start -->
### E2E Test Results:

| Run Name | Run Result | Notes |
|----------|------------|-------|
| [[4440] Rancher-head/2.14 - **@install @short** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/26451910476) | ✅ Pass | |
<!-- e2e-result-end -->
