### PR TITLE
Enable airgap precheck also for 2.13

### DIFF
--- a/tests/e2e/airgap_precheck_test.go
+++ b/tests/e2e/airgap_precheck_test.go
@@ -94,10 +94,10 @@ func getAsoVersion() string {
 
 var _ = Describe("E2E - Airgap Precheck Tests", Label("airgap"), func() {
 	BeforeEach(func() {
-		// Test is suitable for Prime and rancher >= 2.14 only
+		// Test is suitable for Prime and rancher >= 2.13 only
 		// Although it can be expanded to support community channels where we need basically check only rancher/cluster-api-controller (also in env) and rancher/turtles images
-		if !strings.Contains(rancherChannel, "prime") || isRancherManagerVersion("<2.14") {
-			Skip(fmt.Sprintf("Skipping airgap precheck: requires prime channel and Rancher >= 2.14 (channel=%q, version=%s)", rancherChannel, rancherVersion))
+		if !strings.Contains(rancherChannel, "prime") || isRancherManagerVersion("<2.13") {
+			Skip(fmt.Sprintf("Skipping airgap precheck: requires prime channel and Rancher >= 2.13 (channel=%q, version=%s)", rancherChannel, rancherVersion))
 		}
 	})
 


### PR DESCRIPTION
### What does this PR do?
Enables airgap precheck test also for 2.13 - so now all Rancher Prime versions with embedded Turtles are covered 

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [x] Squashed commits into logical changes
- [ ] Documentation
- [ ] Added/Modified Qase IDs
- [x] GitHub Actions (if applicable) https://github.com/rancher/rancher-turtles-e2e/actions/runs/27542643157/job/81408013491#step:4:62 (failed but it found missing artifact)
