### PR TITLE
CAPZ RKE2/Kubeadm tests with No-caapf

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -281,6 +281,8 @@ jobs:
       SPECS: |
         e2e/capd_kubeadm_nocaapf_clusterclass.spec.ts
         e2e/capd_rke2_nocaapf_clusterclass.spec.ts
+        e2e/capz_kubeadm_nocaapf_clusterclass.spec.ts
+        e2e/capz_rke2_nocaapf_clusterclass.spec.ts
         e2e/providers_setup_legacy.spec.ts
         e2e/providers_setup.spec.ts
         e2e/capd_rke2_clusterclass.spec.ts

--- a/tests/cypress/latest/e2e/capd_kubeadm_nocaapf_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capd_kubeadm_nocaapf_clusterclass.spec.ts
@@ -1,10 +1,10 @@
 import '../support/commands';
-import {getClusterName, isUseCAAPFSupported, skipClusterDeletion, turtlesNamespace, isRancherManagerVersion, getCAPIClusterKubeconfig, applyCalicoCNIManifest, providersChartNeedsStgRegistry} from '../support/utils';
+import {getClusterName, isUseCAAPFSupported, skipClusterDeletion, turtlesNamespace, isRancherManagerVersion, getCAPIClusterKubeconfig, applyYAMLManifest, providersChartNeedsStgRegistry} from '../support/utils';
 import {capiClusterDeletion, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
 import {vars} from '../support/variables';
 
 Cypress.config();
-describe('Import CAPD Kubeadm (Calico CNI & No-Caapf) Class-Cluster', {tags: ['@short', '@nocaapf']}, () => {
+describe('Import CAPD Kubeadm (No-Caapf) Class-Cluster', {tags: ['@short', '@nocaapf']}, () => {
   const timeout = vars.shortTimeout
   const classNamePrefix = 'docker-kubeadm'
   const clusterName = getClusterName(classNamePrefix)
@@ -33,7 +33,8 @@ describe('Import CAPD Kubeadm (Calico CNI & No-Caapf) Class-Cluster', {tags: ['@
     );
 
     // We install providers chart here because the test runs before providers_setup.spec.ts
-    qase(440, it('Install turtles-providers-chart for Docker, Kubeadm', () => {
+    // TODO: Move providers installation to separate file
+    qase(440, it('Install turtles-providers-chart for all providers', () => {
       const providerSelectionFunction = (text: any) => {
         // @ts-ignore
         text.providers.bootstrapKubeadm.enabled = true;
@@ -49,6 +50,23 @@ describe('Import CAPD Kubeadm (Calico CNI & No-Caapf) Class-Cluster', {tags: ['@
         text.providers.infrastructureDocker.enabled = true;
         // @ts-ignore
         text.providers.infrastructureDocker.enableAutomaticUpdate = true;
+
+        // @ts-ignore
+        text.providers.infrastructureGCP.enabled = true;
+        // @ts-ignore
+        text.providers.infrastructureGCP.enableAutomaticUpdate = true;
+        // @ts-ignore
+        text.providers.infrastructureGCP.variables.GCP_B64ENCODED_CREDENTIALS = '';
+
+        // @ts-ignore
+        text.providers.infrastructureAzure.enabled = true;
+        // @ts-ignore
+        text.providers.infrastructureAzure.enableAutomaticUpdate = true;
+
+        // @ts-ignore
+        text.providers.infrastructureAWS.enabled = true;
+        // @ts-ignore
+        text.providers.infrastructureAWS.enableAutomaticUpdate = true;
       }
 
       let turtlesProvidersChartVersion = providersChartNeedsStgRegistry() && isRancherManagerVersion('2.14') ? '0.26' : providersChartNeedsStgRegistry() && isRancherManagerVersion('2.15') ? '0.27' : undefined
@@ -79,12 +97,15 @@ describe('Import CAPD Kubeadm (Calico CNI & No-Caapf) Class-Cluster', {tags: ['@
 
         // Check CAPI cluster using its name
         cy.checkCAPICluster(clusterName);
+
+        // Check CAPI cluster status
+        cy.checkCAPIClusterCPInitialized(clusterName);
       })
     );
 
     qase(6,
       it('Apply Calico CNI manifest', () => {
-        cy.kubectlExecute([getCAPIClusterKubeconfig(clusterName), applyCalicoCNIManifest(clusterName)]);
+        cy.kubectlExecute([getCAPIClusterKubeconfig(clusterName), applyYAMLManifest(clusterName, vars.calicoCNIYaml)], 5000);
       })
     );
 

--- a/tests/cypress/latest/e2e/capd_rke2_nocaapf_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capd_rke2_nocaapf_clusterclass.spec.ts
@@ -5,7 +5,7 @@ import {capdResourcesCleanup, capiClusterDeletion, importedRancherv3ClusterDelet
 import {vars} from '../support/variables';
 
 Cypress.config();
-describe('Import CAPD RKE2 (Default CNI & No-Caapf) Class-Cluster using Fleet', {tags: ['@short', '@nocaapf']}, () => {
+describe('Import CAPD RKE2 (No-Caapf) Class-Cluster using Fleet', {tags: ['@short', '@nocaapf']}, () => {
   let clusterName: string
   const timeout = vars.shortTimeout
   const classNamePrefix = 'docker-rke2'

--- a/tests/cypress/latest/e2e/capz_kubeadm_nocaapf_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capz_kubeadm_nocaapf_clusterclass.spec.ts
@@ -1,0 +1,151 @@
+import '../support/commands';
+import {getClusterName, isUseCAAPFSupported, skipClusterDeletion, isRancherManagerVersion, getCAPIClusterKubeconfig, applyYAMLManifest} from '../support/utils';
+import {capiClusterDeletion, capzResourcesCleanup, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
+import {vars} from '../support/variables';
+
+Cypress.config();
+describe('Import CAPZ Kubeadm (No-Caapf) Class-Cluster', {tags: ['@full', '@nocaapf']}, () => {
+  const timeout = vars.fullTimeout
+  const classNamePrefix = 'azure-kubeadm'
+  const clusterName = getClusterName(classNamePrefix)
+  const classesPath = 'examples/clusterclasses/azure/kubeadm'
+  const clusterClassRepoName = "azure-kubeadm-clusterclass"
+  const classClusterFileName = './fixtures/azure/capz-kubeadm-class-cluster-nocaapf.yaml'
+
+  const clientID = Cypress.expose("azure_client_id")
+  const clientSecret = btoa(Cypress.expose("azure_client_secret"))
+  const subscriptionID = Cypress.expose("azure_subscription_id")
+  const tenantID = Cypress.expose("azure_tenant_id")
+
+  const azureCCMFileName = "cloud-provider-azure.yaml"
+  const azureCCMCmd = ["wget " + vars.azureCCMYaml, "sed -i 's|${CLUSTER_CIDR}|192.168.0.0/16|g' " + azureCCMFileName, applyYAMLManifest(clusterName, azureCCMFileName)] 
+
+  // Azure CCM fails to install when using v1.35
+  const k8sVersion = isRancherManagerVersion('2.14') ? 'v1.34.1'
+    : vars.kubeadmVersion
+
+  beforeEach(function () {
+    if (!isUseCAAPFSupported) {
+      // This test is only meant for >=2.14.1
+      this.skip();
+    }
+    cy.login();
+    cy.burgerMenuOperate('open');
+  });
+
+  context('[SETUP]', () => {
+    qase(329, it('Setup the namespace for importing', () => {
+      cy.namespaceAutoImport('Disable');
+    })
+    );
+
+    qase(346, it('Create AzureClusterIdentity', () => {
+      cy.createAzureClusterIdentity(clientID, tenantID, clientSecret)
+    })
+    );
+
+    qase(330, it('Add CAPZ Kubeadm ClusterClass Fleet Repo', () => {
+      cy.addFleetGitRepo(clusterClassRepoName, vars.turtlesRepoUrl, vars.classBranch, classesPath, vars.capiClassesNS)
+      // Go to CAPI > ClusterClass to ensure the clusterclass is created
+      cy.checkCAPIClusterClass(classNamePrefix);
+      })
+    );
+  })
+
+  context('[CLUSTER-IMPORT]', () => {
+    qase(331, it('Import CAPZ Kubeadm class-cluster using YAML', () => {
+      cy.readFile(classClusterFileName).then((data) => {
+        data = data.replace(/replace_cluster_name/g, clusterName)
+        data = data.replace(/replace_k8sVersion/g, k8sVersion)
+        data = data.replace(/replace_subscription_id/g, subscriptionID)
+        cy.importYAML(data, vars.capiClustersNS)
+      });
+      // Check CAPI cluster using its name
+      cy.checkCAPICluster(clusterName);
+
+      // Check CAPI cluster status
+      cy.checkCAPIClusterCPInitialized(clusterName);
+    })
+    );
+
+    it('Apply the CNI & CCM manifest', () => {
+      cy.kubectlExecute([getCAPIClusterKubeconfig(clusterName), applyYAMLManifest(clusterName, vars.calicoCNIYaml), azureCCMCmd[0], azureCCMCmd[1], azureCCMCmd[2]], 15000);
+    })
+
+    qase(332, it('Auto import child CAPZ Kubeadm cluster', () => {
+      // Go to Cluster Management > CAPI > Clusters and check if the cluster has provisioned
+      cy.checkCAPIClusterProvisioned(clusterName, timeout);
+
+      // Check child cluster is created and auto-imported
+      // This is checked by ensuring the cluster is available in navigation menu
+      cy.goToHome();
+      cy.contains(clusterName, {timeout: timeout}).should('exist');
+
+      // Check cluster is Active
+      cy.searchCluster(clusterName);
+      cy.contains(new RegExp('Active.*' + clusterName), {timeout: timeout});
+
+      // Go to Cluster Management > CAPI > Clusters and check if the cluster has provisioned
+      // Ensuring cluster is provisioned also ensures all the Cluster Management > Advanced > Machines for the given cluster are Active.
+      cy.checkCAPIClusterActive(clusterName, timeout);
+    })
+    );
+  })
+
+  context('[CLUSTER-OPERATIONS]', () => {
+    qase(333, (isRancherManagerVersion('>2.14') ? it.skip : it)('Install App on imported cluster', {retries: 1}, () => {
+      cy.checkChart(clusterName, 'Install', 'Logging', 'cattle-logging-system');
+    })
+    );
+
+    qase(334, it("Scale up imported CAPZ cluster by patching class-cluster yaml", () => {
+      cy.readFile(classClusterFileName).then((data) => {
+        data = data.replace(/replicas: 2/g, 'replicas: 3')
+
+        // workaround; these values need to be re-replaced before applying the scaling changes
+        data = data.replace(/replace_cluster_name/g, clusterName)
+        data = data.replace(/replace_k8sVersion/g, k8sVersion)
+        data = data.replace(/replace_subscription_id/g, subscriptionID)
+        cy.importYAML(data, vars.capiClustersNS)
+      })
+
+      // Check CAPI cluster status
+      cy.checkCAPIMenu();
+      cy.contains('Machine Deployments').click();
+      cy.typeInFilter(clusterName);
+      cy.get('.content > .count', {timeout: timeout}).should('have.text', '3');
+      cy.checkCAPIClusterActive(clusterName);
+    })
+    );
+
+    it('Check for any errors in Turtles logs', () => {
+      // Check for any errors
+      cy.filterPodErrorLogs('rancher-turtles-controller-manager');
+    })
+  })
+
+  context('[TEARDOWN]', () => {
+    if (skipClusterDeletion) {
+      qase(366, it('Remove imported CAPZ cluster from Rancher Manager', () => {
+        // Delete the imported cluster
+        // Ensure that the provisioned CAPI cluster still exists
+        importedRancherv3ClusterDeletion(clusterName);
+      })
+      );
+
+      qase(336, it('Delete the CAPZ cluster', {retries: 1}, () => {
+        // Remove CAPI Resources related to the cluster
+        capiClusterDeletion(clusterName, timeout);
+      })
+      );
+
+      qase(337, it('Delete the ClusterClass fleet repo and other resources', () => {
+        // Remove the clusterclass repo
+        cy.removeFleetGitRepo(clusterClassRepoName);
+        // Cleanup other resources
+        capzResourcesCleanup();
+      })
+      );
+    }
+  })
+});

--- a/tests/cypress/latest/e2e/capz_rke2_nocaapf_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capz_rke2_nocaapf_clusterclass.spec.ts
@@ -1,0 +1,146 @@
+import '../support/commands';
+import {getClusterName, skipClusterDeletion, isRancherManagerVersion} from '../support/utils';
+import {capiClusterDeletion, capzResourcesCleanup, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
+import {vars} from '../support/variables';
+
+Cypress.config();
+describe('Import CAPZ RKE2 (No-Caapf) Class-Cluster', {tags: ['@full', '@nocaapf']}, () => {
+  const timeout = vars.fullTimeout
+  const classNamePrefix = 'azure-rke2'
+  const clusterName = getClusterName(classNamePrefix)
+  const classesPath = 'examples/clusterclasses/azure/rke2'
+  const clusterClassRepoName = classNamePrefix + '-clusterclass'
+  const classClusterFileName = './fixtures/azure/capz-rke2-class-cluster-nocaapf.yaml'
+
+  const clientID = Cypress.expose("azure_client_id")
+  const clientSecret = btoa(Cypress.expose("azure_client_secret"))
+  const subscriptionID = Cypress.expose("azure_subscription_id")
+  const tenantID = Cypress.expose("azure_tenant_id")
+
+  // Azure CCM fails to install when using v1.35
+  const k8sVersion = isRancherManagerVersion('2.14') ? 'v1.34.1+rke2r1'
+  : vars.rke2Version
+
+  beforeEach(function () {
+    if (isRancherManagerVersion('<2.15')) {
+      // This test will only work on Rancher >= 2.15, Turtles >= 0.27
+      this.skip();
+    }
+    cy.login();
+    cy.burgerMenuOperate('open');
+  });
+
+  context('[SETUP]', () => {
+    qase(326, it('Setup the namespace for importing', () => {
+      cy.namespaceAutoImport('Disable');
+    })
+    );
+
+    qase(345, it('Create AzureClusterIdentity', () => {
+      cy.createAzureClusterIdentity(clientID, tenantID, clientSecret)
+    })
+    );
+
+    qase(87, it('Add CAPZ RKE2 ClusterClass Fleet Repo', () => {
+        cy.addFleetGitRepo(clusterClassRepoName, vars.turtlesRepoUrl, vars.classBranch, classesPath, vars.capiClassesNS)
+        // Go to CAPI > ClusterClass to ensure the clusterclass is created
+        cy.checkCAPIClusterClass(classNamePrefix);
+      })
+    );
+  })
+
+  context('[CLUSTER-IMPORT]', () => {
+    qase(78,
+      it('Import CAPZ RKE2 class-cluster using YAML', () => {
+        cy.readFile(classClusterFileName).then((data) => {
+          data = data.replace(/replace_cluster_name/g, clusterName)
+          data = data.replace(/replace_subscription_id/g, subscriptionID)
+          data = data.replace(/replace_rke2_version/g, k8sVersion)
+          data = data.replace(/replace_azure_ccm_version/g, vars.azureCCMVersion)
+          cy.importYAML(data, vars.capiClustersNS)
+        });
+        // Check CAPI cluster using its name
+        cy.checkCAPICluster(clusterName);
+      })
+    );
+
+    qase(79, it('Auto import child CAPZ RKE2 cluster', () => {
+        // Go to Cluster Management > CAPI > Clusters and check if the cluster has provisioned
+        cy.checkCAPIClusterProvisioned(clusterName, timeout);
+
+        // Check child cluster is created and auto-imported
+        // This is checked by ensuring the cluster is available in navigation menu
+        cy.goToHome();
+        cy.contains(clusterName).should('exist');
+
+        // Check cluster is Active
+        cy.searchCluster(clusterName);
+        cy.contains(new RegExp('Active.*' + clusterName), {timeout: timeout});
+
+        // Go to Cluster Management > CAPI > Clusters and check if the cluster has provisioned
+        // Ensuring cluster is provisioned also ensures all the Cluster Management > Advanced > Machines for the given cluster are Active.
+        cy.checkCAPIClusterActive(clusterName, timeout);
+      })
+    );
+  })
+
+  context('[CLUSTER-OPERATIONS]', () => {
+
+    qase(80, (isRancherManagerVersion('>2.14') ? it.skip : it)('Install App on imported cluster', {retries: 1}, () => {
+      cy.checkChart(clusterName, 'Install', 'Logging', 'cattle-logging-system');
+      })
+    );
+
+    qase(327, it("Scale up imported CAPZ cluster by patching class-cluster yaml", () => {
+      cy.readFile(classClusterFileName).then((data) => {
+        data = data.replace(/replicas: 2/g, 'replicas: 3')
+
+        // workaround; these values need to be re-replaced before applying the scaling changes
+        data = data.replace(/replace_cluster_name/g, clusterName)
+        data = data.replace(/replace_subscription_id/g, subscriptionID)
+        data = data.replace(/replace_rke2_version/g, k8sVersion)
+        data = data.replace(/replace_azure_ccm_version/g, vars.azureCCMVersion)
+        cy.importYAML(data, vars.capiClustersNS)
+      })
+
+      // Check CAPI cluster status
+      cy.checkCAPIMenu();
+      cy.contains('Machine Deployments').click();
+      cy.typeInFilter(clusterName);
+      cy.get('.content > .count', {timeout: timeout}).should('have.text', '3');
+      cy.checkCAPIClusterActive(clusterName);
+    })
+    );
+
+    it('Check for any errors in Turtles logs', () => {
+      // Check for any errors
+      cy.filterPodErrorLogs('rancher-turtles-controller-manager');
+    })
+  })
+
+  context('[TEARDOWN]', () => {
+    if (skipClusterDeletion) {
+      qase(365, it('Remove imported CAPZ cluster from Rancher Manager', () => {
+        // Delete the imported cluster
+        // Ensure that the provisioned CAPI cluster still exists
+        importedRancherv3ClusterDeletion(clusterName);
+      })
+      );
+
+      qase(82,
+        it('Delete the CAPZ cluster', {retries: 1}, () => {
+          // Remove CAPI Resources related to the cluster
+          capiClusterDeletion(clusterName, timeout);
+        })
+      );
+
+      qase(83, it('Delete the ClusterClass fleet repo and other resources', () => {
+          // Remove the clusterclass repo
+          cy.removeFleetGitRepo(clusterClassRepoName);
+          // Cleanup other resources
+          capzResourcesCleanup();
+        })
+      );
+    }
+  })
+});

--- a/tests/cypress/latest/fixtures/azure/capz-kubeadm-class-cluster-nocaapf.yaml
+++ b/tests/cypress/latest/fixtures/azure/capz-kubeadm-class-cluster-nocaapf.yaml
@@ -1,0 +1,33 @@
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Cluster
+metadata:
+  labels:
+    owner: turtles-qa
+    cluster-api.cattle.io/rancher-auto-import: "true"
+  name: replace_cluster_name
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+  topology:
+    classRef:
+      name: azure-kubeadm-example
+      namespace: capi-classes
+    controlPlane:
+      replicas: 3
+    variables:
+      - name: subscriptionID
+        value: "replace_subscription_id"
+      - name: location
+        value: westeurope # the community image for provisioning Azure VM is only available in certain locations
+      - name: resourceGroup
+        value: replace_cluster_name
+      - name: azureClusterIdentityName
+        value: cluster-identity
+    version: replace_k8sVersion
+    workers:
+      machineDeployments:
+        - class: kubeadm-default-worker
+          name: md-0
+          replicas: 2

--- a/tests/cypress/latest/fixtures/azure/capz-rke2-class-cluster-nocaapf.yaml
+++ b/tests/cypress/latest/fixtures/azure/capz-rke2-class-cluster-nocaapf.yaml
@@ -1,0 +1,69 @@
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Cluster
+metadata:
+  labels:
+    owner: turtles-qa
+    cluster-api.cattle.io/rancher-auto-import: "true"
+  name: replace_cluster_name
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+  topology:
+    classRef:
+      name: azure-rke2-example
+      namespace: capi-classes
+    controlPlane:
+      replicas: 3
+    variables:
+      - name: subscriptionID
+        value: "replace_subscription_id"
+      - name: location
+        value: westeurope # the community image for provisioning Azure VM is only available in certain locations
+      - name: resourceGroup
+        value: replace_cluster_name
+      - name: azureClusterIdentityName
+        value: cluster-identity
+    version: replace_rke2_version
+    workers:
+      machineDeployments:
+        - class: rke2-default-worker
+          name: md-0
+          replicas: 2
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cloud-provider-azure
+data:
+  cloud-provider-azure.yaml: |-
+    apiVersion: helm.cattle.io/v1
+    kind: HelmChart
+    metadata:
+      name: azure-ccm
+      namespace: kube-system
+    spec:
+      repo: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+      chart: cloud-provider-azure
+      bootstrap: true
+      version: "replace_azure_ccm_version"
+      targetNamespace: kube-system
+      valuesContent: |-
+        infra:
+          clusterName: replace_cluster_name
+        cloudControllerManager:
+          clusterCIDR: 192.168.0.0/16
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta2
+kind: ClusterResourceSet
+metadata:
+  name: cloud-provider-azure
+spec:
+  strategy: Reconcile
+  clusterSelector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: 'replace_cluster_name'
+  resources:
+    - name: cloud-provider-azure
+      kind: ConfigMap

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -1384,7 +1384,7 @@ Cypress.Commands.add('checkExternalFleetAnnotation', (clusterName, required = tr
 });
 
 // Commands to execute on kubectl shell
-Cypress.Commands.add('kubectlExecute', (commands: string[]) => {
+Cypress.Commands.add('kubectlExecute', (commands: string[], timeout = 3000) => {
   cy.searchCluster('local');
   cy.getBySel('sortable-table-0-action-button').click();
   cy.get('i.icon.group-icon.icon-terminal').should('be.visible').click();
@@ -1393,7 +1393,7 @@ Cypress.Commands.add('kubectlExecute', (commands: string[]) => {
     cy.get('.shell-body')
       .type(command, {parseSpecialCharSequences: false})
       .type('{enter}');
-    cy.wait(5000);
+    cy.wait(timeout);
   })
   cy.getBySel('wm-tab-close-button').click();
 });
@@ -1405,6 +1405,29 @@ Cypress.Commands.add('viewCAPIClusterYAML', (clusterName) => {
   // click the three-dots menu and click View YAML
   cy.getBySel('sortable-table-0-action-button').click();
   cy.contains('View YAML').click();
+});
+
+Cypress.Commands.add('checkCAPIClusterCPInitialized', (clusterName) => {
+  function checkCAPIClusterCP(retries = 20) {
+    cy.get('.CodeMirror-scroll').invoke('text').then((text) => {
+      if (text.replace(/\s+/g, '').includes('controlPlaneInitialized:true')) {
+        return;
+      }
+
+      if (retries <= 0) {
+        cy.contains(text).should('exist');
+        return;
+      }
+      cy.log(`Refreshing... (${retries} retries remaining)`);
+      cy.wait(15000);
+      cy.reload();
+
+      checkCAPIClusterCP(retries - 1);
+    });
+  }
+
+  cy.viewCAPIClusterYAML(clusterName);
+  checkCAPIClusterCP();
 });
 
 Cypress.Commands.add('filterPodErrorLogs', (podName) => {

--- a/tests/cypress/latest/support/e2e.ts
+++ b/tests/cypress/latest/support/e2e.ts
@@ -87,7 +87,8 @@ declare global {
       createDockerAuthSecret(): Chainable<Element>;
       checkExternalFleetAnnotation(clustername: string, required?: boolean): Chainable<Element>;
       viewCAPIClusterYAML(clustername: string): Chainable<Element>;
-      kubectlExecute(commands: string[]): Chainable<Element>;
+      checkCAPIClusterCPInitialized(clustername: string): Chainable<Element>;
+      kubectlExecute(commands: string[], timeout?: number): Chainable<Element>;
       filterPodErrorLogs(podName: string): Chainable<Element>;
       // Functions declared in capz_support.js
       createAzureClusterIdentity(clientID: string, tenantID: string, clientSecret: string): Chainable<Element>;

--- a/tests/cypress/latest/support/utils.ts
+++ b/tests/cypress/latest/support/utils.ts
@@ -69,9 +69,9 @@ export const getCAPIClusterKubeconfig = (
   clusterName: string,
   namespace: string = 'capi-clusters'
 ): string => {
-  return `kubectl get secret -n ${namespace} ${clusterName}-kubeconfig -o jsonpath='{.data.value}' | base64 -d > ${clusterName}.yaml`;
+  return `kubectl get secret -n ${namespace} ${clusterName}-kubeconfig -o jsonpath='{.data.value}' | base64 -d > ${clusterName}-kubeconfig.yaml`;
 };
 
-export const applyCalicoCNIManifest = (clusterName: string): string => {
-  return `kubectl --kubeconfig=${clusterName}.yaml apply -f https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/applications/calico.yaml`
+export const applyYAMLManifest = (clusterName: string, path: string): string => {
+  return `kubectl --kubeconfig=${clusterName}-kubeconfig.yaml apply -f ${path}`
 };

--- a/tests/cypress/latest/support/variables.ts
+++ b/tests/cypress/latest/support/variables.ts
@@ -37,5 +37,8 @@ export const vars = {
   : isRancherManagerVersion('2.14')
   ? 'cluster-api-ubuntu-2404-v1-35-0-1770652401'
   : 'cluster-api-ubuntu-2404-v1-36-1-1779178908',
-  chartUpdateOperation: isRancherManagerVersion('>=2.13') ? 'Edit' : 'Update'
+  chartUpdateOperation: isRancherManagerVersion('>=2.13') ? 'Edit' : 'Update',
+  azureCCMVersion: '1.36.0',
+  calicoCNIYaml: 'https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/applications/calico.yaml',
+  azureCCMYaml: 'https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/applications/cloud-provider-azure.yaml'
 };


### PR DESCRIPTION
### What does this PR do?
- Adds CAPZ RKE2/Kubeadm tests with No-caapf
- Corresponding function changes

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [ ] Added/Modified Qase IDs
- [ ] GitHub Actions (if applicable)

### Special notes for your reviewer:

<!-- e2e-result-start -->
### E2E Test Results:

| Run Name | Run Result | Notes |
|----------|------------|-------|
| [[4890] Rancher-prime/2.14.3 - **@install @nocaapf** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/28653259588) | ✅ Pass | |
| [[4891] Rancher-prime-alpha/2.15.0-alpha14 - **@install @nocaapf** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/28653288294) | ❌ Fail | |
<!-- e2e-result-end -->














