### PR TITLE
Move imported cluster-deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,13 @@ What tests are doing:
 4. Test the Turtles menu, namespaces import features
 5. Perform CAPI setup prerequisites
 6. Create & Import CAPI cluster using fleet by cluster, namespace annotation
-7. Create & Import CAPI cluster using ClusterClass UI
-8. Install App on imported CAPI cluster
-9. Scale the imported CAPI cluster
-10. Remove & Delete the imported CAPI cluster
-11. Migration test from 2.12 to 2.13 to test turtles migration from an external chart(2.12) to system integrated chart(
+7. Install App on imported CAPI cluster
+8. Scale the imported CAPI cluster
+9. Remove & Delete the imported CAPI cluster
+10. Migration test from 2.12 to 2.13 to test turtles migration from an external chart(2.12) to system integrated chart(
     2.13). These tests are only supported with `dev=true` options; `dev=true` is applicable to 2.13.
-12. Upgrade tests from 2.13 to 2.14 to test turtles CAPI upgrade from v1.10 to v1.12. These tests are only supported
-    with `dev=true` options; `dev=true` is applicable to 2.14.
-13. Add Feature Switch test for 2.13 to test switch between `embedded-cluster-api` and `turtles` features switch.
+11. Upgrade tests from 2.13 to 2.14 to test Turtles & CAPI upgrade from v1.10 to v1.12.
+12. Add Feature Switch test for 2.13 to test switch between `embedded-cluster-api` and `turtles` features switch.
 
 ## Running the tests locally
 

--- a/tests/cypress/latest/e2e/capa_eks_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capa_eks_clusterclass.spec.ts
@@ -113,17 +113,17 @@ describe('Import CAPA EKS Class-Cluster', {tags: '@full'}, () => {
       cy.checkCAPIClusterActive(clusterName);
     })
     );
-
-    qase(362, it('Remove imported CAPA cluster from Rancher Manager', () => {
-      // Delete the imported cluster
-      // Ensure that the provisioned CAPI cluster still exists
-      importedRancherv3ClusterDeletion(clusterName);
-    })
-    );
   })
 
   context('[TEARDOWN]', () => {
     if (skipClusterDeletion) {
+      qase(362, it('Remove imported CAPA cluster from Rancher Manager', () => {
+        // Delete the imported cluster
+        // Ensure that the provisioned CAPI cluster still exists
+        importedRancherv3ClusterDeletion(clusterName);
+      })
+      );
+
       qase(127,
         it('Delete the CAPA cluster', {retries: 1}, () => {
           // Remove CAPI Resources related to the cluster

--- a/tests/cypress/latest/e2e/capa_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capa_kubeadm_clusterclass.spec.ts
@@ -110,17 +110,17 @@ describe('Import CAPA Kubeadm Class-Cluster', {tags: '@full'}, () => {
       cy.checkCAPIClusterActive(clusterName);
     })
     );
-
-    qase(361, it('Remove imported CAPA cluster from Rancher Manager', () => {
-      // Delete the imported cluster
-      // Ensure that the provisioned CAPI cluster still exists
-      importedRancherv3ClusterDeletion(clusterName);
-    })
-    );
   })
 
   context('[TEARDOWN]', () => {
     if (skipClusterDeletion) {
+      qase(361, it('Remove imported CAPA cluster from Rancher Manager', () => {
+        // Delete the imported cluster
+        // Ensure that the provisioned CAPI cluster still exists
+        importedRancherv3ClusterDeletion(clusterName);
+      })
+      );
+
       qase(394,
         it('Delete the CAPA cluster', {retries: 1}, () => {
           // Remove CAPI Resources related to the cluster

--- a/tests/cypress/latest/e2e/capa_rke2_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capa_rke2_clusterclass.spec.ts
@@ -111,18 +111,19 @@ describe('Import CAPA RKE2 Class-Cluster', {tags: '@full'}, () => {
       cy.checkCAPIClusterActive(clusterName);
     })
     );
-
-    qase(360, it('Remove imported CAPA cluster from Rancher Manager', {retries: 1}, () => {
-      // Delete the imported cluster
-      // Ensure that the provisioned CAPI cluster still exists
-      // this check can fail, ref: https://github.com/rancher/turtles/issues/1587
-      importedRancherv3ClusterDeletion(clusterName);
-    })
-    );
   })
 
   context('[TEARDOWN]', () => {
     if (skipClusterDeletion) {
+      qase(360, it('Remove imported CAPA cluster from Rancher Manager', {retries: 1}, () => {
+        // Delete the imported cluster
+        // Ensure that the provisioned CAPI cluster still exists
+        // this check can fail, ref: https://github.com/rancher/turtles/issues/1587
+        importedRancherv3ClusterDeletion(clusterName);
+      })
+      );
+
+
       qase(114,
         it('Delete the CAPA cluster', {retries: 1}, () => {
           // Remove CAPI Resources related to the cluster

--- a/tests/cypress/latest/e2e/capd_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capd_kubeadm_clusterclass.spec.ts
@@ -145,25 +145,25 @@ describe('Import CAPD Kubeadm Class-Cluster', {tags: '@short'}, () => {
       })
     );
 
-    qase(301, it('Remove imported CAPD cluster from Rancher Manager', () => {
+    qase(459, it('Re-import the CAPD cluster', () => {
       // Delete the imported cluster
       // Ensure that the provisioned CAPI cluster still exists
       importedRancherv3ClusterDeletion(clusterName);
-    })
-    );
 
-    qase(459, it('Re-import the CAPD cluster and remove from Rancher Manager', () => {
       reImportRancherv3Cluster(clusterName);
-
-      // Delete the imported cluster
-      // Ensure that the provisioned CAPI cluster still exists
-      importedRancherv3ClusterDeletion(clusterName);
     })
     );
   })
 
   context('[TEARDOWN]', () => {
     if (skipClusterDeletion) {
+      qase(301, it('Remove imported CAPD cluster from Rancher Manager', () => {
+        // Delete the imported cluster
+        // Ensure that the provisioned CAPI cluster still exists
+        importedRancherv3ClusterDeletion(clusterName);
+      })
+      );
+
       qase(98,
         it('Delete the CAPD cluster', {retries: 1}, () => {
           // Remove CAPI Resources related to the cluster

--- a/tests/cypress/latest/e2e/capd_rke2_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capd_rke2_clusterclass.spec.ts
@@ -144,25 +144,25 @@ describe('Import CAPD RKE2 Class-Cluster', {tags: '@short'}, () => {
     );
     }
 
-    qase(356, it('Remove imported CAPD cluster from Rancher Manager', () => {
+    qase(458, it('Re-import the CAPD cluster', () => {
       // Delete the imported cluster
       // Ensure that the provisioned CAPI cluster still exists
       importedRancherv3ClusterDeletion(clusterName);
-    })
-    );
 
-    qase(458, it('Re-import the CAPD cluster and remove from Rancher Manager', () => {
       reImportRancherv3Cluster(clusterName);
-
-      // Delete the imported cluster
-      // Ensure that the provisioned CAPI cluster still exists
-      importedRancherv3ClusterDeletion(clusterName);
     })
     );
   })
 
   context('[TEARDOWN]', () => {
     if (skipClusterDeletion) {
+      qase(356, it('Remove imported CAPD cluster from Rancher Manager', () => {
+        // Delete the imported cluster
+        // Ensure that the provisioned CAPI cluster still exists
+        importedRancherv3ClusterDeletion(clusterName);
+      })
+      );
+
       qase(103,
         it('Delete the CAPD cluster', {retries: 1}, () => {
           // Remove CAPI Resources related to the cluster

--- a/tests/cypress/latest/e2e/capd_rke2_fleet_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capd_rke2_fleet_clusterclass.spec.ts
@@ -106,17 +106,17 @@ describe('Import CAPD RKE2 (Default CNI) Class-Cluster using Fleet', {tags: '@sh
       cy.checkChart(clusterName, 'Install', 'Logging', 'cattle-logging-system');
     })
     );
-
-    qase(433, it('Remove imported CAPD cluster from Rancher Manager', () => {
-      // Delete the imported cluster
-      // Ensure that the provisioned CAPI cluster still exists
-      importedRancherv3ClusterDeletion(clusterName);
-    })
-    );
   })
 
   context('[TEARDOWN]', () => {
     if (skipClusterDeletion) {
+      qase(433, it('Remove imported CAPD cluster from Rancher Manager', () => {
+        // Delete the imported cluster
+        // Ensure that the provisioned CAPI cluster still exists
+        importedRancherv3ClusterDeletion(clusterName);
+      })
+      );
+
       qase(434, it('Delete the CAPD cluster', {retries: 1}, () => {
         // Remove CAPI Resources related to the cluster
         capiClusterDeletion(clusterName, timeout, clustersRepoName, true);

--- a/tests/cypress/latest/e2e/capd_rke2_nocaapf_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capd_rke2_nocaapf_clusterclass.spec.ts
@@ -136,17 +136,17 @@ describe('Import CAPD RKE2 (Default CNI & No-Caapf) Class-Cluster using Fleet', 
       cy.checkChart(clusterName, 'Install', 'Logging', 'cattle-logging-system');
     })
     );
-
-    qase(448, it('Remove imported CAPD cluster from Rancher Manager', () => {
-      // Delete the imported cluster
-      // Ensure that the provisioned CAPI cluster still exists
-      importedRancherv3ClusterDeletion(clusterName);
-    })
-    );
   })
 
   context('[TEARDOWN]', () => {
     if (skipClusterDeletion) {
+      qase(448, it('Remove imported CAPD cluster from Rancher Manager', () => {
+        // Delete the imported cluster
+        // Ensure that the provisioned CAPI cluster still exists
+        importedRancherv3ClusterDeletion(clusterName);
+      })
+      );
+
       qase(449, it('Delete the CAPD cluster', {retries: 1}, () => {
         // Remove CAPI Resources related to the cluster
         capiClusterDeletion(clusterName, timeout, clustersRepoName, true);

--- a/tests/cypress/latest/e2e/capg_gke_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capg_gke_clusterclass.spec.ts
@@ -84,18 +84,18 @@ describe('Import CAPG GKE Class-Cluster', {tags: '@full'}, () => {
       cy.checkChart(clusterName, 'Install', 'Logging', 'cattle-logging-system');
       })
     );
-
-    qase(414,
-      it('Remove imported CAPG cluster from Rancher Manager',() => {
-      // Delete the imported cluster
-      // Ensure that the provisioned CAPI cluster still exists
-      importedRancherv3ClusterDeletion(clusterName);
-    })
-    );
   })
 
   context('[TEARDOWN]', () => {
     if (skipClusterDeletion) {
+      qase(414,
+        it('Remove imported CAPG cluster from Rancher Manager',() => {
+        // Delete the imported cluster
+        // Ensure that the provisioned CAPI cluster still exists
+        importedRancherv3ClusterDeletion(clusterName);
+      })
+      );
+
       qase(401,
         it('Delete the CAPG cluster', {retries: 1}, () => {
           // Remove CAPI Resources related to the cluster

--- a/tests/cypress/latest/e2e/capg_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capg_kubeadm_clusterclass.spec.ts
@@ -103,17 +103,17 @@ describe('Import CAPG Kubeadm Class-Cluster', {tags: '@full'}, () => {
       cy.checkCAPIClusterActive(clusterName);
     })
     );
-
-    qase(363, it('Remove imported CAPG cluster from Rancher Manager', () => {
-      // Delete the imported cluster
-      // Ensure that the provisioned CAPI cluster still exists
-      importedRancherv3ClusterDeletion(clusterName);
-    })
-    );
   })
 
   context('[TEARDOWN]', () => {
     if (skipClusterDeletion) {
+      qase(363, it('Remove imported CAPG cluster from Rancher Manager', () => {
+        // Delete the imported cluster
+        // Ensure that the provisioned CAPI cluster still exists
+        importedRancherv3ClusterDeletion(clusterName);
+      })
+      );
+
       qase(146,
         it('Delete the CAPG cluster', {retries: 1}, () => {
           // Remove CAPI Resources related to the cluster

--- a/tests/cypress/latest/e2e/capv_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capv_kubeadm_clusterclass.spec.ts
@@ -120,17 +120,17 @@ describe('Import CAPV Kubeadm Class-Cluster', {tags: '@vsphere'}, () => {
       cy.checkChart(clusterName, 'Install', 'Logging', 'cattle-logging-system');
     })
     );
-
-    qase(359, it('Remove imported CAPV cluster from Rancher Manager', () => {
-      // Delete the imported cluster
-      // Ensure that the provisioned CAPI cluster still exists
-      importedRancherv3ClusterDeletion(clusterName);
-    })
-    );
   })
 
   context('[TEARDOWN]', () => {
     if (skipClusterDeletion) {
+      qase(359, it('Remove imported CAPV cluster from Rancher Manager', () => {
+        // Delete the imported cluster
+        // Ensure that the provisioned CAPI cluster still exists
+        importedRancherv3ClusterDeletion(clusterName);
+      })
+      );
+
       qase(292, it('Delete the CAPV cluster', {retries: 1}, () => {
         // Remove CAPI Resources related to the cluster
         capiClusterDeletion(clusterName, timeout, clusterRepoName);

--- a/tests/cypress/latest/e2e/capv_rke2_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capv_rke2_clusterclass.spec.ts
@@ -211,17 +211,17 @@ describe('Import CAPV RKE2 Class-Cluster', {tags: '@vsphere'}, () => {
       cy.checkChart(clusterName, 'Install', 'Logging', 'cattle-logging-system');
     })
     );
-
-    qase(358, it('Remove imported CAPV cluster from Rancher Manager', () => {
-      // Delete the imported cluster
-      // Ensure that the provisioned CAPI cluster still exists
-      importedRancherv3ClusterDeletion(clusterName);
-    })
-    );
   })
 
   context('[TEARDOWN]', () => {
     if (skipClusterDeletion) {
+      qase(358, it('Remove imported CAPV cluster from Rancher Manager', () => {
+        // Delete the imported cluster
+        // Ensure that the provisioned CAPI cluster still exists
+        importedRancherv3ClusterDeletion(clusterName);
+      })
+      );
+
       qase(282, it('Delete the CAPV cluster', {retries: 1}, () => {
         // Remove CAPI Resources related to the cluster
         capiClusterDeletion(clusterName, timeout, clusterRepoName);

--- a/tests/cypress/latest/e2e/capz_aks_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capz_aks_clusterclass.spec.ts
@@ -84,18 +84,17 @@ describe('Import CAPZ AKS Class-Cluster', {tags: '@full'}, () => {
       cy.checkChart(clusterName, 'Install', 'Logging', 'cattle-logging-system');
       })
     );
-
-    qase(364, it('Remove imported CAPZ cluster from Rancher Manager', {retries: 1}, () => {
-      // Delete the imported cluster
-      // Ensure that the provisioned CAPI cluster still exists
-      // this check can fail, ref: https://github.com/rancher/turtles/issues/1587
-      importedRancherv3ClusterDeletion(clusterName);
-    })
-    );
   })
 
   context('[TEARDOWN]', () => {
     if (skipClusterDeletion) {
+      qase(364, it('Remove imported CAPZ cluster from Rancher Manager', {retries: 1}, () => {
+        // Delete the imported cluster
+        // Ensure that the provisioned CAPI cluster still exists
+        importedRancherv3ClusterDeletion(clusterName);
+      })
+      );
+
       qase(60, it('Delete the CAPZ cluster', () => {
           // Remove CAPI Resources related to the cluster
           capiClusterDeletion(clusterName, timeout);

--- a/tests/cypress/latest/e2e/capz_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capz_kubeadm_clusterclass.spec.ts
@@ -106,17 +106,17 @@ describe('Import CAPZ Kubeadm Class-Cluster', {tags: '@full'}, () => {
       cy.checkCAPIClusterActive(clusterName);
     })
     );
-
-    qase(366, it('Remove imported CAPZ cluster from Rancher Manager', () => {
-      // Delete the imported cluster
-      // Ensure that the provisioned CAPI cluster still exists
-      importedRancherv3ClusterDeletion(clusterName);
-    })
-    );
   })
 
   context('[TEARDOWN]', () => {
     if (skipClusterDeletion) {
+      qase(366, it('Remove imported CAPZ cluster from Rancher Manager', () => {
+        // Delete the imported cluster
+        // Ensure that the provisioned CAPI cluster still exists
+        importedRancherv3ClusterDeletion(clusterName);
+      })
+      );
+
       qase(336, it('Delete the CAPZ cluster', {retries: 1}, () => {
         // Remove CAPI Resources related to the cluster
         capiClusterDeletion(clusterName, timeout);

--- a/tests/cypress/latest/e2e/capz_rke2_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capz_rke2_clusterclass.spec.ts
@@ -109,18 +109,17 @@ describe('Import CAPZ RKE2 Class-Cluster', {tags: '@full'}, () => {
       cy.checkCAPIClusterActive(clusterName);
     })
     );
-
-    qase(365, it('Remove imported CAPZ cluster from Rancher Manager', () => {
-      // Delete the imported cluster
-      // Ensure that the provisioned CAPI cluster still exists
-      importedRancherv3ClusterDeletion(clusterName);
-    })
-    );
-
   })
 
   context('[TEARDOWN]', () => {
     if (skipClusterDeletion) {
+      qase(365, it('Remove imported CAPZ cluster from Rancher Manager', () => {
+        // Delete the imported cluster
+        // Ensure that the provisioned CAPI cluster still exists
+        importedRancherv3ClusterDeletion(clusterName);
+      })
+      );
+
       qase(82,
         it('Delete the CAPZ cluster', {retries: 1}, () => {
           // Remove CAPI Resources related to the cluster

--- a/tests/cypress/latest/e2e/providers_setup.spec.ts
+++ b/tests/cypress/latest/e2e/providers_setup.spec.ts
@@ -118,7 +118,7 @@ describe('Enable CAPI Providers', () => {
     },
     'dev-v2.15': {
       capi: 'v1.13.1',
-      rke2: 'v0.24.4',
+      rke2: 'v0.25.0',
       kubeadm: 'v1.13.1',
       fleet: 'v0.15.0',
       vsphere: 'v1.16.1',

--- a/tests/cypress/latest/support/cleanup_support.ts
+++ b/tests/cypress/latest/support/cleanup_support.ts
@@ -9,22 +9,31 @@ export const reImportClusterPatchCommand = (clusterName: string): string => {
 };
 
 export function importedRancherv3ClusterDeletion(clusterName: string) {
-  // Delete the imported mgmt v3 cluster from Cluster Management using kubectl
-  cy.kubectlExecute(v3ClusterDeleteCommand(clusterName));
+  // Verify the imported cluster is present before deletion
+  cy.searchCluster(clusterName);
+  cy.get('table.sortable-table tbody tr').then(($rows) => {
+    if ($rows.filter('.no-results').length > 0) {
+      cy.task('suiteLog', 'Skipping imported Rancherv3Cluster deletion, cluster not found')
+      return;
+    }
 
-  // Ensure the cluster is not available on the home page
-  cy.goToHome();
-  cy.contains(clusterName).should('not.exist');
+    // Delete the imported mgmt v3 cluster from Cluster Management using kubectl
+    cy.kubectlExecute(v3ClusterDeleteCommand(clusterName));
 
-  // Ensure that the provisioned cluster/ CAPI resource related to the cluster still exists
-  cy.checkCAPIClusterProvisioned(clusterName);
+    // Ensure the cluster is not available on the home page
+    cy.goToHome();
+    cy.contains(clusterName).should('not.exist');
 
-  // Check the annotation is set on CAPI cluster
-  cy.viewCAPIClusterYAML(clusterName);
-  cy.get('.CodeMirror').then((editor) => {
-    // @ts-expect-error known error with CodeMirror
-    const text = editor[0].CodeMirror.getValue();
-    expect(text).to.include("imported: 'true'");
+    // Ensure that the provisioned cluster/ CAPI resource related to the cluster still exists
+    cy.checkCAPIClusterProvisioned(clusterName);
+
+    // Check the annotation is set on CAPI cluster
+    cy.viewCAPIClusterYAML(clusterName);
+    cy.get('.CodeMirror').then((editor) => {
+      // @ts-expect-error known error with CodeMirror
+      const text = editor[0].CodeMirror.getValue();
+      expect(text).to.include("imported: 'true'");
+    });
   });
 }
 


### PR DESCRIPTION
### What does this PR do?
- Move imported cluster-deletion under [TEARDOWN]
- Skip cluster deletion if not found
- Update `README.md`

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [ ] Added/Modified Qase IDs
- [ ] GitHub Actions (if applicable)

### Special notes for your reviewer:

<!-- e2e-result-start -->
### E2E Test Results:

| Run Name | Run Result | Notes |
|----------|------------|-------|
| [[4481] Rancher-head/2.14 - **@install @short** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/26621600572) | ❌ Fail | Forced failure to check cluster deletion skip https://github.com/rancher/rancher-turtles-e2e/actions/runs/26621600572/job/78448701656#step:29:606 |
| [[4482] Rancher-head/2.14 - **@install @short** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/26621655445) | ✅ Pass | |
<!-- e2e-result-end -->







