### PR TITLE
[updatecli] Bump k3s installer

### DIFF
--- a/tests/e2e/install_test.go
+++ b/tests/e2e/install_test.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	k3sInstallerFile    = "k3s-install.sh"
-	k3sInstallerVersion = "v1.36.1+k3s1"
+	k3sInstallerVersion = "v1.36.2+k3s1"
 	k3sInstallerURL     = "https://raw.githubusercontent.com/k3s-io/k3s/" + k3sInstallerVersion + "/install.sh"
 	k3sInstallerSHA256  = "46177d4c99440b4c0311b67233823a8e8a2fc09693f6c89af1a7161e152fbfad"
 )


### PR DESCRIPTION



<Actions>
    <action id="bc308357a13af12c0f2ba64d370c763fc0231a051f2b98c63d47810c3b010093">
        <h3>[updatecli] Bump k3s installer</h3>
        <details id="c5c7365dd3f6a20e071c8e455e157ef295c3d83cec9775b1fab1a69808a9c50b">
            <summary>Update k3sInstallerVersion</summary>
            <p>1 file(s) updated with &#34;$1$2\&#34;v1.36.2+k3s1\&#34;&#34;:&#xA;&#xA;* tests/e2e/install_test.go&#xA;</p>
            <details>
                <summary>v1.36.2+k3s1</summary>
                <pre>&lt;!-- v1.36.2+k3s1 --&gt;&#xD;&#xA;&gt; [!WARNING]&#xD;&#xA;&gt; This release upgrades Traefik chart to v40.x which includes a breaking change for the ingress-nginx migration: the provider name changes from `kubernetesIngressNginx` to `kubernetesIngressNGINX`. Check https://github.com/traefik/traefik-helm-chart/releases/tag/v40.0.0 for more details&#xD;&#xA;&#xD;&#xA;This release updates Kubernetes to v1.36.2, and fixes a number of issues.&#xD;&#xA;&#xD;&#xA;For more details on what&#39;s new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.36.md#changelog-since-v1361).&#xD;&#xA;&#xD;&#xA;## Changes since v1.36.1+k3s1:&#xD;&#xA;&#xD;&#xA;* Backport GitHub Action SHA pin updates from main [(#14127)](https://github.com/k3s-io/k3s/pull/14127)&#xD;&#xA;* Backports for 2026-06 [(#14151)](https://github.com/k3s-io/k3s/pull/14151)&#xD;&#xA;* Bump v3.7.4 Traefik [(#14193)](https://github.com/k3s-io/k3s/pull/14193)&#xD;&#xA;* More backports for 2026-06 [(#14211)](https://github.com/k3s-io/k3s/pull/14211)&#xD;&#xA;* Testing Backports 2026-06 [(#14213)](https://github.com/k3s-io/k3s/pull/14213)&#xD;&#xA;* Bump klipper-helm for CVE reasons (#14235) [(#14236)](https://github.com/k3s-io/k3s/pull/14236)&#xD;&#xA;* Bump containerd with the fix for []byte [(#14243)](https://github.com/k3s-io/k3s/pull/14243)&#xD;&#xA;* Update to v1.36.2-k3s1 and Go 1.26.4 [(#14230)](https://github.com/k3s-io/k3s/pull/14230)&#xD;&#xA;* Bump containerd to v2.3.2-k3s1 [(#14254)](https://github.com/k3s-io/k3s/pull/14254)&#xD;&#xA;* Bump cri-api and containerd for upstream env string fix [(#14277)](https://github.com/k3s-io/k3s/pull/14277)&#xD;&#xA;&#xD;&#xA;## Embedded Component Versions&#xD;&#xA;| Component | Version |&#xD;&#xA;|---|---|&#xD;&#xA;| Kubernetes | [v1.36.2](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.36.md#v1362) |&#xD;&#xA;| Kine | [v0.16.1](https://github.com/k3s-io/kine/releases/tag/v0.16.1) |&#xD;&#xA;| SQLite | [3.53.0](https://sqlite.org/releaselog/3_53_0.html) |&#xD;&#xA;| Etcd | [v3.6.12-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.6.12-k3s1) |&#xD;&#xA;| Containerd | [v2.3.2-k3s2](https://github.com/k3s-io/containerd/releases/tag/v2.3.2-k3s2) |&#xD;&#xA;| Runc | [v1.4.2](https://github.com/opencontainers/runc/releases/tag/v1.4.2) |&#xD;&#xA;| Flannel | [v0.28.4](https://github.com/flannel-io/flannel/releases/tag/v0.28.4) | &#xD;&#xA;| Metrics-server | [v0.8.1](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.1) |&#xD;&#xA;| Traefik | [v3.7.4](https://github.com/traefik/traefik/releases/tag/v3.7.4) |&#xD;&#xA;| CoreDNS | [v1.14.4](https://github.com/coredns/coredns/releases/tag/v1.14.4) | &#xD;&#xA;| Helm-controller | [v0.17.1](https://github.com/k3s-io/helm-controller/releases/tag/v0.17.1) |&#xD;&#xA;| Local-path-provisioner | [v0.0.36](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.36) |&#xD;&#xA;&#xD;&#xA;## Helpful Links&#xD;&#xA;As always, we welcome and appreciate feedback from our community of users. Please feel free to:&#xD;&#xA;- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)&#xD;&#xA;- [Join our Slack channel](https://slack.rancher.io/)&#xD;&#xA;- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.&#xD;&#xA;- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)&#xD;&#xA;</pre>
            </details>
        </details>
        <a href="https://github.com/rancher/rancher-turtles-e2e/actions/runs/28835350531">GitHub Action workflow link</a>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50" />
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>



<!-- e2e-result-start -->
### E2E Test Results:

| Run Name | Run Result | Notes |
|----------|------------|-------|
| [[4920] Rancher-head/2.14 - **@install** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/28856259545) | ✅ Pass | |
<!-- e2e-result-end -->
