### PR TITLE
Enhance providers setup for no-caapf tests

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -571,7 +571,7 @@ jobs:
       - name: Set Rancher Manager Upgrade version
         if: ${{ contains(inputs.grep_test_by_tag, '@upgrade') }}
         run: |
-          echo "RANCHER_VERSION=prime-alpha/2.14.4-alpha3" >> ${GITHUB_ENV}
+          echo "RANCHER_VERSION=prime-alpha/2.14.4-alpha5" >> ${GITHUB_ENV}
       - name: Upgrade Rancher Manager
         if: ${{ contains(inputs.grep_test_by_tag, '@migration') || contains(inputs.grep_test_by_tag, '@upgrade') }}
         env:

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -279,6 +279,8 @@ jobs:
 
       # Common specs: @short @vsphere @full
       SPECS: |
+        e2e/providers_setup_legacy.spec.ts
+        e2e/providers_setup.spec.ts
         e2e/capd_kubeadm_nocaapf_clusterclass.spec.ts
         e2e/capd_rke2_nocaapf_clusterclass.spec.ts
         e2e/capa_eks_nocaapf_clusterclass.spec.ts
@@ -288,8 +290,7 @@ jobs:
         e2e/capz_rke2_nocaapf_clusterclass.spec.ts
         e2e/capg_kubeadm_nocaapf_clusterclass.spec.ts
         e2e/capg_gke_nocaapf_clusterclass.spec.ts
-        e2e/providers_setup_legacy.spec.ts
-        e2e/providers_setup.spec.ts
+        e2e/fleet_addon_provider_setup.spec.ts
         e2e/capd_rke2_clusterclass.spec.ts
         e2e/capd_rke2_fleet_clusterclass.spec.ts
         e2e/capd_kubeadm_clusterclass.spec.ts

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -334,11 +334,11 @@ jobs:
             echo "SPECS=" >> ${GITHUB_ENV}
           elif [[ "${{ inputs.grep_test_by_tag }}" =~ "@upgrade" ]]; then
             # Required for upgrade tests
-            echo "RANCHER_VERSION=prime/2.13.5" >> ${GITHUB_ENV}
+            echo "RANCHER_VERSION=prime/2.13.7" >> ${GITHUB_ENV}
             echo "COMMON_SPECS=$(echo "${{ env.SPECS }}" | tr '\n' ' ')" >> ${GITHUB_ENV}
           elif [[ "${{ inputs.grep_test_by_tag }}" =~ "@switch" ]]; then
             # Required for switch tests
-            echo "RANCHER_VERSION=prime/2.13.5" >> ${GITHUB_ENV}
+            echo "RANCHER_VERSION=prime/2.13.7" >> ${GITHUB_ENV}
             echo "COMMON_SPECS=$(echo "${{ env.SPECS }}" | tr '\n' ' ')" >> ${GITHUB_ENV}
           else
             echo "RANCHER_VERSION=${{ inputs.rancher_version }}" >> ${GITHUB_ENV}
@@ -566,7 +566,7 @@ jobs:
       - name: Set Rancher Manager Upgrade version
         if: ${{ contains(inputs.grep_test_by_tag, '@upgrade') }}
         run: |
-          echo "RANCHER_VERSION=prime/2.14.3" >> ${GITHUB_ENV}
+          echo "RANCHER_VERSION=prime-alpha/2.14.4-alpha3" >> ${GITHUB_ENV}
       - name: Upgrade Rancher Manager
         if: ${{ contains(inputs.grep_test_by_tag, '@migration') || contains(inputs.grep_test_by_tag, '@upgrade') }}
         env:

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -124,6 +124,10 @@ on:
       target_build_type:
         description: Build type for turtles_dev_chart (prime|community)
         type: string
+      skip_fleet_addon_installation:
+        description: Skip Fleet Addon provider installation
+        type: boolean
+        default: false
 
 jobs:
   determine-runner:
@@ -260,6 +264,7 @@ jobs:
       CLUSTER_NAME_SUFFIX: ${{ inputs.cluster_name_suffix }}
       BUILD_TYPE: ${{ inputs.target_build_type }}
       TURTLES_DEV_CHART: ${{ inputs.turtles_dev_chart }}
+      SKIP_FLEET_ADDON_INSTALLATION: ${{ inputs.skip_fleet_addon_installation }}
       # Secrets
       AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_key }}

--- a/.github/workflows/ui-e2e.yaml
+++ b/.github/workflows/ui-e2e.yaml
@@ -47,6 +47,10 @@ on:
         description: Skip CAPI cluster and fleet repo deletion tests
         default: false
         type: boolean
+      skip_fleet_addon_installation:
+        description: Skip fleet addon installation tests; useful while debugging only NoCAAPF tests
+        default: false
+        type: boolean
       qase_report:
         description: Report to QASE
         default: false
@@ -100,3 +104,4 @@ jobs:
       runner_template: ${{ inputs.runner_template || 'rancher-turtles-e2e-ci-spot-20260622165944418700000001' }}
       cluster_name_suffix: ${{ inputs.cluster_name_suffix || github.run_number }}
       grep_test_by_tag: ${{ inputs.grep_test_by_tag || (github.event.schedule == '0 3 * * *' && '@install @short') || (github.event.schedule == '0 4 * * *' && '@install @vsphere') || (github.event.schedule == '0 5 * * 6' && '@install @full') || (github.event.schedule == '0 3 * * 6' && '@install @migration @short') || (github.event.schedule == '0 5 * * 0' && '@install @upgrade') }}
+      skip_fleet_addon_installation: ${{ inputs.skip_fleet_addon_installation || (github.event_name == 'schedule' && false) }}

--- a/tests/cypress/latest/e2e/capa_eks_nocaapf_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capa_eks_nocaapf_clusterclass.spec.ts
@@ -1,5 +1,5 @@
 import '../support/commands';
-import {getClusterName, isUseCAAPFSupported, isRancherManagerVersion, skipClusterDeletion} from '../support/utils';
+import {getClusterName, isRancherManagerVersion, skipClusterDeletion} from '../support/utils';
 import {capaResourcesCleanup, capiClusterDeletion, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
 import {vars} from '../support/variables';
 
@@ -15,11 +15,15 @@ describe('Import CAPA EKS (No-Caapf) Class-Cluster', {tags: ['@full', '@nocaapf'
   const accessKey = Cypress.expose('aws_access_key')
   const secretKey = Cypress.expose('aws_secret_key')
 
-  beforeEach(function () {
-    if (!isUseCAAPFSupported) {
-      // This test is only meant for >=2.14.1
-      this.skip();
+  before(function () {
+    if (isRancherManagerVersion('<2.15')) {
+      return cy.task('suiteLog', "NoCAAPF is unsupported on Rancher Version <2.15; skipping...").then(() => {
+        this.skip();
+      })
     }
+  })
+
+  beforeEach(function () {
     cy.login();
     cy.burgerMenuOperate('open');
   });

--- a/tests/cypress/latest/e2e/capa_rke2_nocaapf_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capa_rke2_nocaapf_clusterclass.spec.ts
@@ -4,7 +4,7 @@ import {capaResourcesCleanup, capiClusterDeletion, importedRancherv3ClusterDelet
 import {vars} from '../support/variables';
 
 Cypress.config();
-describe('Import CAPA RKE2 (No-Caapf) Class-Cluster', {tags: ['@full', '@nocaapf', '@capar-nocaapf']}, () => {
+describe('Import CAPA RKE2 (No-Caapf) Class-Cluster', {tags: ['@full', '@full-nocaapf', '@nocaapf', '@capar-nocaapf']}, () => {
   let ccID: string;
   const timeout = vars.fullTimeout
   const classNamePrefix = 'aws-rke2'
@@ -28,9 +28,7 @@ describe('Import CAPA RKE2 (No-Caapf) Class-Cluster', {tags: ['@full', '@nocaapf
     })
     );
 
-    it('Add Cloud credentials & Get Cloud credential ID', () => {
-      cy.addCloudCredsAWS(providerName, Cypress.expose('aws_access_key'), Cypress.expose('aws_secret_key'));
-      cy.burgerMenuOperate('open');
+    it('Get Cloud credential ID', () => {
       cy.accesMenuSelection(['Cluster Management', 'Cloud Credentials']);
       cy.getBySel('sortable-table-list-container').should('be.visible');
       cy.typeInFilter(providerName);
@@ -164,7 +162,6 @@ describe('Import CAPA RKE2 (No-Caapf) Class-Cluster', {tags: ['@full', '@nocaapf
           cy.removeFleetGitRepo(clusterClassRepoName);
           // Cleanup other resources
           capaResourcesCleanup();
-          cy.deleteCloudCredsAWS(providerName);
         })
       );
     }

--- a/tests/cypress/latest/e2e/capa_rke2_nocaapf_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capa_rke2_nocaapf_clusterclass.spec.ts
@@ -17,6 +17,14 @@ describe('Import CAPA RKE2 (No-Caapf) Class-Cluster', {tags: ['@full', '@full-no
   const accessKey = Cypress.expose('aws_access_key')
   const secretKey = Cypress.expose('aws_secret_key')
 
+  before(function () {
+    if (isRancherManagerVersion('<2.15')) {
+      return cy.task('suiteLog', "NoCAAPF is unsupported on Rancher Version <2.15; skipping...").then(() => {
+        this.skip();
+      })
+    }
+  })
+
   beforeEach(() => {
     cy.login();
     cy.burgerMenuOperate('open');

--- a/tests/cypress/latest/e2e/capd_kubeadm_nocaapf_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capd_kubeadm_nocaapf_clusterclass.spec.ts
@@ -1,10 +1,10 @@
 import '../support/commands';
-import {getClusterName, isUseCAAPFSupported, skipClusterDeletion, turtlesNamespace, isRancherManagerVersion, getCAPIClusterKubeconfig, applyYAMLManifest, providersChartNeedsStgRegistry} from '../support/utils';
+import {getClusterName, isUseCAAPFSupported, skipClusterDeletion, isRancherManagerVersion, getCAPIClusterKubeconfig, applyYAMLManifest} from '../support/utils';
 import {capiClusterDeletion, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
 import {vars} from '../support/variables';
 
 Cypress.config();
-describe('Import CAPD Kubeadm (No-Caapf) Class-Cluster', {tags: ['@install', '@short', '@nocaapf', '@capdk-nocaapf']}, () => {
+describe('Import CAPD Kubeadm (No-Caapf) Class-Cluster', {tags: ['@short', '@nocaapf', '@capdk-nocaapf']}, () => {
   const timeout = vars.shortTimeout
   const classNamePrefix = 'docker-kubeadm'
   const clusterName = getClusterName(classNamePrefix)
@@ -29,52 +29,6 @@ describe('Import CAPD Kubeadm (No-Caapf) Class-Cluster', {tags: ['@install', '@s
 
     qase(439, it('Setup the namespace for importing', () => {
       cy.namespaceAutoImport('Disable');
-    })
-    );
-
-    // We install providers chart here because the test runs before providers_setup.spec.ts
-    // TODO: Move providers installation to separate file
-    qase(440, it('Install turtles-providers-chart for all providers', () => {
-      const providerSelectionFunction = (text: any) => {
-        // @ts-ignore
-        text.providers.bootstrapKubeadm.enabled = true;
-        // @ts-ignore
-        text.providers.bootstrapKubeadm.enableAutomaticUpdate = true;
-
-        // @ts-ignore
-        text.providers.controlplaneKubeadm.enabled = true;
-        // @ts-ignore
-        text.providers.controlplaneKubeadm.enableAutomaticUpdate = true;
-
-        // @ts-ignore
-        text.providers.infrastructureDocker.enabled = true;
-        // @ts-ignore
-        text.providers.infrastructureDocker.enableAutomaticUpdate = true;
-
-        // @ts-ignore
-        text.providers.infrastructureGCP.enabled = true;
-        // @ts-ignore
-        text.providers.infrastructureGCP.enableAutomaticUpdate = true;
-        // @ts-ignore
-        text.providers.infrastructureGCP.variables.GCP_B64ENCODED_CREDENTIALS = '';
-
-        // @ts-ignore
-        text.providers.infrastructureAzure.enabled = true;
-        // @ts-ignore
-        text.providers.infrastructureAzure.enableAutomaticUpdate = true;
-
-        // @ts-ignore
-        text.providers.infrastructureAWS.enabled = true;
-        // @ts-ignore
-        text.providers.infrastructureAWS.enableAutomaticUpdate = true;
-      }
-
-      let turtlesProvidersChartVersion = providersChartNeedsStgRegistry() && isRancherManagerVersion('2.14') ? '0.26' : providersChartNeedsStgRegistry() && isRancherManagerVersion('2.15') ? '0.27' : undefined
-      // Install Rancher Turtles Certified Providers chart
-      cy.checkChart('local', 'Install', vars.turtlesProvidersChartName, turtlesNamespace, {
-        version: turtlesProvidersChartVersion,
-        modifyYAMLOperation: providerSelectionFunction
-      });
     })
     );
 

--- a/tests/cypress/latest/e2e/capd_kubeadm_nocaapf_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capd_kubeadm_nocaapf_clusterclass.spec.ts
@@ -1,5 +1,11 @@
 import '../support/commands';
-import {getClusterName, isUseCAAPFSupported, skipClusterDeletion, isRancherManagerVersion, getCAPIClusterKubeconfig, applyYAMLManifest} from '../support/utils';
+import {
+  getClusterName,
+  skipClusterDeletion,
+  isRancherManagerVersion,
+  getCAPIClusterKubeconfig,
+  applyYAMLManifest
+} from '../support/utils';
 import {capiClusterDeletion, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
 import {vars} from '../support/variables';
 
@@ -12,11 +18,15 @@ describe('Import CAPD Kubeadm (No-Caapf) Class-Cluster', {tags: ['@short', '@sho
   const clusterClassRepoName = "docker-kb-clusterclass"
   const classClusterFileName = "./fixtures/docker/capd-kubeadm-class-cluster-nocaapf.yaml"
 
-  beforeEach(function () {
-    if (!isUseCAAPFSupported) {
-      // This test is only meant for >=2.14.1
-      this.skip();
+  before(function () {
+    if (isRancherManagerVersion('<2.15')) {
+      return cy.task('suiteLog', "NoCAAPF is unsupported on Rancher Version <2.15; skipping...").then(() => {
+        this.skip();
+      })
     }
+  })
+
+  beforeEach(function () {
     cy.login();
     cy.burgerMenuOperate('open');
   });

--- a/tests/cypress/latest/e2e/capd_kubeadm_nocaapf_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capd_kubeadm_nocaapf_clusterclass.spec.ts
@@ -4,7 +4,7 @@ import {capiClusterDeletion, importedRancherv3ClusterDeletion} from "../support/
 import {vars} from '../support/variables';
 
 Cypress.config();
-describe('Import CAPD Kubeadm (No-Caapf) Class-Cluster', {tags: ['@short', '@nocaapf', '@capdk-nocaapf']}, () => {
+describe('Import CAPD Kubeadm (No-Caapf) Class-Cluster', {tags: ['@short', '@short-nocaapf', '@nocaapf', '@capdk-nocaapf']}, () => {
   const timeout = vars.shortTimeout
   const classNamePrefix = 'docker-kubeadm'
   const clusterName = getClusterName(classNamePrefix)
@@ -22,11 +22,6 @@ describe('Import CAPD Kubeadm (No-Caapf) Class-Cluster', {tags: ['@short', '@noc
   });
 
   context('[SETUP]', () => {
-    qase(438, it('Create Docker Resources', () => {
-      cy.createNamespace([vars.capiClustersNS]);
-    })
-    );
-
     qase(439, it('Setup the namespace for importing', () => {
       cy.namespaceAutoImport('Disable');
     })

--- a/tests/cypress/latest/e2e/capd_kubeadm_use_caapf_switch.spec.ts
+++ b/tests/cypress/latest/e2e/capd_kubeadm_use_caapf_switch.spec.ts
@@ -125,27 +125,11 @@ describe('Import CAPD Kubeadm Class-Cluster for Use-CAAPF Migration', {tags: ['@
     }))
 
     qase(595, it('Disable fleet-addon provider', () => {
-      const repositoryName = isTurtlesDevChart? "chartmuseum-repo": "turtles-providers-chart";
-      const resourceKind = 'clusterrepos.catalog.cattle.io';
-      const namespace = turtlesNamespace;
-      const patch = {spec: {OCIOptions: {'downloadAllTags': true}}};
-      cy.patchYamlResource('local', namespace, resourceKind, repositoryName, patch);
-
-      cy.typeInFilter(repositoryName);
-      // Make sure the repo is active before leaving
-      // Always press Refresh button as workaround for https://github.com/rancher/rancher/issues/49671
-      cy.getBySel('sortable-table-0-action-button').click();
-      cy.wait(1000);
-      cy.get('.icon.group-icon.icon-refresh').parent().click();
-      cy.wait(1000);
-      cy.contains(new RegExp('Active.*' + repositoryName), {timeout: 150000});
-
       const providerSelectionFunction = (text: any) => {
         // @ts-ignore
         text.providers.addonFleet.enabled = false;
       }
 
-      cy.burgerMenuOperate('open');
       // Update Rancher Turtles Certified Providers chart to disable the fleet addon provider
       cy.checkChart('local', vars.chartUpdateOperation, vars.turtlesProvidersChartName, turtlesNamespace, {
         modifyYAMLOperation: providerSelectionFunction,

--- a/tests/cypress/latest/e2e/capd_rke2_nocaapf_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capd_rke2_nocaapf_clusterclass.spec.ts
@@ -1,6 +1,6 @@
 import '../support/commands';
 import * as cypressLib from '@rancher-ecp-qa/cypress-library';
-import {isUseCAAPFSupported, skipClusterDeletion, isRancherManagerVersion} from '../support/utils';
+import {skipClusterDeletion, isRancherManagerVersion} from '../support/utils';
 import {capdResourcesCleanup, capiClusterDeletion, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
 import {vars} from '../support/variables';
 
@@ -14,11 +14,15 @@ describe('Import CAPD RKE2 (No-Caapf) Class-Cluster using Fleet', {tags: ['@shor
   const clustersRepoName = 'docker-rke2-class-clusters'
   const clusterClassRepoName = "docker-rke2-clusterclass"
 
-  beforeEach(function () {
-    if (!isUseCAAPFSupported) {
-      // This test is only meant for >=2.14.1
-      this.skip();
+  before(function () {
+    if (isRancherManagerVersion('<2.15')) {
+      return cy.task('suiteLog', "NoCAAPF is unsupported on Rancher Version <2.15; skipping...").then(() => {
+        this.skip();
+      })
     }
+  })
+
+  beforeEach(function () {
     cy.login();
     cy.burgerMenuOperate('open');
   });

--- a/tests/cypress/latest/e2e/capd_rke2_nocaapf_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capd_rke2_nocaapf_clusterclass.spec.ts
@@ -5,7 +5,7 @@ import {capdResourcesCleanup, capiClusterDeletion, importedRancherv3ClusterDelet
 import {vars} from '../support/variables';
 
 Cypress.config();
-describe('Import CAPD RKE2 (No-Caapf) Class-Cluster using Fleet', {tags: ['@short', '@nocaapf', '@capdr-nocaapf']}, () => {
+describe('Import CAPD RKE2 (No-Caapf) Class-Cluster using Fleet', {tags: ['@short', '@short-nocaapf', '@nocaapf', '@capdr-nocaapf']}, () => {
   let clusterName: string
   const timeout = vars.shortTimeout
   const classNamePrefix = 'docker-rke2'
@@ -25,9 +25,6 @@ describe('Import CAPD RKE2 (No-Caapf) Class-Cluster using Fleet', {tags: ['@shor
 
   context('[SETUP]', () => {
     qase(438, it('Create Docker Resources', () => {
-      // Docker rke2 lb-config
-      cy.addFleetGitRepo('lb-docker', vars.turtlesRepoUrl, vars.classBranch, 'examples/applications/lb/docker', vars.capiClustersNS);
-      cy.burgerMenuOperate('open');
       // Prevention for Docker.io rate limiting
       cy.createDockerAuthSecret();
     })
@@ -152,12 +149,5 @@ describe('Import CAPD RKE2 (No-Caapf) Class-Cluster using Fleet', {tags: ['@shor
       })
       );
     }
-
-    qase(451, it('Delete the docker resources', () => {
-      // Remove the lb-config
-      cy.removeFleetGitRepo('lb-docker');
-      cy.deleteKubernetesResource('local', ['Storage', 'ConfigMaps'], 'docker-rke2-lb-config', vars.capiClustersNS);
-    })
-    );
   })
 });

--- a/tests/cypress/latest/e2e/capg_gke_nocaapf_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capg_gke_nocaapf_clusterclass.spec.ts
@@ -1,5 +1,5 @@
 import '../support/commands';
-import {getClusterName, isUseCAAPFSupported, isRancherManagerVersion, skipClusterDeletion} from '../support/utils';
+import {getClusterName, isRancherManagerVersion, skipClusterDeletion} from '../support/utils';
 import {capiClusterDeletion, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
 import {vars} from '../support/variables';
 
@@ -16,11 +16,15 @@ describe('Import CAPG GKE (No-Caapf) Class-Cluster', {tags: ['@full', '@nocaapf'
   const gcpProject = Cypress.expose('gcp_project')
   const k8sVersion = 'v1.35.5'      // this version is different from GCP Kubeadm version
 
-  beforeEach(function () {
-    if (!isUseCAAPFSupported) {
-      // This test is only meant for >=2.14.1
-      this.skip();
+  before(function () {
+    if (isRancherManagerVersion('<2.15')) {
+      return cy.task('suiteLog', "NoCAAPF is unsupported on Rancher Version <2.15; skipping...").then(() => {
+        this.skip();
+      })
     }
+  })
+
+  beforeEach(function () {
     cy.login();
     cy.burgerMenuOperate('open');
   });

--- a/tests/cypress/latest/e2e/capg_kubeadm_nocaapf_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capg_kubeadm_nocaapf_clusterclass.spec.ts
@@ -1,5 +1,11 @@
 import '../support/commands';
-import {getClusterName, isUseCAAPFSupported, skipClusterDeletion, isRancherManagerVersion, getCAPIClusterKubeconfig, applyYAMLManifest} from '../support/utils';
+import {
+  getClusterName,
+  skipClusterDeletion,
+  isRancherManagerVersion,
+  getCAPIClusterKubeconfig,
+  applyYAMLManifest
+} from '../support/utils';
 import {capiClusterDeletion, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
 import {vars} from '../support/variables';
 
@@ -20,11 +26,15 @@ describe('Import CAPG Kubeadm (No-Caapf) Class-Cluster', {tags: ['@full', '@full
   const gcpCCMFileName = "cloud-provider-gcp.yaml"
   const gcpCCMCmd = [`wget ${vars.gcpCCMYaml}`, `sed -i 's|\${CLUSTER_CIDR}|192.168.0.0/16|g' ${gcpCCMFileName}`, applyYAMLManifest(clusterName, gcpCCMFileName)]
 
-  beforeEach(function () {
-    if (!isUseCAAPFSupported) {
-      // This test is only meant for >=2.14.1
-      this.skip();
+  before(function () {
+    if (isRancherManagerVersion('<2.15')) {
+      return cy.task('suiteLog', "NoCAAPF is unsupported on Rancher Version <2.15; skipping...").then(() => {
+        this.skip();
+      })
     }
+  })
+
+  beforeEach(function () {
     cy.login();
     cy.burgerMenuOperate('open');
   });

--- a/tests/cypress/latest/e2e/capg_kubeadm_nocaapf_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capg_kubeadm_nocaapf_clusterclass.spec.ts
@@ -35,22 +35,6 @@ describe('Import CAPG Kubeadm (No-Caapf) Class-Cluster', {tags: ['@full', '@noca
     })
     );
 
-    it('Initialize CAPG provider', () => {
-      // Verify GCP Infrastructure provider
-      cy.navigateToProviders();
-
-      cy.get('tr.main-row').contains('a', googleProvider).closest('tr').within(() => {
-        cy.get('td').eq(7).click();      // Action button
-      })
-      cy.contains('Edit Config').click();
-      cy.contains(`Provider: Google - ${googleProvider}`).should('exist');
-      cy.typeValue('Credential Name', googleProvider);
-      cy.getBySel('text-area-auto-grow').type(Cypress.expose('gcp_credentials'), {log: false});
-      cy.clickButton('Continue');
-      cy.getBySel('cluster-prov-select-credential').contains(googleProvider).should('be.visible');
-      cy.clickButton('Save');
-    })
-
     qase(148,
       it('Add CAPG Kubeadm ClusterClass Fleet Repo and check GCP CCM', () => {
         cy.addFleetGitRepo(clusterClassRepoName, vars.turtlesRepoUrl, vars.classBranch, classesPath, vars.capiClassesNS)

--- a/tests/cypress/latest/e2e/capg_kubeadm_nocaapf_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capg_kubeadm_nocaapf_clusterclass.spec.ts
@@ -4,7 +4,7 @@ import {capiClusterDeletion, importedRancherv3ClusterDeletion} from "../support/
 import {vars} from '../support/variables';
 
 Cypress.config();
-describe('Import CAPG Kubeadm (No-Caapf) Class-Cluster', {tags: ['@full', '@nocaapf', '@capgk-nocaapf']}, () => {
+describe('Import CAPG Kubeadm (No-Caapf) Class-Cluster', {tags: ['@full', '@full-nocaapf', '@nocaapf', '@capgk-nocaapf']}, () => {
   const timeout = vars.fullTimeout
   const classNamePrefix = 'gcp-kubeadm'
   const clusterName = getClusterName(classNamePrefix)

--- a/tests/cypress/latest/e2e/capz_aks_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capz_aks_clusterclass.spec.ts
@@ -12,7 +12,6 @@ describe('Import CAPZ AKS Class-Cluster', {tags: ['@full', '@capzaks']}, () => {
   const clusterClassRepoName = "azure-aks-clusterclass"
 
   const clientSecret = Cypress.expose("azure_client_secret")
-  const clientSecretBase64 = btoa(Cypress.expose("azure_client_secret"))
   const clientID = Cypress.expose("azure_client_id")
   const subscriptionID = Cypress.expose("azure_subscription_id")
   const tenantID = Cypress.expose("azure_tenant_id")
@@ -108,9 +107,7 @@ describe('Import CAPZ AKS Class-Cluster', {tags: ['@full', '@capzaks']}, () => {
         // Remove the clusterclass repo
         cy.removeFleetGitRepo(clusterClassRepoName);
         // Cleanup other resources
-        if (isAPIv1beta1) {
-          capzResourcesCleanup(false);
-        } else {
+        if (!isAPIv1beta1) {
           capzResourcesCleanup(true);
         }
       

--- a/tests/cypress/latest/e2e/capz_aks_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capz_aks_clusterclass.spec.ts
@@ -28,14 +28,12 @@ describe('Import CAPZ AKS Class-Cluster', {tags: ['@full', '@capzaks']}, () => {
     })
     );
 
-    qase(415, it('Create AzureASOCredential or AzureClusterIdentity', () => {
-      if (isAPIv1beta1) {
-        cy.createAzureClusterIdentity(clientID, tenantID, clientSecretBase64);
-      } else {
-        cy.createAzureASOCredential(clientID, tenantID, clientSecret, subscriptionID);
-      }
-    })
-    );
+    if (!isAPIv1beta1) {
+      qase(415, it('Create AzureASOCredential', () => {
+          cy.createAzureASOCredential(clientID, tenantID, clientSecret, subscriptionID);
+      })
+      );
+    }
 
     qase(84, it('Add CAPZ AKS ClusterClass using fleet', () => {
         cy.addFleetGitRepo(clusterClassRepoName, vars.turtlesRepoUrl, vars.classBranch, classesPath, vars.capiClassesNS)

--- a/tests/cypress/latest/e2e/capz_aks_nocaapf_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capz_aks_nocaapf_clusterclass.spec.ts
@@ -1,5 +1,5 @@
 import '../support/commands';
-import {getClusterName, isUseCAAPFSupported, skipClusterDeletion, isRancherManagerVersion} from '../support/utils';
+import {getClusterName, skipClusterDeletion, isRancherManagerVersion} from '../support/utils';
 import {capiClusterDeletion, capzResourcesCleanup, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
 import {vars} from '../support/variables';
 
@@ -17,11 +17,15 @@ describe('Import CAPZ AKS (No-Caapf) Class-Cluster', {tags: ['@full', '@nocaapf'
   const subscriptionID = Cypress.expose("azure_subscription_id")
   const tenantID = Cypress.expose("azure_tenant_id")
 
-  beforeEach(function () {
-    if (!isUseCAAPFSupported) {
-      // This test is only meant for >=2.14.1
-      this.skip();
+  before(function () {
+    if (isRancherManagerVersion('<2.15')) {
+      return cy.task('suiteLog', "NoCAAPF is unsupported on Rancher Version <2.15; skipping...").then(() => {
+        this.skip();
+      })
     }
+  })
+
+  beforeEach(function () {
     cy.login();
     cy.burgerMenuOperate('open');
   });

--- a/tests/cypress/latest/e2e/capz_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capz_kubeadm_clusterclass.spec.ts
@@ -1,6 +1,6 @@
 import '../support/commands';
 import {getClusterName, isAPIv1beta1, skipClusterDeletion, isRancherManagerVersion} from '../support/utils';
-import {capiClusterDeletion, capzResourcesCleanup, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
+import {capiClusterDeletion, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
 import {vars} from '../support/variables';
 
 Cypress.config();
@@ -123,8 +123,6 @@ describe('Import CAPZ Kubeadm Class-Cluster', {tags: ['@full', '@capzk']}, () =>
       qase(337, it('Delete the ClusterClass fleet repo and other resources', () => {
         // Remove the clusterclass repo
         cy.removeFleetGitRepo(clusterClassRepoName);
-        // Cleanup other resources
-        capzResourcesCleanup();
       })
       );
     }

--- a/tests/cypress/latest/e2e/capz_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capz_kubeadm_clusterclass.spec.ts
@@ -12,10 +12,7 @@ describe('Import CAPZ Kubeadm Class-Cluster', {tags: ['@full', '@capzk']}, () =>
   const clusterClassRepoName = "azure-kubeadm-clusterclass"
   const classClusterFileName = isAPIv1beta1 ? './fixtures/azure/capz-kubeadm-class-cluster-v1beta1.yaml' : './fixtures/azure/capz-kubeadm-class-cluster.yaml'
 
-  const clientID = Cypress.expose("azure_client_id")
-  const clientSecret = btoa(Cypress.expose("azure_client_secret"))
   const subscriptionID = Cypress.expose("azure_subscription_id")
-  const tenantID = Cypress.expose("azure_tenant_id")
 
   // Azure CCM fails to install when using v1.35
   const k8sVersion = isRancherManagerVersion('2.14') ? 'v1.34.1'
@@ -29,11 +26,6 @@ describe('Import CAPZ Kubeadm Class-Cluster', {tags: ['@full', '@capzk']}, () =>
   context('[SETUP]', () => {
     qase(329, it('Setup the namespace for importing', () => {
       cy.namespaceAutoImport('Disable');
-    })
-    );
-
-    qase(346, it('Create AzureClusterIdentity', () => {
-      cy.createAzureClusterIdentity(clientID, tenantID, clientSecret)
     })
     );
 

--- a/tests/cypress/latest/e2e/capz_kubeadm_nocaapf_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capz_kubeadm_nocaapf_clusterclass.spec.ts
@@ -1,5 +1,11 @@
 import '../support/commands';
-import {getClusterName, isUseCAAPFSupported, skipClusterDeletion, isRancherManagerVersion, getCAPIClusterKubeconfig, applyYAMLManifest} from '../support/utils';
+import {
+  getClusterName,
+  skipClusterDeletion,
+  isRancherManagerVersion,
+  getCAPIClusterKubeconfig,
+  applyYAMLManifest
+} from '../support/utils';
 import {capiClusterDeletion, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
 import {vars} from '../support/variables';
 
@@ -21,11 +27,15 @@ describe('Import CAPZ Kubeadm (No-Caapf) Class-Cluster', {tags: ['@full', '@full
   const k8sVersion = isRancherManagerVersion('2.14') ? 'v1.34.1'
     : vars.kubeadmVersion
 
-  beforeEach(function () {
-    if (!isUseCAAPFSupported) {
-      // This test is only meant for >=2.14.1
-      this.skip();
+  before(function () {
+    if (isRancherManagerVersion('<2.15')) {
+      return cy.task('suiteLog', "NoCAAPF is unsupported on Rancher Version <2.15; skipping...").then(() => {
+        this.skip();
+      })
     }
+  })
+
+  beforeEach(function () {
     cy.login();
     cy.burgerMenuOperate('open');
   });

--- a/tests/cypress/latest/e2e/capz_kubeadm_nocaapf_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capz_kubeadm_nocaapf_clusterclass.spec.ts
@@ -12,10 +12,7 @@ describe('Import CAPZ Kubeadm (No-Caapf) Class-Cluster', {tags: ['@full', '@noca
   const clusterClassRepoName = "azure-kubeadm-clusterclass"
   const classClusterFileName = './fixtures/azure/capz-kubeadm-class-cluster-nocaapf.yaml'
 
-  const clientID = Cypress.expose("azure_client_id")
-  const clientSecret = btoa(Cypress.expose("azure_client_secret"))
   const subscriptionID = Cypress.expose("azure_subscription_id")
-  const tenantID = Cypress.expose("azure_tenant_id")
 
   const azureCCMFileName = "cloud-provider-azure.yaml"
   const azureCCMCmd = [`wget ${vars.azureCCMYaml}`, `sed -i 's|\${CLUSTER_CIDR}|192.168.0.0/16|g' ${azureCCMFileName}`, applyYAMLManifest(clusterName, azureCCMFileName)]
@@ -36,11 +33,6 @@ describe('Import CAPZ Kubeadm (No-Caapf) Class-Cluster', {tags: ['@full', '@noca
   context('[SETUP]', () => {
     qase(329, it('Setup the namespace for importing', () => {
       cy.namespaceAutoImport('Disable');
-    })
-    );
-
-    qase(346, it('Create AzureClusterIdentity', () => {
-      cy.createAzureClusterIdentity(clientID, tenantID, clientSecret)
     })
     );
 

--- a/tests/cypress/latest/e2e/capz_kubeadm_nocaapf_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capz_kubeadm_nocaapf_clusterclass.spec.ts
@@ -1,10 +1,10 @@
 import '../support/commands';
 import {getClusterName, isUseCAAPFSupported, skipClusterDeletion, isRancherManagerVersion, getCAPIClusterKubeconfig, applyYAMLManifest} from '../support/utils';
-import {capiClusterDeletion, capzResourcesCleanup, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
+import {capiClusterDeletion, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
 import {vars} from '../support/variables';
 
 Cypress.config();
-describe('Import CAPZ Kubeadm (No-Caapf) Class-Cluster', {tags: ['@full', '@nocaapf', '@capzk-nocaapf']}, () => {
+describe('Import CAPZ Kubeadm (No-Caapf) Class-Cluster', {tags: ['@full', '@full-nocaapf', '@nocaapf', '@capzk-nocaapf']}, () => {
   const timeout = vars.fullTimeout
   const classNamePrefix = 'azure-kubeadm'
   const clusterName = getClusterName(classNamePrefix)
@@ -134,8 +134,6 @@ describe('Import CAPZ Kubeadm (No-Caapf) Class-Cluster', {tags: ['@full', '@noca
       qase(337, it('Delete the ClusterClass fleet repo and other resources', () => {
         // Remove the clusterclass repo
         cy.removeFleetGitRepo(clusterClassRepoName);
-        // Cleanup other resources
-        capzResourcesCleanup();
       })
       );
     }

--- a/tests/cypress/latest/e2e/capz_rke2_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capz_rke2_clusterclass.spec.ts
@@ -33,11 +33,6 @@ describe('Import CAPZ RKE2 Class-Cluster', {tags: ['@full', '@capzr']}, () => {
     })
     );
 
-    qase(345, it('Create AzureClusterIdentity', () => {
-      cy.createAzureClusterIdentity(clientID, tenantID, clientSecret)
-    })
-    );
-
     qase(87, it('Add CAPZ RKE2 ClusterClass Fleet Repo and check Azure CCM', () => {
         cy.addFleetGitRepo(clusterClassRepoName, vars.turtlesRepoUrl, vars.classBranch, classesPath, vars.capiClassesNS)
         // Go to CAPI > ClusterClass to ensure the clusterclass is created

--- a/tests/cypress/latest/e2e/capz_rke2_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capz_rke2_clusterclass.spec.ts
@@ -1,6 +1,6 @@
 import '../support/commands';
 import {getClusterName, isAPIv1beta1, skipClusterDeletion, isRancherManagerVersion} from '../support/utils';
-import {capiClusterDeletion, capzResourcesCleanup, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
+import {capiClusterDeletion, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
 import {vars} from '../support/variables';
 
 Cypress.config();
@@ -12,10 +12,7 @@ describe('Import CAPZ RKE2 Class-Cluster', {tags: ['@full', '@capzr']}, () => {
   const clusterClassRepoName = classNamePrefix + '-clusterclass'
   const classClusterFileName = isAPIv1beta1 ? './fixtures/azure/capz-rke2-class-cluster-v1beta1.yaml' : './fixtures/azure/capz-rke2-class-cluster.yaml'
 
-  const clientID = Cypress.expose("azure_client_id")
-  const clientSecret = btoa(Cypress.expose("azure_client_secret"))
   const subscriptionID = Cypress.expose("azure_subscription_id")
-  const tenantID = Cypress.expose("azure_tenant_id")
 
   // Azure CCM fails to install when using v1.35
   const k8sVersion = isRancherManagerVersion('2.14') ? 'v1.34.1+rke2r1'
@@ -130,8 +127,6 @@ describe('Import CAPZ RKE2 Class-Cluster', {tags: ['@full', '@capzr']}, () => {
       qase(83, it('Delete the ClusterClass fleet repo and other resources', () => {
           // Remove the clusterclass repo
           cy.removeFleetGitRepo(clusterClassRepoName);
-          // Cleanup other resources
-          capzResourcesCleanup();
         })
       );
     }

--- a/tests/cypress/latest/e2e/capz_rke2_nocaapf_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capz_rke2_nocaapf_clusterclass.spec.ts
@@ -18,11 +18,15 @@ describe('Import CAPZ RKE2 (No-Caapf) Class-Cluster', {tags: ['@full', '@full-no
   const k8sVersion = isRancherManagerVersion('2.14') ? 'v1.34.1+rke2r1'
   : vars.rke2Version
 
-  beforeEach(function () {
+  before(function () {
     if (isRancherManagerVersion('<2.15')) {
-      // This test will only work on Rancher >= 2.15, Turtles >= 0.27
-      this.skip();
+      return cy.task('suiteLog', "NoCAAPF is unsupported on Rancher Version <2.15; skipping...").then(() => {
+        this.skip();
+      })
     }
+  })
+
+  beforeEach(function () {
     cy.login();
     cy.burgerMenuOperate('open');
   });

--- a/tests/cypress/latest/e2e/capz_rke2_nocaapf_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capz_rke2_nocaapf_clusterclass.spec.ts
@@ -1,10 +1,10 @@
 import '../support/commands';
 import {getClusterName, skipClusterDeletion, isRancherManagerVersion} from '../support/utils';
-import {capiClusterDeletion, capzResourcesCleanup, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
+import {capiClusterDeletion, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
 import {vars} from '../support/variables';
 
 Cypress.config();
-describe('Import CAPZ RKE2 (No-Caapf) Class-Cluster', {tags: ['@full', '@nocaapf', '@capzr-nocaapf']}, () => {
+describe('Import CAPZ RKE2 (No-Caapf) Class-Cluster', {tags: ['@full', '@full-nocaapf', '@nocaapf', '@capzr-nocaapf']}, () => {
   const timeout = vars.fullTimeout
   const classNamePrefix = 'azure-rke2'
   const clusterName = getClusterName(classNamePrefix)
@@ -12,10 +12,7 @@ describe('Import CAPZ RKE2 (No-Caapf) Class-Cluster', {tags: ['@full', '@nocaapf
   const clusterClassRepoName = classNamePrefix + '-clusterclass'
   const classClusterFileName = './fixtures/azure/capz-rke2-class-cluster-nocaapf.yaml'
 
-  const clientID = Cypress.expose("azure_client_id")
-  const clientSecret = btoa(Cypress.expose("azure_client_secret"))
   const subscriptionID = Cypress.expose("azure_subscription_id")
-  const tenantID = Cypress.expose("azure_tenant_id")
 
   // Azure CCM fails to install when using v1.35
   const k8sVersion = isRancherManagerVersion('2.14') ? 'v1.34.1+rke2r1'
@@ -132,8 +129,6 @@ describe('Import CAPZ RKE2 (No-Caapf) Class-Cluster', {tags: ['@full', '@nocaapf
       qase(83, it('Delete the ClusterClass fleet repo and other resources', () => {
           // Remove the clusterclass repo
           cy.removeFleetGitRepo(clusterClassRepoName);
-          // Cleanup other resources
-          capzResourcesCleanup();
         })
       );
     }

--- a/tests/cypress/latest/e2e/capz_rke2_nocaapf_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capz_rke2_nocaapf_clusterclass.spec.ts
@@ -36,11 +36,6 @@ describe('Import CAPZ RKE2 (No-Caapf) Class-Cluster', {tags: ['@full', '@nocaapf
     })
     );
 
-    qase(345, it('Create AzureClusterIdentity', () => {
-      cy.createAzureClusterIdentity(clientID, tenantID, clientSecret)
-    })
-    );
-
     qase(87, it('Add CAPZ RKE2 ClusterClass Fleet Repo', () => {
         cy.addFleetGitRepo(clusterClassRepoName, vars.turtlesRepoUrl, vars.classBranch, classesPath, vars.capiClassesNS)
         // Go to CAPI > ClusterClass to ensure the clusterclass is created

--- a/tests/cypress/latest/e2e/fleet_addon_provider_setup.spec.ts
+++ b/tests/cypress/latest/e2e/fleet_addon_provider_setup.spec.ts
@@ -13,53 +13,52 @@ limitations under the License.
 
 import '../support/commands';
 import {
-  determineBuildType,
+  isRancherManagerVersion,
   isUpgrade,
   isUseCAAPFSupported,
   turtlesNamespace,
 } from '../support/utils';
-import {providers, vars} from '../support/variables';
+import {determineBuildType, providers, vars} from '../support/variables';
 import {matchAndWaitForProviderReadyStatus, setUseCAAPFFeatureGate} from "../support/commands";
 
 
 Cypress.config();
-describe('Enable use-caapf feature gate', {tags: '@install'}, () => {
-  beforeEach(function () {
-    // This feature gate needs to be enabled for >=2.14.1
-    if (!isUseCAAPFSupported){
-      cy.task('suiteLog', 'use-caapf feature gate is not supported; skipping...');
-      this.skip();
-    }
-    if(isUpgrade){
-      // This feature is set to true(in pre_upgrade_setup.spec.ts) before the rancher upgrade;
-      // that's why we skip this step for upgrade test.
-      cy.task('suiteLog', 'use-caapf feature gate is already enabled by pre_upgrade_setup; skipping...');
+describe('Enable use-caapf feature gate and install fleet-addon provider', {tags: '@install'}, () => {
+  beforeEach(function (){
+    if (isRancherManagerVersion('2.12')){
+      cy.task('suiteLog', 'Skipping test on Rancher 2.12...');
       this.skip();
     }
 
     cy.login();
     cy.burgerMenuOperate('open');
-  });
-
-
-  qase(436, it('Enable turtles feature gate: use-caapf', () => {
-      setUseCAAPFFeatureGate(true);
-    })
-  );
-
-  it('Enable fleet-addon provider', ()=>{
-    const providerSelectionFunction = (text: any) => {
-      // fleet-addon needs to be explicitly enabled for >=2.14.1.
-      // @ts-ignore
-      text.providers.addonFleet.enabled = true;
-
-    }
-
-    cy.checkChart('local', vars.chartUpdateOperation, vars.turtlesProvidersChartName, turtlesNamespace, {
-      version: vars.turtlesProvidersChartVersion,
-      modifyYAMLOperation: providerSelectionFunction
-    });
   })
+
+  if (isUseCAAPFSupported && !isUpgrade) {
+    // This feature gate needs to be enabled for >=2.14.1
+    // This feature is set to true(in pre_upgrade_setup.spec.ts) before the rancher upgrade; that's why we skip this
+    // step for upgrade test.
+    qase(436, it('Enable turtles feature gate: use-caapf', () => {
+        setUseCAAPFFeatureGate(true);
+      })
+    );
+  }
+
+  if (isRancherManagerVersion('>=2.14')) {
+    // In <2.14 versions, fleet is enabled by default
+    it('Enable Fleet addon provider', () => {
+      const providerSelectionFunction = (text: any) => {
+        // fleet-addon needs to be explicitly enabled for >=2.14.1.
+        // @ts-ignore
+        text.providers.addonFleet.enabled = true;
+      }
+
+      cy.checkChart('local', vars.chartUpdateOperation, vars.turtlesProvidersChartName, turtlesNamespace, {
+        version: vars.turtlesProvidersChartVersion,
+        modifyYAMLOperation: providerSelectionFunction
+      });
+    })
+  }
 
   qase(368,
     it('Verify Fleet addon provider', () => {
@@ -72,4 +71,3 @@ describe('Enable use-caapf feature gate', {tags: '@install'}, () => {
   );
 
 });
-

--- a/tests/cypress/latest/e2e/fleet_addon_provider_setup.spec.ts
+++ b/tests/cypress/latest/e2e/fleet_addon_provider_setup.spec.ts
@@ -24,17 +24,21 @@ import {matchAndWaitForProviderReadyStatus, setUseCAAPFFeatureGate} from "../sup
 
 Cypress.config();
 describe('Enable use-caapf feature gate and install fleet-addon provider', {tags: '@install'}, () => {
-  beforeEach(function (){
+  before(function () {
     if (isRancherManagerVersion('2.12')){
-      cy.task('suiteLog', 'Skipping test on Rancher 2.12...');
-      this.skip();
+      return cy.task('suiteLog', 'Skipping test on Rancher 2.12...').then(()=>{
+        this.skip();
+      })
     }
 
     if (skipFleetAddOnInstallation) {
-      cy.task('suiteLog', 'SKIP_FLEET_ADDON_INSTALLATION=true; Skipping fleet-addon provider installation...');
-      this.skip();
+      return cy.task('suiteLog', 'SKIP_FLEET_ADDON_INSTALLATION=true; Skipping fleet-addon provider installation...').then(()=>{
+        this.skip();
+      })
     }
+  })
 
+  beforeEach(function (){
     cy.login();
     cy.burgerMenuOperate('open');
   })

--- a/tests/cypress/latest/e2e/fleet_addon_provider_setup.spec.ts
+++ b/tests/cypress/latest/e2e/fleet_addon_provider_setup.spec.ts
@@ -1,0 +1,75 @@
+/*
+Copyright © 2022 - 2023 SUSE LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import '../support/commands';
+import {
+  determineBuildType,
+  isUpgrade,
+  isUseCAAPFSupported,
+  turtlesNamespace,
+} from '../support/utils';
+import {providers, vars} from '../support/variables';
+import {matchAndWaitForProviderReadyStatus, setUseCAAPFFeatureGate} from "../support/commands";
+
+
+Cypress.config();
+describe('Enable use-caapf feature gate', {tags: '@install'}, () => {
+  beforeEach(function () {
+    // This feature gate needs to be enabled for >=2.14.1
+    if (!isUseCAAPFSupported){
+      cy.task('suiteLog', 'use-caapf feature gate is not supported; skipping...');
+      this.skip();
+    }
+    if(isUpgrade){
+      // This feature is set to true(in pre_upgrade_setup.spec.ts) before the rancher upgrade;
+      // that's why we skip this step for upgrade test.
+      cy.task('suiteLog', 'use-caapf feature gate is already enabled by pre_upgrade_setup; skipping...');
+      this.skip();
+    }
+
+    cy.login();
+    cy.burgerMenuOperate('open');
+  });
+
+
+  qase(436, it('Enable turtles feature gate: use-caapf', () => {
+      setUseCAAPFFeatureGate(true);
+    })
+  );
+
+  it('Enable fleet-addon provider', ()=>{
+    const providerSelectionFunction = (text: any) => {
+      // fleet-addon needs to be explicitly enabled for >=2.14.1.
+      // @ts-ignore
+      text.providers.addonFleet.enabled = true;
+
+    }
+
+    cy.checkChart('local', vars.chartUpdateOperation, vars.turtlesProvidersChartName, turtlesNamespace, {
+      version: vars.turtlesProvidersChartVersion,
+      modifyYAMLOperation: providerSelectionFunction
+    });
+  })
+
+  qase(368,
+    it('Verify Fleet addon provider', () => {
+      const buildType = determineBuildType();
+      const fleetProviderVersion = providers.version[buildType].fleet
+
+      cy.navigateToProviders();
+      matchAndWaitForProviderReadyStatus(providers.fleetProvider, 'addon', providers.fleetProvider, fleetProviderVersion, 'fleet-addon-system');
+    })
+  );
+
+});
+

--- a/tests/cypress/latest/e2e/fleet_addon_provider_setup.spec.ts
+++ b/tests/cypress/latest/e2e/fleet_addon_provider_setup.spec.ts
@@ -15,7 +15,7 @@ import '../support/commands';
 import {
   isRancherManagerVersion,
   isUpgrade,
-  isUseCAAPFSupported,
+  isUseCAAPFSupported, skipFleetAddOnInstallation,
   turtlesNamespace,
 } from '../support/utils';
 import {determineBuildType, providers, vars} from '../support/variables';
@@ -27,6 +27,11 @@ describe('Enable use-caapf feature gate and install fleet-addon provider', {tags
   beforeEach(function (){
     if (isRancherManagerVersion('2.12')){
       cy.task('suiteLog', 'Skipping test on Rancher 2.12...');
+      this.skip();
+    }
+
+    if (skipFleetAddOnInstallation) {
+      cy.task('suiteLog', 'SKIP_FLEET_ADDON_INSTALLATION=true; Skipping fleet-addon provider installation...');
       this.skip();
     }
 

--- a/tests/cypress/latest/e2e/pre_upgrade_setup.spec.ts
+++ b/tests/cypress/latest/e2e/pre_upgrade_setup.spec.ts
@@ -1,6 +1,6 @@
 import '../support/commands';
 import {isRancherManagerVersion} from "../support/utils";
-import {vars} from "~/support/variables";
+import {setUseCAAPFFeatureGate} from "../support/commands";
 
 Cypress.config();
 describe('Pre Rancher Upgrade Setup - @upgrade', {tags: '@upgrade'}, () => {
@@ -14,19 +14,9 @@ describe('Pre Rancher Upgrade Setup - @upgrade', {tags: '@upgrade'}, () => {
   });
 
   qase(509, it("Enable use-caapf feature gate before Rancher upgrade", () => {
-    const enableFeatureGate = (text: any) => {
-      // to disable the feature flag, simply removing this data won't be enough. The value must be reset to "false".
-      text.data["rancher-turtles"] = `{"features": {"use-caapf": {"enabled": "true"}}}`;
-    }
-    cy.editKubernetesResource({
-      name: "rancher-config",
-      clusterName: "local",
-      resourcePath: ["More Resources", "Core", "ConfigMaps"],
-      namespace: vars.cattleSystemNS,
-      modifyYAMLOperation: enableFeatureGate
-    });
-
-    // At this point the feature does not really exist, but it should be set before upgrading Rancher Turtles via Rancher Manager upgrade.
+      // At this point the feature does not really exist, but it should be set before upgrading Rancher Turtles via Rancher Manager upgrade,
+      // which is also one of the reasons why we do not wait for it to take effect
+      setUseCAAPFFeatureGate(true, false)
   })
   );
 });

--- a/tests/cypress/latest/e2e/providers_setup.spec.ts
+++ b/tests/cypress/latest/e2e/providers_setup.spec.ts
@@ -13,13 +13,13 @@ limitations under the License.
 
 import '../support/commands';
 import {
-  capiNamespace, determineBuildType,
+  capiNamespace,
   isCypressTag,
-  isRancherManagerVersion,
+  isRancherManagerVersion, isTurtlesDevChart,
   isUpgrade,
   turtlesNamespace,
 } from '../support/utils';
-import {providers, vars} from '../support/variables';
+import {determineBuildType, providers, vars} from '../support/variables';
 import {matchAndWaitForProviderReadyStatus} from "../support/commands";
 
 if (isRancherManagerVersion('>2.12')) {
@@ -51,6 +51,27 @@ describe('Enable CAPI Providers', () => {
     })
     );
 
+    if (!isTurtlesDevChart && isRancherManagerVersion('>=2.14')) {
+      it('Patch the providers chart repository with OCIOptions.downloadAllTags: true', () => {
+        // .spec.OCIOptions.downloadAllTags is useful with staging registry which might contain unsupported versions
+        // and charts might seem broken with missing namespace or chart name.
+        // Enabling this option downloads all the chart versions and ensures only supported versions show up
+        // Doing so makes editing/updating the chart a smoother process.
+        const repositoryName = "turtles-providers-chart";
+        const resourceKind = 'clusterrepos.catalog.cattle.io';
+        const patch = {spec: {OCIOptions: {'downloadAllTags': true}}};
+        cy.patchYamlResource('local', 'default', resourceKind, repositoryName, patch);
+        cy.typeInFilter(repositoryName);
+        // Make sure the repo is active before leaving
+        // Always press Refresh button as workaround for https://github.com/rancher/rancher/issues/49671
+        cy.getBySel('sortable-table-0-action-button').click();
+        cy.wait(1000);
+        cy.get('.icon.group-icon.icon-refresh').parent().click();
+        cy.wait(1000);
+        cy.contains(new RegExp('Active.*' + repositoryName), {timeout: 150000});
+      })
+    }
+
     qase(338, it('Create Providers using Charts', () => {
       const providerSelectionFunction = (text: any) => {
         // @ts-ignore
@@ -62,10 +83,6 @@ describe('Enable CAPI Providers', () => {
         text.providers.controlplaneKubeadm.enabled = true;
         // @ts-ignore
         text.providers.controlplaneKubeadm.enableAutomaticUpdate = true;
-
-        // fleet-addon needs to be explicitly enabled for >=2.14.1.
-        // @ts-ignore
-        text.providers.addonFleet.enabled = true;
 
         if (isCypressTag('@short') || isCypressTag('@capd') || isCypressTag('@upgrade') || isCypressTag('@switch') || isCypressTag('@use-caapf-switch')) {
             // @ts-ignore
@@ -99,11 +116,10 @@ describe('Enable CAPI Providers', () => {
             text.providers.infrastructureVSphere.enableAutomaticUpdate = true;
           }
       }
-      // Uninstall Rancher Turtles Providers chart if already present
-      cy.deleteKubernetesResource('local', ['Apps', 'Installed Apps'], vars.turtlesProvidersHelmApp, turtlesNamespace);
 
       // Install Rancher Turtles Certified Providers chart
       let operation = isRancherManagerVersion('2.14') && isUpgrade ? 'Upgrade' : 'Install'
+      cy.task('suiteLog', `Installing turtles providers chart version ${vars.turtlesProvidersChartVersion}`)
       cy.checkChart('local', operation, vars.turtlesProvidersChartName, turtlesNamespace, {
         version: vars.turtlesProvidersChartVersion,
         modifyYAMLOperation: providerSelectionFunction
@@ -158,7 +174,7 @@ describe('Enable CAPI Providers', () => {
     })
   });
 
-  context('Docker provider', {tags: ['@short', '@capdk', '@capdr', '@upgrade', '@switch', '@use-caapf-switch']}, () => {
+  context('Docker provider', {tags: ['@short', '@short-nocaapf', '@nocaapf', '@capdk', '@capdr', '@upgrade', '@switch', '@use-caapf-switch', '@capdk-nocaapf', '@capdr-nocaapf']}, () => {
     const dockerProviderNamespace = 'capd-system'
     qase(422, it('Verify CAPD provider', () => {
       // Verify Docker Infrastructure provider
@@ -189,9 +205,9 @@ describe('Enable CAPI Providers', () => {
     );
   })
 
-  context('Cloud Providers', {tags: '@full'}, () => {
+  context('Cloud Providers', {tags: ['@full', '@full-nocaapf', '@nocaapf']}, () => {
     const providerType = 'infrastructure'
-    qase(424, it('Verify CAPA provider', {tags: ['@capak', '@capar', '@capaeks']},() => {
+    qase(424, it('Verify CAPA provider', {tags: ['@capak', '@capar', '@capaeks', '@capar-nocaapf', '@capaeks-nocaapf']},() => {
       const namespace = 'capa-system'
       // Verify AWS Infrastructure provider
       cy.addCloudCredsAWS(providers.amazonProvider, Cypress.expose('aws_access_key'), Cypress.expose('aws_secret_key'));
@@ -201,7 +217,7 @@ describe('Enable CAPI Providers', () => {
     })
     );
 
-    qase(425, it('Verify CAPG provider', {tags: ['@capgk', '@capgke']}, () => {
+    qase(425, it('Verify CAPG provider', {tags: ['@capgk', '@capgke', '@capgk-nocaapf', '@capgke-nocaapf']}, () => {
       const namespace = 'capg-system'
       // Verify GCP Infrastructure provider
       cy.navigateToProviders();
@@ -221,7 +237,7 @@ describe('Enable CAPI Providers', () => {
     })
     );
 
-    context('CAPZ Setup', {tags: ['@capzk', '@capzr', '@capzaks']}, ()=>{
+    context('CAPZ Setup', {tags: ['@capzk', '@capzr', '@capzaks', '@capzk-nocaapf','@capzr-nocaapf', '@capzaks-nocaapf']}, ()=>{
       qase(426,
         it('Verify CAPZ provider', () => {
           const namespace = 'capz-system'

--- a/tests/cypress/latest/e2e/providers_setup.spec.ts
+++ b/tests/cypress/latest/e2e/providers_setup.spec.ts
@@ -53,10 +53,8 @@ describe('Enable CAPI Providers', () => {
 
     if (!isTurtlesDevChart && isRancherManagerVersion('>=2.14')) {
       it('Patch the providers chart repository with OCIOptions.downloadAllTags: true', () => {
-        // .spec.OCIOptions.downloadAllTags is useful with staging registry which might contain unsupported versions
-        // and charts might seem broken with missing namespace or chart name.
         // Enabling this option downloads all the chart versions and ensures only supported versions show up
-        // Doing so makes editing/updating the chart a smoother process.
+        // Doing so makes updating the chart a smoother process.
         const repositoryName = "turtles-providers-chart";
         const resourceKind = 'clusterrepos.catalog.cattle.io';
         const patch = {spec: {OCIOptions: {'downloadAllTags': true}}};
@@ -84,14 +82,14 @@ describe('Enable CAPI Providers', () => {
         // @ts-ignore
         text.providers.controlplaneKubeadm.enableAutomaticUpdate = true;
 
-        if (isCypressTag('@short') || isCypressTag('@capd') || isCypressTag('@upgrade') || isCypressTag('@switch') || isCypressTag('@use-caapf-switch')) {
+        if (isCypressTag('@short') || isCypressTag('@nocaapf') || isCypressTag('@capd') || isCypressTag('@upgrade') || isCypressTag('@switch') || isCypressTag('@use-caapf-switch')) {
             // @ts-ignore
             text.providers.infrastructureDocker.enabled = true;
             // @ts-ignore
             text.providers.infrastructureDocker.enableAutomaticUpdate = true;
           }
         // there is no easy way to only install a specific provider when something like `@capgke` is passed, so we enable all the cloud providers
-        if (isCypressTag('@full') || isCypressTag('@capg') || isCypressTag('@capa') || isCypressTag('@capz')) {
+        if (isCypressTag('@full') || isCypressTag('@nocaapf') || isCypressTag('@capg') || isCypressTag('@capa') || isCypressTag('@capz')) {
             // @ts-ignore
             text.providers.infrastructureGCP.enabled = true;
             // @ts-ignore
@@ -109,6 +107,7 @@ describe('Enable CAPI Providers', () => {
             // @ts-ignore
             text.providers.infrastructureAWS.enableAutomaticUpdate = true;
           }
+        // TODO: Add isCypressTag('@nocaapf') when vsphere nocaapf is implemented
         if (isCypressTag('@vsphere') || isCypressTag('@capv')) {
             // @ts-ignore
             text.providers.infrastructureVSphere.enabled = true;
@@ -184,6 +183,7 @@ describe('Enable CAPI Providers', () => {
     );
   })
 
+  // TODO: Add isCypressTag('@nocaapf') when vsphere nocaapf is implemented
   context('vSphere provider', {tags: ['@vsphere', '@capvk', '@capvr']}, () => {
     const vsphereProviderNamespace = 'capv-system'
     qase(423, it('Verify CAPV provider', () => {

--- a/tests/cypress/latest/e2e/providers_setup.spec.ts
+++ b/tests/cypress/latest/e2e/providers_setup.spec.ts
@@ -13,129 +13,27 @@ limitations under the License.
 
 import '../support/commands';
 import {
-  capiNamespace,
+  capiNamespace, determineBuildType,
   isCypressTag,
   isRancherManagerVersion,
-  isTurtlesDevChart,
   isUpgrade,
-  isUseCAAPFSupported,
   turtlesNamespace,
 } from '../support/utils';
-import {vars} from '../support/variables';
-import {matchAndWaitForProviderReadyStatus, setUseCAAPFFeatureGate} from "../support/commands";
-
-type BuildType = 'prod-v2.13' | 'prod-v2.14' | 'prod-v2.15' | 'dev-v2.13' | 'dev-v2.14' | 'dev-v2.15';
-const buildType = determineBuildType();
-
-function determineBuildType(): BuildType {
-  if (isTurtlesDevChart && isRancherManagerVersion('2.13')) {
-    return 'dev-v2.13';
-  }
-  if (isTurtlesDevChart && isRancherManagerVersion('2.14')) {
-    return 'dev-v2.14';
-  }
-  if (isTurtlesDevChart && isRancherManagerVersion('2.15')) {
-    return 'dev-v2.15';
-  }
-  if (isRancherManagerVersion('2.13')) {
-    return 'prod-v2.13';
-  }
-  if (isRancherManagerVersion('2.14')) {
-    return 'prod-v2.14';
-  }
-  if (isRancherManagerVersion('2.15')) {
-    return 'prod-v2.15';
-  }
-  return undefined as unknown as BuildType; // This should never happen, but it satisfies the type checker
-}
+import {providers, vars} from '../support/variables';
+import {matchAndWaitForProviderReadyStatus} from "../support/commands";
 
 if (isRancherManagerVersion('>2.12')) {
 Cypress.config();
 describe('Enable CAPI Providers', () => {
-  // Providers names
-  const coreCAPIProvider = 'cluster-api'
-  const rke2Provider = 'rke2'
-  const kubeadmProvider = 'kubeadm'
-  const dockerProvider = 'docker'
-  const amazonProvider = 'aws'
-  const googleProvider = 'gcp'
-  const azureProvider = 'azure'
-  const fleetProvider = 'fleet'
-  const vsphereProvider = 'vsphere'
-
-  // Expected provider versions
-  const providerVersions = {
-    'prod-v2.13': {
-      capi: 'v1.10.6',
-      rke2: 'v0.21.1',
-      kubeadm: 'v1.10.6',
-      fleet: 'v0.12.0',
-      vsphere: 'v1.13.1',
-      amazon: 'v2.9.1',
-      google: 'v1.10.0',
-      azure: 'v1.21.0'
-    },
-    'prod-v2.14': {
-      capi: 'v1.12.7',
-      rke2: 'v0.24.4',
-      kubeadm: 'v1.12.7',
-      fleet: 'v0.14.1',
-      vsphere: 'v1.15.2',
-      amazon: 'v2.11.1',
-      google: 'v1.11.1',
-      azure: 'v1.22.0'
-    },
-    'prod-v2.15': {
-      capi: 'v1.13.3',
-      rke2: 'v0.25.0',
-      kubeadm: 'v1.13.3',
-      fleet: 'v0.15.0',
-      vsphere: 'v1.16.1',
-      amazon: 'v2.11.1',
-      google: 'v1.11.2',
-      azure: 'v1.23.2'
-    },
-    'dev-v2.13': {
-      capi: 'v1.10.6',
-      rke2: 'v0.21.1',
-      kubeadm: 'v1.10.6',
-      fleet: 'v0.12.0',
-      vsphere: 'v1.13.1',
-      amazon: 'v2.9.1',
-      google: 'v1.10.0',
-      azure: 'v1.21.0'
-    },
-    'dev-v2.14': {
-      capi: 'v1.12.7',
-      rke2: 'v0.24.4',
-      kubeadm: 'v1.12.7',
-      fleet: 'v0.14.1',
-      vsphere: 'v1.15.2',
-      amazon: 'v2.11.1',
-      google: 'v1.11.1',
-      azure: 'v1.22.0'
-    },
-    'dev-v2.15': {
-      capi: 'v1.13.3',
-      rke2: 'v0.25.0',
-      kubeadm: 'v1.13.3',
-      fleet: 'v0.15.0',
-      vsphere: 'v1.16.1',
-      amazon: 'v2.11.1',
-      google: 'v1.11.2',
-      azure: 'v1.23.2'
-    }
-  }
-
   // Assign the provider versions based on the chart type
-  const coreCAPIProviderVersion = providerVersions[buildType].capi;
-  const rke2ProviderVersion = providerVersions[buildType].rke2;
-  const kubeadmProviderVersion = providerVersions[buildType].kubeadm
-  const fleetProviderVersion = providerVersions[buildType].fleet
-  const vsphereProviderVersion = providerVersions[buildType].vsphere
-  const amazonProviderVersion = providerVersions[buildType].amazon
-  const googleProviderVersion = providerVersions[buildType].google
-  const azureProviderVersion = providerVersions[buildType].azure
+  const buildType = determineBuildType();
+  const coreCAPIProviderVersion = providers.version[buildType].capi;
+  const rke2ProviderVersion = providers.version[buildType].rke2;
+  const kubeadmProviderVersion = providers.version[buildType].kubeadm
+  const vsphereProviderVersion = providers.version[buildType].vsphere
+  const amazonProviderVersion = providers.version[buildType].amazon
+  const googleProviderVersion = providers.version[buildType].google
+  const azureProviderVersion = providers.version[buildType].azure
 
   const providerTypes = ['bootstrap', 'control plane']
   const kubeadmProviderNamespaces = ['capi-kubeadm-bootstrap-system', 'capi-kubeadm-control-plane-system']
@@ -152,15 +50,6 @@ describe('Enable CAPI Providers', () => {
       cy.addFleetGitRepo('helm-ops', vars.turtlesRepoUrl, vars.classBranch, 'examples/applications/', vars.capiClustersNS);
     })
     );
-
-    // This feature gate needs to be enabled for >=2.14.1
-    // This feature is set to true(in pre_upgrade_setup.spec.ts) before the rancher upgrade; that's why we skip this step for upgrade test.
-    if (isUseCAAPFSupported && !isUpgrade) {
-      qase(436, it('Enable turtles feature gate: use-caapf', () => {
-        setUseCAAPFFeatureGate(true)
-      })
-      );
-    }
 
     qase(338, it('Create Providers using Charts', () => {
       const providerSelectionFunction = (text: any) => {
@@ -231,13 +120,7 @@ describe('Enable CAPI Providers', () => {
 
     qase(367, it('Verify Core CAPI Provider', () => {
       cy.navigateToProviders();
-      matchAndWaitForProviderReadyStatus(coreCAPIProvider, 'core', coreCAPIProvider, coreCAPIProviderVersion, capiNamespace);
-    })
-    );
-
-    qase(368, it('Verify Fleet addon provider', () => {
-      cy.navigateToProviders();
-      matchAndWaitForProviderReadyStatus(fleetProvider, 'addon', fleetProvider, fleetProviderVersion, 'fleet-addon-system');
+      matchAndWaitForProviderReadyStatus(providers.coreCAPIProvider, 'core', providers.coreCAPIProvider, coreCAPIProviderVersion, capiNamespace);
     })
     );
 
@@ -246,14 +129,14 @@ describe('Enable CAPI Providers', () => {
         // Verify CAPI Kubeadm providers
         if (providerType == 'control plane') {
           const namespace = kubeadmProviderNamespaces[1]
-          const providerName = kubeadmProvider + '-' + 'control-plane'
+          const providerName = providers.kubeadmProvider + '-' + 'control-plane'
           cy.navigateToProviders();
-          matchAndWaitForProviderReadyStatus(providerName, 'controlPlane', kubeadmProvider, kubeadmProviderVersion, namespace);
+          matchAndWaitForProviderReadyStatus(providerName, 'controlPlane', providers.kubeadmProvider, kubeadmProviderVersion, namespace);
         } else {
           const namespace = kubeadmProviderNamespaces[0]
-          const providerName = kubeadmProvider + '-' + providerType
+          const providerName = providers.kubeadmProvider + '-' + providerType
           cy.navigateToProviders()
-          matchAndWaitForProviderReadyStatus(providerName, providerType, kubeadmProvider, kubeadmProviderVersion, namespace);
+          matchAndWaitForProviderReadyStatus(providerName, providerType, providers.kubeadmProvider, kubeadmProviderVersion, namespace);
         }
       })
       );
@@ -261,14 +144,14 @@ describe('Enable CAPI Providers', () => {
       qase([369,370], it('Verify RKE2 Providers - ' + providerType, () => {
         if (providerType == 'control plane') {
           const namespace = 'rke2-control-plane-system'
-          const providerName = rke2Provider + '-' + 'control-plane'
+          const providerName = providers.rke2Provider + '-' + 'control-plane'
           cy.navigateToProviders();
-          matchAndWaitForProviderReadyStatus(providerName, 'controlPlane', rke2Provider, rke2ProviderVersion, namespace);
+          matchAndWaitForProviderReadyStatus(providerName, 'controlPlane', providers.rke2Provider, rke2ProviderVersion, namespace);
         } else {
           const namespace = 'rke2-bootstrap-system'
-          const providerName = rke2Provider + '-' + providerType
+          const providerName = providers.rke2Provider + '-' + providerType
           cy.navigateToProviders();
-          matchAndWaitForProviderReadyStatus(providerName, providerType, rke2Provider, rke2ProviderVersion, namespace);
+          matchAndWaitForProviderReadyStatus(providerName, providerType, providers.rke2Provider, rke2ProviderVersion, namespace);
         }
       })
       );
@@ -280,7 +163,7 @@ describe('Enable CAPI Providers', () => {
     qase(422, it('Verify CAPD provider', () => {
       // Verify Docker Infrastructure provider
       cy.navigateToProviders();
-      matchAndWaitForProviderReadyStatus(dockerProvider, 'infrastructure', dockerProvider, kubeadmProviderVersion, dockerProviderNamespace);
+      matchAndWaitForProviderReadyStatus(providers.dockerProvider, 'infrastructure', providers.dockerProvider, kubeadmProviderVersion, dockerProviderNamespace);
     })
     );
   })
@@ -298,10 +181,10 @@ describe('Enable CAPI Providers', () => {
       const vspherePassword = vsphere_secrets_json.vsphere_password;
       const vsphereServer = vsphere_secrets_json.vsphere_server;
       const vspherePort = '443';
-      cy.addCloudCredsVMware(vsphereProvider, vsphereUsername, vspherePassword, vsphereServer, vspherePort);
+      cy.addCloudCredsVMware(providers.vsphereProvider, vsphereUsername, vspherePassword, vsphereServer, vspherePort);
       cy.burgerMenuOperate('open');
       cy.navigateToProviders();
-      matchAndWaitForProviderReadyStatus(vsphereProvider, 'infrastructure', vsphereProvider, vsphereProviderVersion, vsphereProviderNamespace);
+      matchAndWaitForProviderReadyStatus(providers.vsphereProvider, 'infrastructure', providers.vsphereProvider, vsphereProviderVersion, vsphereProviderNamespace);
     })
     );
   })
@@ -311,10 +194,10 @@ describe('Enable CAPI Providers', () => {
     qase(424, it('Verify CAPA provider', {tags: ['@capak', '@capar', '@capaeks']},() => {
       const namespace = 'capa-system'
       // Verify AWS Infrastructure provider
-      cy.addCloudCredsAWS(amazonProvider, Cypress.expose('aws_access_key'), Cypress.expose('aws_secret_key'));
+      cy.addCloudCredsAWS(providers.amazonProvider, Cypress.expose('aws_access_key'), Cypress.expose('aws_secret_key'));
       cy.burgerMenuOperate('open');
       cy.navigateToProviders();
-      matchAndWaitForProviderReadyStatus(amazonProvider, providerType, amazonProvider, amazonProviderVersion, namespace);
+      matchAndWaitForProviderReadyStatus(providers.amazonProvider, providerType, providers.amazonProvider, amazonProviderVersion, namespace);
     })
     );
 
@@ -324,27 +207,40 @@ describe('Enable CAPI Providers', () => {
       cy.navigateToProviders();
 
       // Create GCP Cloud Credential until https://github.com/rancher/dashboard/issues/15391 is fixed
-      cy.get('tr.main-row').contains('a', googleProvider).closest('tr').within(() => {
+      cy.get('tr.main-row').contains('a', providers.googleProvider).closest('tr').within(() => {
         cy.get('td').eq(7).click();      // Action button
       })
       cy.contains('Edit Config').click();
-      cy.contains(`Provider: Google - ${googleProvider}`).should('exist');
-      cy.typeValue('Credential Name', googleProvider);
+      cy.contains(`Provider: Google - ${providers.googleProvider}`).should('exist');
+      cy.typeValue('Credential Name', providers.googleProvider);
       cy.getBySel('text-area-auto-grow').type(Cypress.expose('gcp_credentials'), {log: false});
       cy.clickButton('Continue');
-      cy.getBySel('cluster-prov-select-credential').contains(googleProvider).should('be.visible');
+      cy.getBySel('cluster-prov-select-credential').contains(providers.googleProvider).should('be.visible');
       cy.clickButton('Save');
-      matchAndWaitForProviderReadyStatus(googleProvider, providerType, googleProvider, googleProviderVersion, namespace);
+      matchAndWaitForProviderReadyStatus(providers.googleProvider, providerType, providers.googleProvider, googleProviderVersion, namespace);
     })
     );
 
-    qase(426, it('Verify CAPZ provider', {tags: ['@capzk', '@capzr', '@capzaks']}, () => {
-      const namespace = 'capz-system'
-      // Verify Azure Infrastructure provider
-      cy.navigateToProviders();
-      matchAndWaitForProviderReadyStatus(azureProvider, providerType, azureProvider, azureProviderVersion, namespace);
+    context('CAPZ Setup', {tags: ['@capzk', '@capzr', '@capzaks']}, ()=>{
+      qase(426,
+        it('Verify CAPZ provider', () => {
+          const namespace = 'capz-system'
+          // Verify Azure Infrastructure provider
+          cy.navigateToProviders();
+          matchAndWaitForProviderReadyStatus(providers.azureProvider, providerType, providers.azureProvider, azureProviderVersion, namespace);
+        })
+      );
+
+      qase(345,
+        it('Create AzureClusterIdentity', () => {
+          const clientID = Cypress.expose("azure_client_id")
+          const clientSecret = btoa(Cypress.expose("azure_client_secret"))
+          const tenantID = Cypress.expose("azure_tenant_id")
+
+          cy.createAzureClusterIdentity(clientID, tenantID, clientSecret)
+        })
+      );
     })
-    );
   })
 });
 }

--- a/tests/cypress/latest/e2e/providers_setup_legacy.spec.ts
+++ b/tests/cypress/latest/e2e/providers_setup_legacy.spec.ts
@@ -213,15 +213,29 @@ describe('Enable CAPI Providers (2.12)', () => {
     })
     );
 
-    qase(507, it('Create CAPZ provider', {tags: ['@capzk', '@capzr', 'capzaks']}, () => {
-      const namespace = 'capz-system'
-      cy.createNamespace([namespace]);
-      cy.burgerMenuOperate('open');
-      // Create Azure Infrastructure provider
-      cy.addInfraProvider('Azure', namespace, azureProvider);
-      matchAndWaitForProviderReadyStatus(azureProvider, providerType, azureProvider, azureProviderVersion, namespace);
+    context('CAPZ Setup', {tags: ['@capzk', '@capzr', '@capzaks']}, ()=>{
+
+      qase(507, it('Create CAPZ provider', () => {
+          const namespace = 'capz-system'
+          cy.createNamespace([namespace]);
+          cy.burgerMenuOperate('open');
+          // Create Azure Infrastructure provider
+          cy.addInfraProvider('Azure', namespace, azureProvider);
+          matchAndWaitForProviderReadyStatus(azureProvider, providerType, azureProvider, azureProviderVersion, namespace);
+        })
+      );
+
+      qase(345,
+        it('Create AzureClusterIdentity', () => {
+          const clientID = Cypress.expose("azure_client_id")
+          const clientSecret = btoa(Cypress.expose("azure_client_secret"))
+          const tenantID = Cypress.expose("azure_tenant_id")
+
+          cy.createAzureClusterIdentity(clientID, tenantID, clientSecret)
+        })
+      );
     })
-    );
+
   })
 });
 }

--- a/tests/cypress/latest/e2e/providers_setup_legacy.spec.ts
+++ b/tests/cypress/latest/e2e/providers_setup_legacy.spec.ts
@@ -16,61 +16,26 @@ import {
   capiNamespace,
   isMigration,
   isRancherManagerVersion,
-  isTurtlesDevChart,
   turtlesNamespace
 } from '../support/utils';
-import {vars} from '../support/variables';
+import {determineBuildType, providers, vars} from '../support/variables';
 import {matchAndWaitForProviderReadyStatus} from "../support/commands";
 
-const buildType = isTurtlesDevChart && isRancherManagerVersion('2.12') ? 'dev-v2.12' : 'prod';
+const buildType = determineBuildType();
 
 if (isRancherManagerVersion('2.12') && !isMigration) {
 Cypress.config();
 describe('Enable CAPI Providers (2.12)', () => {
-  // Providers names
-  const coreCAPIProvider = 'cluster-api'
-  const rke2Provider = 'rke2'
-  const kubeadmProvider = 'kubeadm'
-  const dockerProvider = 'docker'
-  const amazonProvider = 'aws'
-  const googleProvider = 'gcp'
-  const azureProvider = 'azure'
-  const fleetProvider = 'fleet'
-  const vsphereProvider = 'vsphere'
-
-  // Expected provider versions
-  const providerVersions = {
-    prod: {
-      capi: 'v1.10.5',
-      rke2: 'v0.20.1',
-      kubeadm: 'v1.10.5',
-      fleet: 'v0.11.0',
-      vsphere: 'v1.13.1',
-      amazon: 'v2.9.1',
-      google: 'v1.10.0',
-      azure: 'v1.21.0'
-    },
-    'dev-v2.12': {
-      capi: 'v1.10.5',
-      rke2: 'v0.20.1',
-      kubeadm: 'v1.10.5',
-      fleet: 'v0.11.0',
-      vsphere: 'v1.13.1',
-      amazon: 'v2.9.1',
-      google: 'v1.10.0',
-      azure: 'v1.21.0'
-    }
-  }
 
   // Assign the provider versions based on the chart type
-  const coreCAPIProviderVersion = providerVersions[buildType].capi;
-  const rke2ProviderVersion = providerVersions[buildType].rke2;
-  const kubeadmProviderVersion = providerVersions[buildType].kubeadm
-  const fleetProviderVersion = providerVersions[buildType].fleet
-  const vsphereProviderVersion = providerVersions[buildType].vsphere
-  const amazonProviderVersion = providerVersions[buildType].amazon
-  const googleProviderVersion = providerVersions[buildType].google
-  const azureProviderVersion = providerVersions[buildType].azure
+  const coreCAPIProviderVersion = providers.version[buildType].capi;
+  const rke2ProviderVersion = providers.version[buildType].rke2;
+  const kubeadmProviderVersion = providers.version[buildType].kubeadm
+  const fleetProviderVersion = providers.version[buildType].fleet
+  const vsphereProviderVersion = providers.version[buildType].vsphere
+  const amazonProviderVersion = providers.version[buildType].amazon
+  const googleProviderVersion = providers.version[buildType].google
+  const azureProviderVersion = providers.version[buildType].azure
 
   const kubeadmBaseURL = 'https://github.com/kubernetes-sigs/cluster-api/releases/'
   const providerTypes = ['bootstrap', 'control plane']
@@ -97,13 +62,13 @@ describe('Enable CAPI Providers (2.12)', () => {
  
     qase(494, it('Verify Core CAPI Provider', () => {
       cy.navigateToProviders();
-      matchAndWaitForProviderReadyStatus(coreCAPIProvider, 'core', coreCAPIProvider, coreCAPIProviderVersion, capiNamespace);
+      matchAndWaitForProviderReadyStatus(providers.coreCAPIProvider, 'core', providers.coreCAPIProvider, coreCAPIProviderVersion, capiNamespace);
     })
     );
 
     qase(495, it('Verify Fleet addon provider', () => {
       cy.navigateToProviders();
-      matchAndWaitForProviderReadyStatus(fleetProvider, 'addon', fleetProvider, fleetProviderVersion, turtlesNamespace);
+      matchAndWaitForProviderReadyStatus(providers.fleetProvider, 'addon', providers.fleetProvider, fleetProviderVersion, turtlesNamespace);
     })
     );
 
@@ -112,20 +77,20 @@ describe('Enable CAPI Providers (2.12)', () => {
         // Create CAPI Kubeadm providers
         if (providerType == 'control plane') {
           const namespace = kubeadmProviderNamespaces[1]
-          const providerName = kubeadmProvider + '-' + 'control-plane'
+          const providerName = providers.kubeadmProvider + '-' + 'control-plane'
           cy.createNamespace([namespace]);
           // https://github.com/kubernetes-sigs/cluster-api/releases/v1.10.6/control-plane-components.yaml
           const providerURL = kubeadmBaseURL + kubeadmProviderVersion + '/' + 'control-plane' + '-components.yaml'
-          cy.addCustomProvider(providerName, 'capi-kubeadm-control-plane-system', kubeadmProvider, providerType, kubeadmProviderVersion, providerURL);
-          matchAndWaitForProviderReadyStatus(providerName, 'controlPlane', kubeadmProvider, kubeadmProviderVersion, namespace);
+          cy.addCustomProvider(providerName, 'capi-kubeadm-control-plane-system', providers.kubeadmProvider, providerType, kubeadmProviderVersion, providerURL);
+          matchAndWaitForProviderReadyStatus(providerName, 'controlPlane', providers.kubeadmProvider, kubeadmProviderVersion, namespace);
         } else {
           const namespace = kubeadmProviderNamespaces[0]
-          const providerName = kubeadmProvider + '-' + providerType
+          const providerName = providers.kubeadmProvider + '-' + providerType
           cy.createNamespace([namespace]);
           // https://github.com/kubernetes-sigs/cluster-api/releases/v1.10.6/bootstrap-components.yaml
           const providerURL = kubeadmBaseURL + kubeadmProviderVersion + '/' + providerType + '-components.yaml'
-          cy.addCustomProvider(providerName, 'capi-kubeadm-bootstrap-system', kubeadmProvider, providerType, kubeadmProviderVersion, providerURL);
-          matchAndWaitForProviderReadyStatus(providerName, providerType, kubeadmProvider, kubeadmProviderVersion, namespace);
+          cy.addCustomProvider(providerName, 'capi-kubeadm-bootstrap-system', providers.kubeadmProvider, providerType, kubeadmProviderVersion, providerURL);
+          matchAndWaitForProviderReadyStatus(providerName, providerType, providers.kubeadmProvider, kubeadmProviderVersion, namespace);
         }
       })
       );
@@ -133,14 +98,14 @@ describe('Enable CAPI Providers (2.12)', () => {
       qase([497,499], it('Verify RKE2 Providers - ' + providerType, () => {
         if (providerType == 'control plane') {
           const namespace = 'rke2-control-plane-system'
-          const providerName = rke2Provider + '-' + 'control-plane'
+          const providerName = providers.rke2Provider + '-' + 'control-plane'
           cy.navigateToProviders();
-          matchAndWaitForProviderReadyStatus(providerName, 'controlPlane', rke2Provider, rke2ProviderVersion, namespace);
+          matchAndWaitForProviderReadyStatus(providerName, 'controlPlane', providers.rke2Provider, rke2ProviderVersion, namespace);
          } else {
           const namespace = 'rke2-bootstrap-system'
-          const providerName = rke2Provider + '-' + providerType
+          const providerName = providers.rke2Provider + '-' + providerType
           cy.navigateToProviders();
-          matchAndWaitForProviderReadyStatus(providerName, providerType, rke2Provider, rke2ProviderVersion, namespace);
+          matchAndWaitForProviderReadyStatus(providerName, providerType, providers.rke2Provider, rke2ProviderVersion, namespace);
         }
       })
       );
@@ -157,7 +122,7 @@ describe('Enable CAPI Providers (2.12)', () => {
     qase(501, it('Create CAPD provider', () => {
       // Create Docker Infrastructure provider
       cy.addInfraProvider('Docker', dockerProviderNamespace);
-      matchAndWaitForProviderReadyStatus(dockerProvider, 'infrastructure', dockerProvider, kubeadmProviderVersion, dockerProviderNamespace);
+      matchAndWaitForProviderReadyStatus(providers.dockerProvider, 'infrastructure', providers.dockerProvider, kubeadmProviderVersion, dockerProviderNamespace);
     })
     );
   })
@@ -181,10 +146,10 @@ describe('Enable CAPI Providers (2.12)', () => {
       const vspherePassword = vsphere_secrets_json.vsphere_password;
       const vsphereServer = vsphere_secrets_json.vsphere_server;
       const vspherePort = '443';
-      cy.addCloudCredsVMware(vsphereProvider, vsphereUsername, vspherePassword, vsphereServer, vspherePort);
+      cy.addCloudCredsVMware(providers.vsphereProvider, vsphereUsername, vspherePassword, vsphereServer, vspherePort);
       cy.burgerMenuOperate('open');
-      cy.addInfraProvider('vSphere', vsphereProviderNamespace, vsphereProvider);
-      matchAndWaitForProviderReadyStatus(vsphereProvider, 'infrastructure', vsphereProvider, vsphereProviderVersion, vsphereProviderNamespace);
+      cy.addInfraProvider('vSphere', vsphereProviderNamespace, providers.vsphereProvider);
+      matchAndWaitForProviderReadyStatus(providers.vsphereProvider, 'infrastructure', providers.vsphereProvider, vsphereProviderVersion, vsphereProviderNamespace);
     })
     );
   })
@@ -197,7 +162,7 @@ describe('Enable CAPI Providers (2.12)', () => {
       const providerName = 'aws'
       cy.createCAPIProvider(providerName);
       cy.checkCAPIProvider(providerName);
-      matchAndWaitForProviderReadyStatus(amazonProvider, providerType, amazonProvider, amazonProviderVersion, namespace);
+      matchAndWaitForProviderReadyStatus(providers.amazonProvider, providerType, providers.amazonProvider, amazonProviderVersion, namespace);
     })
     );
 
@@ -206,10 +171,10 @@ describe('Enable CAPI Providers (2.12)', () => {
       cy.createNamespace([namespace]);
       cy.burgerMenuOperate('open');
       // Create GCP Infrastructure provider
-      cy.addCloudCredsGCP(googleProvider, Cypress.expose('gcp_credentials'));
+      cy.addCloudCredsGCP(providers.googleProvider, Cypress.expose('gcp_credentials'));
       cy.burgerMenuOperate('open');
-      cy.addInfraProvider('Google Cloud Platform', namespace, googleProvider);
-      matchAndWaitForProviderReadyStatus(googleProvider, providerType, googleProvider, googleProviderVersion, namespace);
+      cy.addInfraProvider('Google Cloud Platform', namespace, providers.googleProvider);
+      matchAndWaitForProviderReadyStatus(providers.googleProvider, providerType, providers.googleProvider, googleProviderVersion, namespace);
     })
     );
 
@@ -220,8 +185,8 @@ describe('Enable CAPI Providers (2.12)', () => {
           cy.createNamespace([namespace]);
           cy.burgerMenuOperate('open');
           // Create Azure Infrastructure provider
-          cy.addInfraProvider('Azure', namespace, azureProvider);
-          matchAndWaitForProviderReadyStatus(azureProvider, providerType, azureProvider, azureProviderVersion, namespace);
+          cy.addInfraProvider('Azure', namespace, providers.azureProvider);
+          matchAndWaitForProviderReadyStatus(providers.azureProvider, providerType, providers.azureProvider, azureProviderVersion, namespace);
         })
       );
 

--- a/tests/cypress/latest/e2e/turtles_chart.spec.ts
+++ b/tests/cypress/latest/e2e/turtles_chart.spec.ts
@@ -52,6 +52,8 @@ describe('Install Turtles Chart - @install', {tags: '@install'}, () => {
 
       if (isRancherManagerVersion('2.13') && isUpgrade) {
         // Used in Pre-upgrade: For Upgrade tests; providers will be installed from turtles-providers-chart repo
+        // TODO(pvala): this needs to be fixed, the chart repository added depends on the current rancher version rather than the upgrade rancher version.
+        // For e.g. if rancher version is prime/2.13.7 and upgrade version is prime-alpha/2.14.4-alpha3, it will add regular registry instead of staging registry
         addTurtlesProvidersRepo();
         // In Post-upgrade, providers will be installed using chartmuseum repo
       }

--- a/tests/cypress/latest/plugins/index.ts
+++ b/tests/cypress/latest/plugins/index.ts
@@ -45,6 +45,7 @@ module.exports = (on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions)
   config.expose.cluster_name_suffix = process.env.CLUSTER_NAME_SUFFIX || clusterNameSuffixDefault;
   config.expose.prime_registry = process.env.PRIME_REGISTRY;
   config.expose.stg_prime_registry = process.env.STG_PRIME_REGISTRY;
+  config.expose.skip_fleet_addon_installation = process.env.SKIP_FLEET_ADDON_INSTALLATION == "true";
 
   // Secrets
   config.expose.password = process.env.RANCHER_PASSWORD;

--- a/tests/cypress/latest/support/cleanup_support.ts
+++ b/tests/cypress/latest/support/cleanup_support.ts
@@ -73,11 +73,13 @@ export function capiClusterDeletion(clusterName: string, timeout: number, cluste
   }
 }
 
+const capiClustersNS = 'capi-clusters'
+
 export function capzResourcesCleanup(aso: boolean = false) {
   if (aso) {
-    cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], 'aso-credential-secret', vars.capiClustersNS)
+    cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], 'aso-credential-secret', capiClustersNS)
   } else {
-    cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'AzureClusterIdentities'], 'cluster-identity', vars.capiClustersNS)
+    cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'AzureClusterIdentities'], 'cluster-identity', capiClustersNS)
     cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], 'cluster-identity', 'capz-system')
   }
 }
@@ -93,10 +95,10 @@ export function capvResourcesCleanup(provider: 'kubeadm' | 'rke2') {
   cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'VSphereClusterIdentities'], 'cluster-identity');
   cy.deleteKubernetesResource('local', ['Storage', 'Secrets'], "capv-helm-values", 'capv-system')
   if (provider === 'rke2') {
-    cy.deleteKubernetesResource('local', ['Storage', 'Secrets'], "capv-docker-token", vars.capiClustersNS)
+    cy.deleteKubernetesResource('local', ['Storage', 'Secrets'], "capv-docker-token", capiClustersNS)
   }
 }
 
 export function capdResourcesCleanup() {
-  cy.deleteKubernetesResource('local', ['Storage', 'Secrets'], 'capd-docker-token', vars.capiClustersNS)
+  cy.deleteKubernetesResource('local', ['Storage', 'Secrets'], 'capd-docker-token', capiClustersNS)
 }

--- a/tests/cypress/latest/support/cleanup_support.ts
+++ b/tests/cypress/latest/support/cleanup_support.ts
@@ -73,13 +73,11 @@ export function capiClusterDeletion(clusterName: string, timeout: number, cluste
   }
 }
 
-const capiClustersNS = 'capi-clusters'
-
 export function capzResourcesCleanup(aso: boolean = false) {
   if (aso) {
-    cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], 'aso-credential-secret', capiClustersNS)
+    cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], 'aso-credential-secret', vars.capiClustersNS)
   } else {
-    cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'AzureClusterIdentities'], 'cluster-identity', capiClustersNS)
+    cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'AzureClusterIdentities'], 'cluster-identity', vars.capiClustersNS)
     cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], 'cluster-identity', 'capz-system')
   }
 }
@@ -95,10 +93,10 @@ export function capvResourcesCleanup(provider: 'kubeadm' | 'rke2') {
   cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'VSphereClusterIdentities'], 'cluster-identity');
   cy.deleteKubernetesResource('local', ['Storage', 'Secrets'], "capv-helm-values", 'capv-system')
   if (provider === 'rke2') {
-    cy.deleteKubernetesResource('local', ['Storage', 'Secrets'], "capv-docker-token", capiClustersNS)
+    cy.deleteKubernetesResource('local', ['Storage', 'Secrets'], "capv-docker-token", vars.capiClustersNS)
   }
 }
 
 export function capdResourcesCleanup() {
-  cy.deleteKubernetesResource('local', ['Storage', 'Secrets'], 'capd-docker-token', capiClustersNS)
+  cy.deleteKubernetesResource('local', ['Storage', 'Secrets'], 'capd-docker-token', vars.capiClustersNS)
 }

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -52,7 +52,7 @@ Cypress.Commands.add('namespaceAutoImport', (mode) => {
     .should('be.visible');
 
   // Select capi-clusters namespace
-  cy.setNamespace('capi-clusters');
+  cy.setNamespace(vars.capiClustersNS);
   cy.setAutoImport(mode);
   cy.namespaceReset();
 });
@@ -1537,7 +1537,6 @@ export function matchAndWaitForProviderReadyStatus(
     // Verify provider image
     cy.verifyCAPIProviderImage(providerNamespace);
 }
-
 
 export function setUseCAAPFFeatureGate(enabled: boolean, wait: boolean=true) {
   const resourceKind = 'ConfigMap';

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -52,7 +52,7 @@ Cypress.Commands.add('namespaceAutoImport', (mode) => {
     .should('be.visible');
 
   // Select capi-clusters namespace
-  cy.setNamespace(vars.capiClustersNS);
+  cy.setNamespace('capi-clusters');
   cy.setAutoImport(mode);
   cy.namespaceReset();
 });
@@ -1537,6 +1537,7 @@ export function matchAndWaitForProviderReadyStatus(
     // Verify provider image
     cy.verifyCAPIProviderImage(providerNamespace);
 }
+
 
 export function setUseCAAPFFeatureGate(enabled: boolean, wait: boolean=true) {
   const resourceKind = 'ConfigMap';

--- a/tests/cypress/latest/support/utils.ts
+++ b/tests/cypress/latest/support/utils.ts
@@ -75,3 +75,28 @@ export const getCAPIClusterKubeconfig = (
 export const applyYAMLManifest = (clusterName: string, path: string): string => {
   return `kubectl --kubeconfig=${clusterName}-kubeconfig.yaml apply -f ${path}`
 };
+
+
+type BuildType = 'prod-v2.13' | 'prod-v2.14' | 'prod-v2.15' | 'dev-v2.13' | 'dev-v2.14' | 'dev-v2.15';
+
+export function determineBuildType(): BuildType {
+  if (isTurtlesDevChart && isRancherManagerVersion('2.13')) {
+    return 'dev-v2.13';
+  }
+  if (isTurtlesDevChart && isRancherManagerVersion('2.14')) {
+    return 'dev-v2.14';
+  }
+  if (isTurtlesDevChart && isRancherManagerVersion('2.15')) {
+    return 'dev-v2.15';
+  }
+  if (isRancherManagerVersion('2.13')) {
+    return 'prod-v2.13';
+  }
+  if (isRancherManagerVersion('2.14')) {
+    return 'prod-v2.14';
+  }
+  if (isRancherManagerVersion('2.15')) {
+    return 'prod-v2.15';
+  }
+  return undefined as unknown as BuildType; // This should never happen, but it satisfies the type checker
+}

--- a/tests/cypress/latest/support/utils.ts
+++ b/tests/cypress/latest/support/utils.ts
@@ -65,6 +65,8 @@ export const isTurtlesDevChart = Cypress.expose('turtles_dev_chart')
 
 export const isUseCAAPFSupported = (isRancherManagerVersion('>=2.14.1') || (isRancherManagerVersion('>=2.14') && isHeadBuild))
 
+export const skipFleetAddOnInstallation = Cypress.expose('skip_fleet_addon_installation')
+
 export const getCAPIClusterKubeconfig = (
   clusterName: string,
   namespace: string = 'capi-clusters'

--- a/tests/cypress/latest/support/utils.ts
+++ b/tests/cypress/latest/support/utils.ts
@@ -75,28 +75,3 @@ export const getCAPIClusterKubeconfig = (
 export const applyYAMLManifest = (clusterName: string, path: string): string => {
   return `kubectl --kubeconfig=${clusterName}-kubeconfig.yaml apply -f ${path}`
 };
-
-
-type BuildType = 'prod-v2.13' | 'prod-v2.14' | 'prod-v2.15' | 'dev-v2.13' | 'dev-v2.14' | 'dev-v2.15';
-
-export function determineBuildType(): BuildType {
-  if (isTurtlesDevChart && isRancherManagerVersion('2.13')) {
-    return 'dev-v2.13';
-  }
-  if (isTurtlesDevChart && isRancherManagerVersion('2.14')) {
-    return 'dev-v2.14';
-  }
-  if (isTurtlesDevChart && isRancherManagerVersion('2.15')) {
-    return 'dev-v2.15';
-  }
-  if (isRancherManagerVersion('2.13')) {
-    return 'prod-v2.13';
-  }
-  if (isRancherManagerVersion('2.14')) {
-    return 'prod-v2.14';
-  }
-  if (isRancherManagerVersion('2.15')) {
-    return 'prod-v2.15';
-  }
-  return undefined as unknown as BuildType; // This should never happen, but it satisfies the type checker
-}

--- a/tests/cypress/latest/support/variables.ts
+++ b/tests/cypress/latest/support/variables.ts
@@ -1,4 +1,9 @@
-import {isAPIv1beta1, isRancherManagerVersion, providersChartNeedsStgRegistry} from './utils';
+import {
+  isAPIv1beta1,
+  isRancherManagerVersion,
+  isTurtlesDevChart, isUpgrade,
+  providersChartNeedsStgRegistry
+} from './utils';
 
 const primeRegistry = Cypress.expose('prime_registry');
 const stgPrimeRegistry = Cypress.expose('stg_prime_registry');
@@ -42,12 +47,64 @@ export const vars = {
   calicoCNIYaml: 'https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/applications/calico.yaml',
   azureCCMYaml: 'https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/applications/cloud-provider-azure.yaml',
   gcpCCMYaml: 'https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/applications/cloud-provider-gcp.yaml',
-  turtlesProvidersChartVersion: providersChartNeedsStgRegistry() && isRancherManagerVersion('2.13') ? '0.25' : providersChartNeedsStgRegistry() && isRancherManagerVersion('2.14') ? '0.26' : providersChartNeedsStgRegistry() && isRancherManagerVersion('2.15') ? '0.27' : undefined
+  turtlesProvidersChartVersion: (() => {
+    if (isUpgrade && isRancherManagerVersion('2.13')) {
+      // for upgrade tests, 2.13 will always be dev=false; dev=true is only applicable to 2.14
+      return '0.25';
+    }
+
+    if (!isTurtlesDevChart) {
+      if (isRancherManagerVersion('2.13')) return '0.25';
+      if (isRancherManagerVersion('2.14')) return '0.26';
+      if (isRancherManagerVersion('2.15')) return '0.27';
+    }
+
+    return undefined;
+  })()
 };
 
+type BuildType = 'prod-v2.12' | 'prod-v2.13' | 'prod-v2.14' | 'prod-v2.15' | 'dev-v2.12' | 'dev-v2.13' | 'dev-v2.14' | 'dev-v2.15';
+
+export function determineBuildType(): BuildType {
+  if (isTurtlesDevChart && isRancherManagerVersion('2.12')){
+    return 'dev-v2.12';
+  }
+  if (isTurtlesDevChart && isRancherManagerVersion('2.13')) {
+    return 'dev-v2.13';
+  }
+  if (isTurtlesDevChart && isRancherManagerVersion('2.14')) {
+    return 'dev-v2.14';
+  }
+  if (isTurtlesDevChart && isRancherManagerVersion('2.15')) {
+    return 'dev-v2.15';
+  }
+  if(isRancherManagerVersion('2.12')){
+    return 'prod-v2.12';
+  }
+  if (isRancherManagerVersion('2.13')) {
+    return 'prod-v2.13';
+  }
+  if (isRancherManagerVersion('2.14')) {
+    return 'prod-v2.14';
+  }
+  if (isRancherManagerVersion('2.15')) {
+    return 'prod-v2.15';
+  }
+  return undefined as unknown as BuildType; // This should never happen, but it satisfies the type checker
+}
 
 export const providers = {
   version: {
+    'prod-v2.12': {
+      capi: 'v1.10.5',
+      rke2: 'v0.20.1',
+      kubeadm: 'v1.10.5',
+      fleet: 'v0.11.0',
+      vsphere: 'v1.13.1',
+      amazon: 'v2.9.1',
+      google: 'v1.10.0',
+      azure: 'v1.21.0'
+    },
     'prod-v2.13': {
       capi: 'v1.10.6',
       rke2: 'v0.21.1',
@@ -77,6 +134,16 @@ export const providers = {
       amazon: 'v2.11.1',
       google: 'v1.11.2',
       azure: 'v1.23.2'
+    },
+    'dev-v2.12': {
+      capi: 'v1.10.5',
+      rke2: 'v0.20.1',
+      kubeadm: 'v1.10.5',
+      fleet: 'v0.11.0',
+      vsphere: 'v1.13.1',
+      amazon: 'v2.9.1',
+      google: 'v1.10.0',
+      azure: 'v1.21.0'
     },
     'dev-v2.13': {
       capi: 'v1.10.6',

--- a/tests/cypress/latest/support/variables.ts
+++ b/tests/cypress/latest/support/variables.ts
@@ -44,3 +44,78 @@ export const vars = {
   gcpCCMYaml: 'https://raw.githubusercontent.com/rancher/turtles/refs/heads/main/test/e2e/data/applications/cloud-provider-gcp.yaml',
   turtlesProvidersChartVersion: providersChartNeedsStgRegistry() && isRancherManagerVersion('2.13') ? '0.25' : providersChartNeedsStgRegistry() && isRancherManagerVersion('2.14') ? '0.26' : providersChartNeedsStgRegistry() && isRancherManagerVersion('2.15') ? '0.27' : undefined
 };
+
+
+export const providers = {
+  version: {
+    'prod-v2.13': {
+      capi: 'v1.10.6',
+      rke2: 'v0.21.1',
+      kubeadm: 'v1.10.6',
+      fleet: 'v0.12.0',
+      vsphere: 'v1.13.1',
+      amazon: 'v2.9.1',
+      google: 'v1.10.0',
+      azure: 'v1.21.0'
+    },
+    'prod-v2.14': {
+      capi: 'v1.12.7',
+      rke2: 'v0.24.4',
+      kubeadm: 'v1.12.7',
+      fleet: 'v0.14.1',
+      vsphere: 'v1.15.2',
+      amazon: 'v2.11.1',
+      google: 'v1.11.1',
+      azure: 'v1.22.0'
+    },
+    'prod-v2.15': {
+      capi: 'v1.13.3',
+      rke2: 'v0.25.0',
+      kubeadm: 'v1.13.3',
+      fleet: 'v0.15.0',
+      vsphere: 'v1.16.1',
+      amazon: 'v2.11.1',
+      google: 'v1.11.2',
+      azure: 'v1.23.2'
+    },
+    'dev-v2.13': {
+      capi: 'v1.10.6',
+      rke2: 'v0.21.1',
+      kubeadm: 'v1.10.6',
+      fleet: 'v0.12.0',
+      vsphere: 'v1.13.1',
+      amazon: 'v2.9.1',
+      google: 'v1.10.0',
+      azure: 'v1.21.0'
+    },
+    'dev-v2.14': {
+      capi: 'v1.12.7',
+      rke2: 'v0.24.4',
+      kubeadm: 'v1.12.7',
+      fleet: 'v0.14.1',
+      vsphere: 'v1.15.2',
+      amazon: 'v2.11.1',
+      google: 'v1.11.1',
+      azure: 'v1.22.0'
+    },
+    'dev-v2.15': {
+      capi: 'v1.13.3',
+      rke2: 'v0.25.0',
+      kubeadm: 'v1.13.3',
+      fleet: 'v0.15.0',
+      vsphere: 'v1.16.1',
+      amazon: 'v2.11.1',
+      google: 'v1.11.2',
+      azure: 'v1.23.2'
+    }
+  },
+  coreCAPIProvider : 'cluster-api',
+  rke2Provider : 'rke2',
+  kubeadmProvider : 'kubeadm',
+  dockerProvider : 'docker',
+  amazonProvider : 'aws',
+  googleProvider : 'gcp',
+  azureProvider : 'azure',
+  fleetProvider : 'fleet',
+  vsphereProvider : 'vsphere'
+}

--- a/tests/cypress/latest/support/variables.ts
+++ b/tests/cypress/latest/support/variables.ts
@@ -53,12 +53,14 @@ export const vars = {
       return '0.25';
     }
 
-    if (!isTurtlesDevChart) {
+    if (!isTurtlesDevChart && providersChartNeedsStgRegistry()) {
       if (isRancherManagerVersion('2.13')) return '0.25';
       if (isRancherManagerVersion('2.14')) return '0.26';
       if (isRancherManagerVersion('2.15')) return '0.27';
     }
-
+    // for stable releases, only supported versions will be listed, so we do not need to return/select a specific
+    // versions; selecting a version is only necessary for alpha/rc/head builds where we use staging registry that
+    // consists of unsupported versions
     return undefined;
   })()
 };
@@ -176,13 +178,13 @@ export const providers = {
       azure: 'v1.23.2'
     }
   },
-  coreCAPIProvider : 'cluster-api',
-  rke2Provider : 'rke2',
-  kubeadmProvider : 'kubeadm',
-  dockerProvider : 'docker',
-  amazonProvider : 'aws',
-  googleProvider : 'gcp',
-  azureProvider : 'azure',
-  fleetProvider : 'fleet',
-  vsphereProvider : 'vsphere'
+  coreCAPIProvider: 'cluster-api',
+  rke2Provider: 'rke2',
+  kubeadmProvider: 'kubeadm',
+  dockerProvider: 'docker',
+  amazonProvider: 'aws',
+  googleProvider: 'gcp',
+  azureProvider: 'azure',
+  fleetProvider: 'fleet',
+  vsphereProvider: 'vsphere'
 }

--- a/tests/scripts/start-cypress-tests
+++ b/tests/scripts/start-cypress-tests
@@ -60,6 +60,7 @@ docker run --init -v $PWD:/workdir -w /workdir \
     -e "CI=$CI" \
     -e PRIME_REGISTRY=$PRIME_REGISTRY \
     -e STG_PRIME_REGISTRY=$STG_PRIME_REGISTRY \
+    -e SKIP_FLEET_ADDON_INSTALLATION=$SKIP_FLEET_ADDON_INSTALLATION \
     --add-host host.docker.internal:host-gateway \
     --ipc=host \
     $CYPRESS_DOCKER \


### PR DESCRIPTION
### What does this PR do?
1. Move Fleet Addon provider setup our of providers setup into `fleet_addon_provider_setup.spec.ts` file
2. Add a new GH input and env var `SKIP_FLEET_ADDON_INSTALLATION` that can be useful while debugging nocaapf tests, otherwise fleet addon provider will be installed and having to switch back will be a headache.
3. Move code around (mostly to variables.ts) to better serve both the provider setup files.
4. Move `Create AzureClusterIdentity` test to providers_setup since it was repeated for almost all the tests. (This to be done for the remaining cloud providers as well wherever applicable
5. Remove cloud credentials and provider setup code out of the nocaapf test files.
6. Add new tags for nocaapf tests.
7. Bump Rancher version for upgrade test to 2.13.7 and 2.14.4-alpha5.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #575

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [x] Added/Modified Qase IDs
- [ ] GitHub Actions (if applicable)

### Special notes for your reviewer:

<!-- e2e-result-start -->
### E2E Test Results:

| Run Name | Run Result | Notes |
|----------|------------|-------|
| [[4966] Rancher-prime/2.14.3 - **@install @full** dev=true destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29080690578) | ❌ Fail | CAPG GKE failed |
| [[5012] Rancher-head/2.14 - **@install @upgrade** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29323094742) | ✅ Pass | prime/2.13.5 > prime/2.14.3 |
| [[5009] Rancher-head/2.14 - **@install @migration** dev=false destroy=false](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29322998093) | ❌ Fail | Failure related to azure-rke2 v2prov on 2.13 (known issue) |
| [[5014] Rancher-head/2.14 - **@install @vsphere** dev=true destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29325780563) | ❌ Fail | CAPV RKE2 failure (unrelated) |
| [[5020] Rancher-prime/2.12.11 - **@install @short** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29334089833) | ❌ Fail | related to verifying provider images |
| [[5019] Rancher-prime/2.13.7 - **@install @short** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29334024807) | ❌ Fail | azure_rke2_v2prov_cluster failure (known issue) |
| [[5024] Rancher-head/2.14 - **@install @upgrade** dev=true destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29342619558) | ✅ Pass | |
| [[5034] Rancher-prime/2.14.3 - **@install @full** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29392362311) | ❌ Fail | capa_rke2_nocaapf_clusterclass failed in Install App; capa_rke2_clusterclass failed in `1) Get Cloud credential ID` _needs investigation_; capg_gke_clusterclass failed in cluster import (but it also failed on [main](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29421965769) as well, so needs to be investigated separately, from the log it looks like we need to bump k8s version to 1.35.5) |
| [[5040] Rancher-prime/2.14.3 - **@install @capar @capar-nocaapf** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29423560430) | ❌ Fail | capar-nocaapf failed in Install App; failed on [main](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29429534136) |
| [[5042] Rancher-prime/2.13.7 - **@install @switch** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29429935077) | ✅ Pass | |
| [[5047] Rancher-prime-alpha/2.14.4-alpha3 - **@install @short** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29481750561) | ✅ Pass | |
| [[5048] Rancher-prime-alpha/2.14.4-alpha3 - **@install @full** dev=false destroy=false](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29485504684) | ⚠️ Cancelled | Cypress total timeout; the test ran for 7h; CAPG Kubeadm No-CAAPF failed, rerunning it; CAPA RKE2 No-CAAPF Install App failed (known issue) |
| [[5055] Rancher-prime-alpha/2.14.4-alpha3 - **@install @capgk-nocaapf** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29514675226) | ✅ Pass | |
| [[5056] Rancher-head/2.14 - **@install @upgrade** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29514767507) | ✅ Pass | prime/2.13.7 > prime-alpha/2.14.4-alpha3 |
| [[5057] Rancher-prime-alpha/2.14.4-alpha3 - **@install @capgk-nocaapf @capgk** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29521020246) | ❌ Fail | CAPGK Scaling operation failed, but it looks like flake since it passed in the full run |
| [[5063] Rancher-prime/2.13.7 - **@install** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29557860662) | ✅ Pass | |
| [[5064] Rancher-head/2.14 - **@install @short** dev=true destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29558208853) | ✅ Pass | |
| [[5067] Rancher-prime-alpha/2.14.4-alpha3 - **@install @vsphere** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29561607775) | ✅ Pass | |
| [[5068] Rancher-prime-alpha/2.14.4-alpha3 - **@install @short** dev=false destroy=false](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29562405839) | ✅ Pass | |
| [[5090] Rancher-prime-alpha/2.15.0-alpha21 - **@install @capar-nocaapf** dev=false destroy=false](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29733530096) | ✅ Pass | |
| [[5091] Rancher-prime-alpha/2.15.0-alpha21 - **@install @short** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29735297364) | ❌ Fail | |
| [[5111] Rancher-prime-alpha/2.14.4-alpha4 - **@install @capar** dev=false destroy=false](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29812548667) | ❌ Fail | |
| [[5117] Rancher-prime-alpha/2.14.4-alpha4 - **@install** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29823673082) | ✅ Pass | Tests SKIP_FLEET_ADDON_INSTALLATION=true |
| [[5118] Rancher-prime-alpha/2.14.4-alpha4 - **@install @short** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29823695405) | ✅ Pass | Tests SKIP_FLEET_ADDON_INSTALLATION=false (default) |
| [[5125] Rancher-prime-alpha/2.15.0-alpha21 - **@install @capar-nocaapf** dev=false destroy=false](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29837609616) | ✅ Pass | |
| [[5135] Rancher-head/2.14 - **@install @short** dev=true destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29897497128) | ✅ Pass | Tests NoCAAPF tests are skipped on 2.14|
| [[5138] Rancher-prime-alpha/2.15.0-alpha21 - **@install @short** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29898440683) | ❌ Fail | Tests NoCAAPF tests are not skipped on 2.15 |
| [[5142] Rancher-prime-alpha/2.14.4-alpha5 - **@install @nocaapf** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29905356027) | ✅ Pass | Tests NoCAAPF tests were not run on 2.14 |
| [[5146] Rancher-prime-alpha/2.14.4-alpha6 - **@install** dev=false destroy=false](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29986894841) | ✅ Pass | |
<!-- e2e-result-end -->

























































































