### PR TITLE
Skip logging InstallApp for 2.15

### DIFF
--- a/tests/cypress/latest/e2e/capa_eks_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capa_eks_clusterclass.spec.ts
@@ -83,7 +83,7 @@ describe('Import CAPA EKS Class-Cluster', {tags: '@full'}, () => {
 
   context('[CLUSTER-OPERATIONS]', () => {
     qase(126,
-      it('Install App on imported cluster', {retries: 1}, () => {
+      (isRancherManagerVersion('>2.14') ? it.skip : it)('Install App on imported cluster', {retries: 1}, () => {
         if (isAPIv1beta1) {
           appVersion = '108.0'
         } else {

--- a/tests/cypress/latest/e2e/capa_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capa_kubeadm_clusterclass.spec.ts
@@ -86,7 +86,7 @@ describe('Import CAPA Kubeadm Class-Cluster', {tags: '@full'}, () => {
 
   context('[CLUSTER-OPERATIONS]', () => {
     qase(393,
-      it('Install App on imported cluster', {retries: 1}, () => {
+      (isRancherManagerVersion('>2.14') ? it.skip : it)('Install App on imported cluster', {retries: 1}, () => {
         cy.checkChart(clusterName, 'Install', 'Logging', 'cattle-logging-system');
       })
     );

--- a/tests/cypress/latest/e2e/capa_rke2_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capa_rke2_clusterclass.spec.ts
@@ -87,7 +87,7 @@ describe('Import CAPA RKE2 Class-Cluster', {tags: '@full'}, () => {
 
   context('[CLUSTER-OPERATIONS]', () => {
     qase(112,
-      it('Install App on imported cluster', {retries: 1}, () => {
+      (isRancherManagerVersion('>2.14') ? it.skip : it)('Install App on imported cluster', {retries: 1}, () => {
         cy.checkChart(clusterName, 'Install', 'Logging', 'cattle-logging-system');
       })
     );

--- a/tests/cypress/latest/e2e/capd_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capd_kubeadm_clusterclass.spec.ts
@@ -120,7 +120,7 @@ describe('Import CAPD Kubeadm Class-Cluster', {tags: '@short'}, () => {
     )
 
     qase(7,
-      it('Install App on imported cluster', {retries: 1}, () => {
+      (isRancherManagerVersion('>2.14') ? it.skip : it)('Install App on imported cluster', {retries: 1}, () => {
         cy.checkChart(clusterName, 'Install', 'Logging', 'cattle-logging-system');
       })
     );

--- a/tests/cypress/latest/e2e/capd_rke2_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capd_rke2_clusterclass.spec.ts
@@ -106,7 +106,8 @@ describe('Import CAPD RKE2 Class-Cluster', {tags: '@short'}, () => {
 
   context('[CLUSTER-OPERATIONS]', () => {
     qase(101,
-      it('Install App on imported cluster', {retries: 1}, () => {
+      // TODO: Remove the condition once logging is supported on 2.15
+      (isRancherManagerVersion('>2.14') ? it.skip : it)('Install App on imported cluster', {retries: 1}, () => {
         cy.checkChart(clusterName, 'Install', 'Logging', 'cattle-logging-system');
       })
     );

--- a/tests/cypress/latest/e2e/capd_rke2_fleet_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capd_rke2_fleet_clusterclass.spec.ts
@@ -13,7 +13,7 @@ limitations under the License.
 
 import '../support/commands';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
-import {isUseCAAPFSupported, skipClusterDeletion} from '../support/utils';
+import {isUseCAAPFSupported, skipClusterDeletion, isRancherManagerVersion} from '../support/utils';
 import {capdResourcesCleanup, capiClusterDeletion, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
 import {vars} from '../support/variables';
 
@@ -102,7 +102,7 @@ describe('Import CAPD RKE2 (Default CNI) Class-Cluster using Fleet', {tags: '@sh
     })
     );
 
-    qase(432, it('Install App on imported cluster', {retries: 1}, () => {
+    qase(432, (isRancherManagerVersion('>2.14') ? it.skip : it)('Install App on imported cluster', {retries: 1}, () => {
       cy.checkChart(clusterName, 'Install', 'Logging', 'cattle-logging-system');
     })
     );

--- a/tests/cypress/latest/e2e/capd_rke2_migration_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capd_rke2_migration_clusterclass.spec.ts
@@ -150,7 +150,7 @@ describe('Import CAPD RKE2 Class-Cluster for Migration', {tags: '@migration'}, (
       })
       );
 
-      qase(409, it('Install App on imported cluster', {retries: 1}, () => {
+      qase(409, (isRancherManagerVersion('>2.14') ? it.skip : it)('Install App on imported cluster', {retries: 1}, () => {
         cy.checkChart(clusterName, 'Install', 'Logging', 'cattle-logging-system');
       })
       );

--- a/tests/cypress/latest/e2e/capd_rke2_nocaapf_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capd_rke2_nocaapf_clusterclass.spec.ts
@@ -1,6 +1,6 @@
 import '../support/commands';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
-import {isUseCAAPFSupported, skipClusterDeletion, turtlesNamespace} from '../support/utils';
+import {isUseCAAPFSupported, skipClusterDeletion, turtlesNamespace, isRancherManagerVersion} from '../support/utils';
 import {capdResourcesCleanup, capiClusterDeletion, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
 import {vars} from '../support/variables';
 
@@ -132,7 +132,7 @@ describe('Import CAPD RKE2 (Default CNI & No-Caapf) Class-Cluster using Fleet', 
     })
     );
 
-    qase(447, it('Install App on imported cluster', {retries: 1}, () => {
+    qase(447, (isRancherManagerVersion('>2.14') ? it.skip : it)('Install App on imported cluster', {retries: 1}, () => {
       cy.checkChart(clusterName, 'Install', 'Logging', 'cattle-logging-system');
     })
     );

--- a/tests/cypress/latest/e2e/capd_rke2_upgrade_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capd_rke2_upgrade_clusterclass.spec.ts
@@ -151,7 +151,7 @@ describe('Import CAPD RKE2 Class-Cluster for Upgrade', {tags: '@upgrade'}, () =>
       })
       );
 
-      qase(244, it('Install App on imported cluster', {retries: 1}, () => {
+      qase(244, (isRancherManagerVersion('>2.14') ? it.skip : it)('Install App on imported cluster', {retries: 1}, () => {
         cy.checkChart(clusterName, 'Install', 'Logging', 'cattle-logging-system');
       })
       );

--- a/tests/cypress/latest/e2e/capg_gke_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capg_gke_clusterclass.spec.ts
@@ -78,7 +78,7 @@ describe('Import CAPG GKE Class-Cluster', {tags: '@full'}, () => {
 
   context('[CLUSTER-OPERATIONS]', () => {
     qase(400,
-      it('Install App on imported cluster', {retries: 1}, () => {
+      (isRancherManagerVersion('>2.14') ? it.skip : it)('Install App on imported cluster', {retries: 1}, () => {
       // Install Chart
       // We install Logging chart instead of Monitoring, since this is relatively lightweight.
       cy.checkChart(clusterName, 'Install', 'Logging', 'cattle-logging-system');

--- a/tests/cypress/latest/e2e/capg_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capg_kubeadm_clusterclass.spec.ts
@@ -1,5 +1,5 @@
 import '../support/commands';
-import {getClusterName, isAPIv1beta1, skipClusterDeletion} from '../support/utils';
+import {getClusterName, isAPIv1beta1, skipClusterDeletion, isRancherManagerVersion} from '../support/utils';
 import {capiClusterDeletion, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
 import {vars} from '../support/variables';
 
@@ -78,7 +78,7 @@ describe('Import CAPG Kubeadm Class-Cluster', {tags: '@full'}, () => {
 
   context('[CLUSTER-OPERATIONS]', () => {
     qase(145,
-      it('Install App on imported cluster', {retries: 1}, () => {
+      (isRancherManagerVersion('>2.14') ? it.skip : it)('Install App on imported cluster', {retries: 1}, () => {
         cy.checkChart(clusterName, 'Install', 'Logging', 'cattle-logging-system');
       })
     );

--- a/tests/cypress/latest/e2e/capv_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capv_kubeadm_clusterclass.spec.ts
@@ -116,7 +116,7 @@ describe('Import CAPV Kubeadm Class-Cluster', {tags: '@vsphere'}, () => {
   })
 
   context('[CLUSTER-OPERATIONS]', () => {
-    qase(290, it('Install App on imported cluster', {retries: 1}, () => {
+    qase(290, (isRancherManagerVersion('>2.14') ? it.skip : it)('Install App on imported cluster', {retries: 1}, () => {
       cy.checkChart(clusterName, 'Install', 'Logging', 'cattle-logging-system');
     })
     );

--- a/tests/cypress/latest/e2e/capv_rke2_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capv_rke2_clusterclass.spec.ts
@@ -207,7 +207,7 @@ describe('Import CAPV RKE2 Class-Cluster', {tags: '@vsphere'}, () => {
       })
     );
 
-    qase(280, it('Install App on imported cluster', {retries: 1}, () => {
+    qase(280, (isRancherManagerVersion('>2.14') ? it.skip : it)('Install App on imported cluster', {retries: 1}, () => {
       cy.checkChart(clusterName, 'Install', 'Logging', 'cattle-logging-system');
     })
     );

--- a/tests/cypress/latest/e2e/capz_aks_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capz_aks_clusterclass.spec.ts
@@ -1,5 +1,5 @@
 import '../support/commands';
-import {getClusterName, isAPIv1beta1, skipClusterDeletion} from '../support/utils';
+import {getClusterName, isAPIv1beta1, skipClusterDeletion, isRancherManagerVersion} from '../support/utils';
 import {capiClusterDeletion, capzResourcesCleanup, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
 import {vars} from '../support/variables';
 
@@ -80,7 +80,7 @@ describe('Import CAPZ AKS Class-Cluster', {tags: '@full'}, () => {
   })
 
   context('[CLUSTER-OPERATIONS]', () => {
-    qase(57, it('Install App on imported cluster', {retries: 1}, () => {
+    qase(57, (isRancherManagerVersion('>2.14') ? it.skip : it)('Install App on imported cluster', {retries: 1}, () => {
       cy.checkChart(clusterName, 'Install', 'Logging', 'cattle-logging-system');
       })
     );

--- a/tests/cypress/latest/e2e/capz_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capz_kubeadm_clusterclass.spec.ts
@@ -82,7 +82,7 @@ describe('Import CAPZ Kubeadm Class-Cluster', {tags: '@full'}, () => {
   })
 
   context('[CLUSTER-OPERATIONS]', () => {
-    qase(333, it('Install App on imported cluster', {retries: 1}, () => {
+    qase(333, (isRancherManagerVersion('>2.14') ? it.skip : it)('Install App on imported cluster', {retries: 1}, () => {
       cy.checkChart(clusterName, 'Install', 'Logging', 'cattle-logging-system');
     })
     );

--- a/tests/cypress/latest/e2e/capz_rke2_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capz_rke2_clusterclass.spec.ts
@@ -85,7 +85,7 @@ describe('Import CAPZ RKE2 Class-Cluster', {tags: '@full'}, () => {
 
   context('[CLUSTER-OPERATIONS]', () => {
 
-    qase(80, it('Install App on imported cluster', {retries: 1}, () => {
+    qase(80, (isRancherManagerVersion('>2.14') ? it.skip : it)('Install App on imported cluster', {retries: 1}, () => {
       cy.checkChart(clusterName, 'Install', 'Logging', 'cattle-logging-system');
       })
     );


### PR DESCRIPTION
### What does this PR do?
Skip installApp test for time being, until logging chart is available on 2.15 https://github.com/rancher/charts/blob/dev-v2.15/charts/rancher-logging/109.0.0%2Bup4.10.0-rancher.23/Chart.yaml#L10

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [ ] Added/Modified Qase IDs
- [ ] GitHub Actions (if applicable)

### Special notes for your reviewer:

<!-- e2e-result-start -->
### E2E Test Results:

| Run Name | Run Result | Notes |
|----------|------------|-------|
| [[4511] Rancher-prime/2.14.2 - **@install @short** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/26945482841) | ✅ Pass | |
| [[4512] Rancher-prime-alpha/2.15.0-alpha8 - **@install @short** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/26945501873) | ✅ Pass | |
<!-- e2e-result-end -->



