### PR TITLE
Update GCP templates with recent gh-runner

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -90,7 +90,7 @@ on:
         type: boolean
       runner_template:
         description: Runner template to use
-        default: rancher-turtles-e2e-ci-spot-20260417075336903600000001
+        default: rancher-turtles-e2e-ci-spot-20260622121628751700000001
         type: string
       test_description:
         description: Short description of the test

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -90,7 +90,7 @@ on:
         type: boolean
       runner_template:
         description: Runner template to use
-        default: rancher-turtles-e2e-ci-spot-20260622121628751700000001
+        default: rancher-turtles-e2e-ci-spot-20260622165944418700000001
         type: string
       test_description:
         description: Short description of the test

--- a/.github/workflows/ui-e2e.yaml
+++ b/.github/workflows/ui-e2e.yaml
@@ -53,11 +53,11 @@ on:
         type: boolean
       runner_template:
         description: Runner template to use
-        default: rancher-turtles-e2e-ci-spot-20260417075336903600000001
+        default: rancher-turtles-e2e-ci-spot-20260622121628751700000001
         type: choice
         options:
-          - rancher-turtles-e2e-ci-spot-20260417075336903600000001
-          - rancher-turtles-e2e-ci-standard-20260417075451469600000001
+          - rancher-turtles-e2e-ci-spot-20260622121628751700000001
+          - rancher-turtles-e2e-ci-standard-20260622121820708300000001
   schedule:
     - cron: '0 3 * * *' # @short
     - cron: '0 4 * * *' # @vsphere
@@ -97,6 +97,6 @@ jobs:
       target_build_type: ${{ inputs.target_build_type || 'prime' }}
       turtles_chart_version: ${{ inputs.turtles_chart_version }}
       skip_cluster_delete: ${{ inputs.skip_cluster_delete || (github.event_name == 'schedule' && false) }}
-      runner_template: ${{ inputs.runner_template || 'rancher-turtles-e2e-ci-spot-20260417075336903600000001' }}
+      runner_template: ${{ inputs.runner_template || 'rancher-turtles-e2e-ci-spot-20260622121628751700000001' }}
       cluster_name_suffix: ${{ inputs.cluster_name_suffix || github.run_number }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag || (github.event.schedule == '0 3 * * *' && '@install @short') || (github.event.schedule == '0 4 * * *' && '@install @vsphere') || (github.event.schedule == '0 5 * * 6' && '@install @full') || (github.event.schedule == '0 3 * * 6' && '@install @migration @short') || (github.event.schedule == '0 5 * * 0' && '@install @upgrade') }}

--- a/.github/workflows/ui-e2e.yaml
+++ b/.github/workflows/ui-e2e.yaml
@@ -53,11 +53,11 @@ on:
         type: boolean
       runner_template:
         description: Runner template to use
-        default: rancher-turtles-e2e-ci-spot-20260622121628751700000001
+        default: rancher-turtles-e2e-ci-spot-20260622165944418700000001
         type: choice
         options:
-          - rancher-turtles-e2e-ci-spot-20260622121628751700000001
-          - rancher-turtles-e2e-ci-standard-20260622121820708300000001
+          - rancher-turtles-e2e-ci-spot-20260622165944418700000001
+          - rancher-turtles-e2e-ci-standard-20260622170026005600000001
   schedule:
     - cron: '0 3 * * *' # @short
     - cron: '0 4 * * *' # @vsphere
@@ -97,6 +97,6 @@ jobs:
       target_build_type: ${{ inputs.target_build_type || 'prime' }}
       turtles_chart_version: ${{ inputs.turtles_chart_version }}
       skip_cluster_delete: ${{ inputs.skip_cluster_delete || (github.event_name == 'schedule' && false) }}
-      runner_template: ${{ inputs.runner_template || 'rancher-turtles-e2e-ci-spot-20260622121628751700000001' }}
+      runner_template: ${{ inputs.runner_template || 'rancher-turtles-e2e-ci-spot-20260622165944418700000001' }}
       cluster_name_suffix: ${{ inputs.cluster_name_suffix || github.run_number }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag || (github.event.schedule == '0 3 * * *' && '@install @short') || (github.event.schedule == '0 4 * * *' && '@install @vsphere') || (github.event.schedule == '0 5 * * 6' && '@install @full') || (github.event.schedule == '0 3 * * 6' && '@install @migration @short') || (github.event.schedule == '0 5 * * 0' && '@install @upgrade') }}


### PR DESCRIPTION
### What does this PR do?
updated gh runner version via google secret - new templates generated

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [ ] Added/Modified Qase IDs
- [ ] GitHub Actions (if applicable)

### Special notes for your reviewer:

<!-- e2e-result-start -->
### E2E Test Results:

| Run Name | Run Result | Notes |
|----------|------------|-------|
| [[4740] Rancher-head/2.14 - **@install** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/27970303387) | ✅ Pass | spot - dynamic runner version|
| [[4741] Rancher-head/2.14 - **@install** dev=true destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/27970332131) | ✅ Pass | standard - dynamic runner version |
<!-- e2e-result-end -->

Updated gh runner version visible here https://github.com/rancher/rancher-turtles-e2e/actions/runs/27952478764/job/82712682262#step:1:1




