### PR TITLE
Kind image removal for 1.36

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -462,11 +462,6 @@ jobs:
         with:
           cache: false
           go-version-file: tests/go.mod
-      # until kindest/node:v1.36.1 is available upstream
-      - name: Create kind node-image
-        if: ${{ contains(env.RANCHER_VERSION, '2.15') }}
-        run: |
-          cd tests && make kind-node-image
       - name: Copy turtles chart files for chartmuseum
         if: ${{ inputs.turtles_dev_chart == true }}
         run: |


### PR DESCRIPTION
### What does this PR do?
Kind image removal for 1.36, since its now available upstream

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [ ] Added/Modified Qase IDs
- [ ] GitHub Actions (if applicable)

### Special notes for your reviewer:

<!-- e2e-result-start -->
### E2E Test Results:

| Run Name | Run Result | Notes |
|----------|------------|-------|
| [[4986] Rancher-prime-alpha/2.15.0-alpha17 - **@install @short** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29237210008) | ❌ Fail | Failures are unrelated |
<!-- e2e-result-end -->


