### PR TITLE
[updatecli] Bump Logging stack

### DIFF
--- a/.github/scripts/collect-rancher-logs.sh
+++ b/.github/scripts/collect-rancher-logs.sh
@@ -13,7 +13,7 @@ RANCHER_LOG_COLLECTER_SHA256="e1cec23568c1c5846021a0833b4bf134952bb7c7dfdc936520
 # RANCHER_LOG_COLLECTER_SHA256="$(curl -sSfL "${RANCHER_LOG_COLLECTER}" | sha256sum | awk '{print $1}')"
 
 # crust-gather installer (pinned by tag + checksum)
-CRUST_GATHER_INSTALLER_VERSION="v0.15.1"
+CRUST_GATHER_INSTALLER_VERSION="v0.15.2"
 CRUST_GATHER_INSTALLER="https://raw.githubusercontent.com/crust-gather/crust-gather/refs/tags/${CRUST_GATHER_INSTALLER_VERSION}/install.sh"
 CRUST_GATHER_INSTALLER_SHA256="b51cb2f18a7452e70b0d0f3090428a46ed97257ed0572c808f06e30885c29e4b"
 # To refresh SHA256:

--- a/.github/scripts/collect-rancher-logs.sh
+++ b/.github/scripts/collect-rancher-logs.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 # Variables
 
 # Rancher support-tools log collector (pinned by commit + checksum)
-RANCHER_LOG_COLLECTER_COMMIT="ac0a4b0bd44588076fc4f493e7d3d72aea177049"
+RANCHER_LOG_COLLECTER_COMMIT="1becdb3376660ad3cdbc3c5e3d98e94d7c41fa37"
 RANCHER_LOG_COLLECTER_PATH="collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh"
 RANCHER_LOG_COLLECTER="https://raw.githubusercontent.com/rancherlabs/support-tools/${RANCHER_LOG_COLLECTER_COMMIT}/${RANCHER_LOG_COLLECTER_PATH}"
 RANCHER_LOG_COLLECTER_SHA256="e1cec23568c1c5846021a0833b4bf134952bb7c7dfdc936520c3f650dd2573a1"

--- a/.github/scripts/collect-rancher-logs.sh
+++ b/.github/scripts/collect-rancher-logs.sh
@@ -8,7 +8,7 @@ set -eo pipefail
 RANCHER_LOG_COLLECTER_COMMIT="1becdb3376660ad3cdbc3c5e3d98e94d7c41fa37"
 RANCHER_LOG_COLLECTER_PATH="collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh"
 RANCHER_LOG_COLLECTER="https://raw.githubusercontent.com/rancherlabs/support-tools/${RANCHER_LOG_COLLECTER_COMMIT}/${RANCHER_LOG_COLLECTER_PATH}"
-RANCHER_LOG_COLLECTER_SHA256="e1cec23568c1c5846021a0833b4bf134952bb7c7dfdc936520c3f650dd2573a1"
+RANCHER_LOG_COLLECTER_SHA256="d7a1233b84086f6261cf0540134216acb603b7298b940da1713db1165eccc642"
 # To refresh SHA256:
 # RANCHER_LOG_COLLECTER_SHA256="$(curl -sSfL "${RANCHER_LOG_COLLECTER}" | sha256sum | awk '{print $1}')"
 


### PR DESCRIPTION



<Actions>
    <action id="fdc5aa0d7e06cc670109465f997bff0f67b8c13799d4afda24e5278dca1fc741">
        <h3>[updatecli] Bump Logging stack</h3>
        <details id="01e7e68cb41d692733c759ca1c9c1a7e09b47ffc6a494d68b6ab6dadf6d0a9f6">
            <summary>Update RANCHER_LOG_COLLECTER_COMMIT</summary>
            <p>1 file(s) updated with &#34;RANCHER_LOG_COLLECTER_COMMIT=\&#34;1becdb3376660ad3cdbc3c5e3d98e94d7c41fa37\&#34;&#34;:&#xA;&#xA;* .github/scripts/collect-rancher-logs.sh&#xA;</p>
        </details>
        <details id="0eed0951f0365cba215f9242c789286595d10da091b6b387b4061dfb93990980">
            <summary>Update CRUST_GATHER_INSTALLER_VERSION</summary>
            <p>1 file(s) updated with &#34;CRUST_GATHER_INSTALLER_VERSION=\&#34;v0.15.2\&#34;&#34;:&#xA;&#xA;* .github/scripts/collect-rancher-logs.sh&#xA;</p>
            <details>
                <summary>v0.15.2</summary>
                <pre>## What&#39;s Changed&#xD;&#xA;* Bump serde_json from 1.0.149 to 1.0.150 by @dependabot[bot] in https://github.com/crust-gather/crust-gather/pull/479&#xD;&#xA;* Bump http from 1.4.0 to 1.4.1 in the dependencies group by @dependabot[bot] in https://github.com/crust-gather/crust-gather/pull/480&#xD;&#xA;* Bump serde-saphyr from 0.0.26 to 0.0.27 by @dependabot[bot] in https://github.com/crust-gather/crust-gather/pull/482&#xD;&#xA;* Bump chrono from 0.4.44 to 0.4.45 by @dependabot[bot] in https://github.com/crust-gather/crust-gather/pull/484&#xD;&#xA;* Bump serde_with from 3.20.0 to 3.21.0 by @dependabot[bot] in https://github.com/crust-gather/crust-gather/pull/485&#xD;&#xA;* Skip collection of logs or events html via flags by @Danil-Grigorev in https://github.com/crust-gather/crust-gather/pull/486&#xD;&#xA;&#xD;&#xA;&#xD;&#xA;**Full Changelog**: https://github.com/crust-gather/crust-gather/compare/v0.15.1...v0.15.2</pre>
            </details>
        </details>
        <details id="711c2be3606875e78c8aee49b71d89b08fec39ff4704c369395d9d1afd69f2a2">
            <summary>Update RANCHER_LOG_COLLECTER_SHA256</summary>
            <p>1 file(s) updated with &#34;RANCHER_LOG_COLLECTER_SHA256=\&#34;d7a1233b84086f6261cf0540134216acb603b7298b940da1713db1165eccc642\&#34;&#34;:&#xA;&#xA;* .github/scripts/collect-rancher-logs.sh&#xA;</p>
        </details>
        <a href="https://github.com/rancher/rancher-turtles-e2e/actions/runs/27199922589">GitHub Action workflow link</a>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50" />
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>



<!-- e2e-result-start -->
### E2E Test Results:

| Run Name | Run Result | Notes |
|----------|------------|-------|
| [[4564] Rancher-head/2.14 - **@install** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/27207570307) | ✅ Pass | |
<!-- e2e-result-end -->
