### PR TITLE
Add retry to including prerelease version and check/wait for system-upgrade-controller deployment

### DIFF
--- a/tests/cypress/latest/e2e/turtles_chart.spec.ts
+++ b/tests/cypress/latest/e2e/turtles_chart.spec.ts
@@ -26,7 +26,7 @@ describe('Install Turtles Chart - @install', {tags: '@install'}, () => {
     cy.burgerMenuOperate('open');
   });
 
-  qase(151, it("Change helm charts to Include Prerelease Versions", () => {
+  qase(151, it("Change helm charts to Include Prerelease Versions", {retries: 1}, () => {
     // this test should be run before the turtles repository is added; so that it can fetch the prereleased versions
 
     // toggle the navigation menu to a close

--- a/tests/cypress/latest/e2e/turtles_chart.spec.ts
+++ b/tests/cypress/latest/e2e/turtles_chart.spec.ts
@@ -26,7 +26,7 @@ describe('Install Turtles Chart - @install', {tags: '@install'}, () => {
     cy.burgerMenuOperate('open');
   });
 
-  qase(151, it("Change helm charts to Include Prerelease Versions", {retries: 1}, () => {
+  qase(151, it("Change helm charts to Include Prerelease Versions", () => {
     // this test should be run before the turtles repository is added; so that it can fetch the prereleased versions
 
     // toggle the navigation menu to a close
@@ -34,10 +34,10 @@ describe('Install Turtles Chart - @install', {tags: '@install'}, () => {
 
     cy.getBySel('nav_header_showUserMenu').click();
     cy.contains('Preferences').click();
-    cy.contains("Include Prerelease Versions").click();
+    cy.contains("Include Prerelease Versions").scrollIntoView().should('be.visible').click();
     cy.reload();
     // check that the prerelease version is selected by ensuring it does not have `bg-disabled` class
-    cy.contains("Include Prerelease Versions").should('not.have.class', 'bg-disabled');
+    cy.contains("Include Prerelease Versions").scrollIntoView().should('not.have.class', 'bg-disabled');
   })
   );
 

--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -174,6 +174,7 @@ var _ = Describe("E2E - Install/Upgrade Rancher Manager", Label("install", "upgr
 			if isRancherManagerVersion(">=2.13") {
 				waitForResourceCondition("cattle-turtles-system", "deployments/rancher-turtles-controller-manager", "Available")
 				waitForResourceCondition("cattle-capi-system", "deployments/capi-controller-manager", "Available")
+				waitForResourceCondition("cattle-system", "deployments/system-upgrade-controller", "Available")
 			}
 		})
 	})


### PR DESCRIPTION
### What does this PR do?
1. `qase(151, it("Change helm charts to Include Prerelease Versions", ` fails quite often, and then everything else fails, adding a retry should help.
2. Absence of `system-upgrade-controller` deployment sometimes causes system-integrated charts to continually get re-deployed. Adding a check for that to install_test.go should help avoid this.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [ ] Added/Modified Qase IDs
- [ ] GitHub Actions (if applicable)

### Special notes for your reviewer:

<!-- e2e-result-start -->
### E2E Test Results:

| Run Name | Run Result | Notes |
|----------|------------|-------|
| [[4667] Rancher-prime-alpha/2.15.0-alpha12 - **@install @capdk** dev=false destroy=false](https://github.com/rancher/rancher-turtles-e2e/actions/runs/27677040263) | ❌ Fail | |
| [[4666] Rancher-prime/2.14.2 - **@install @capdk** dev=false destroy=false](https://github.com/rancher/rancher-turtles-e2e/actions/runs/27677018175) | ✅ Pass | |
| [[4669] Rancher-prime/2.15.0-alpha12 - **@install** dev=false destroy=false](https://github.com/rancher/rancher-turtles-e2e/actions/runs/27679619005) | ❌ Fail | |
| [[4670] Rancher-prime/2.14.2 - **@install @capdk** dev=false destroy=false](https://github.com/rancher/rancher-turtles-e2e/actions/runs/27679646674) | ❌ Fail | |
| [[4671] Rancher-prime-alpha/2.15.0-alpha12 - **@install** dev=false destroy=false](https://github.com/rancher/rancher-turtles-e2e/actions/runs/27680119382) | ❌ Fail | |
| [[4674] Rancher-prime-alpha/2.13.7-alpha2 - **@install** dev=false destroy=false](https://github.com/rancher/rancher-turtles-e2e/actions/runs/27680702218) | ✅ Pass | |
| [[4672] Rancher-prime-alpha/2.14.3-alpha2 - **@install @capdk** dev=false destroy=false](https://github.com/rancher/rancher-turtles-e2e/actions/runs/27680342677) | ❌ Fail | |
<!-- e2e-result-end -->







