### PR TITLE
Add CAPA RKE2 No-Caapf tests

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -281,6 +281,7 @@ jobs:
       SPECS: |
         e2e/capd_kubeadm_nocaapf_clusterclass.spec.ts
         e2e/capd_rke2_nocaapf_clusterclass.spec.ts
+        e2e/capa_rke2_nocaapf_clusterclass.spec.ts
         e2e/capz_kubeadm_nocaapf_clusterclass.spec.ts
         e2e/capz_rke2_nocaapf_clusterclass.spec.ts
         e2e/capg_kubeadm_nocaapf_clusterclass.spec.ts

--- a/tests/cypress/latest/e2e/capa_eks_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capa_eks_clusterclass.spec.ts
@@ -30,8 +30,6 @@ describe('Import CAPA EKS Class-Cluster', {tags: ['@full', '@capaeks']}, () => {
 
     qase(343, it('Create AWS CAPIProvider & AWSClusterStaticIdentity', () => {
       if (isRancherManagerVersion('<2.13')) {
-        cy.removeCAPIResource('Providers', providerName);
-        cy.createCAPIProvider(providerName);
         cy.checkCAPIProvider(providerName);
       }
       cy.createAWSClusterStaticIdentity(accessKey, secretKey);

--- a/tests/cypress/latest/e2e/capa_kubeadm_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capa_kubeadm_clusterclass.spec.ts
@@ -29,8 +29,7 @@ describe('Import CAPA Kubeadm Class-Cluster', {tags: ['@full', '@capak']}, () =>
 
     qase(342, it('Create AWS CAPIProvider & AWSClusterStaticIdentity', () => {
       if (isRancherManagerVersion('<2.13')) {
-        cy.removeCAPIResource('Providers', providerName);
-        cy.createCAPIProvider(providerName);
+        cy.checkCAPIProvider(providerName);
       }
       cy.createAWSClusterStaticIdentity(accessKey, secretKey);
     })

--- a/tests/cypress/latest/e2e/capa_rke2_nocaapf_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capa_rke2_nocaapf_clusterclass.spec.ts
@@ -1,17 +1,17 @@
 import '../support/commands';
-import {getClusterName, isAPIv1beta1, isRancherManagerVersion, skipClusterDeletion} from '../support/utils';
+import {getClusterName, isRancherManagerVersion, skipClusterDeletion} from '../support/utils';
 import {capaResourcesCleanup, capiClusterDeletion, importedRancherv3ClusterDeletion} from "../support/cleanup_support";
 import {vars} from '../support/variables';
 
 Cypress.config();
-describe('Import CAPA RKE2 Class-Cluster', {tags: ['@full', '@capar']}, () => {
+describe('Import CAPA RKE2 (No-Caapf) Class-Cluster', {tags: ['@full', '@nocaapf', '@capar-nocaapf']}, () => {
   let ccID: string;
   const timeout = vars.fullTimeout
   const classNamePrefix = 'aws-rke2'
   const clusterName = getClusterName(classNamePrefix)
   const classesPath = 'examples/clusterclasses/aws/rke2'
   const clusterClassRepoName = 'aws-rke2-clusterclass'
-  const classClusterFileName = isAPIv1beta1 ? './fixtures/aws/capa-rke2-class-cluster-v1beta1.yaml' : './fixtures/aws/capa-rke2-class-cluster.yaml'
+  const classClusterFileName = './fixtures/aws/capa-rke2-class-cluster-nocaapf.yaml'
 
   const providerName = 'aws'
   const accessKey = Cypress.expose('aws_access_key')
@@ -28,19 +28,9 @@ describe('Import CAPA RKE2 Class-Cluster', {tags: ['@full', '@capar']}, () => {
     })
     );
 
-    qase(341, it('Create AWS CAPIProvider & AWSClusterStaticIdentity', () => {
-      if (isRancherManagerVersion('<2.13')) {
-        cy.checkCAPIProvider(providerName);
-      }
-      if (isRancherManagerVersion('<2.15')) {
-        cy.createAWSClusterStaticIdentity(accessKey, secretKey);
-      } else {
-        cy.checkAWSClusterStaticIdentity();
-      }
-    })
-    );
-
-    it('Get Cloud credential ID', () => {
+    it('Add Cloud credentials & Get Cloud credential ID', () => {
+      cy.addCloudCredsAWS(providerName, Cypress.expose('aws_access_key'), Cypress.expose('aws_secret_key'));
+      cy.burgerMenuOperate('open');
       cy.accesMenuSelection(['Cluster Management', 'Cloud Credentials']);
       cy.getBySel('sortable-table-list-container').should('be.visible');
       cy.typeInFilter(providerName);
@@ -51,27 +41,27 @@ describe('Import CAPA RKE2 Class-Cluster', {tags: ['@full', '@capar']}, () => {
       });
     })
 
-    // HelmOps to be used for this spec
-    // AWSClusterStaticIdentity only allows provisioning clusters in "fleet-default"
-    it('Add Applications fleet repo', () => {
-      // Add upstream apps repo
-      cy.addFleetGitRepo('helm-ops-aws', vars.turtlesRepoUrl, vars.classBranch, 'examples/applications/', vars.fleetDefaultNS);
+    it('Create AWS CAPIProvider & AWSClusterStaticIdentity', () => {
+      if (isRancherManagerVersion('<2.13')) {
+        cy.checkCAPIProvider(providerName);
+      }
+      if (isRancherManagerVersion('<2.15')) {
+        cy.createAWSClusterStaticIdentity(accessKey, secretKey);
+      } else {
+        cy.checkAWSClusterStaticIdentity();
+      }
     })
-    
+
     qase(116,
       it('Add CAPA RKE2 ClusterClass Fleet Repo and check Applications', () => {
         cy.addFleetGitRepo(clusterClassRepoName, vars.turtlesRepoUrl, vars.classBranch, classesPath, vars.capiClassesNS)
         // Go to CAPI > ClusterClass to ensure the clusterclass is created
         cy.checkCAPIClusterClass(classNamePrefix);
-
-        // Navigate to `local` cluster, More Resources > Fleet > HelmOps and ensure the charts are present.
-        cy.checkFleetHelmOps(['aws-ccm', 'aws-csi-driver']);
       })
     );
   })
 
   context('[CLUSTER-IMPORT]', () => {
-
     qase(110,
       it('Import CAPA RKE2 class-cluster using YAML', () => {
         cy.readFile(classClusterFileName).then((data) => {
@@ -83,6 +73,7 @@ describe('Import CAPA RKE2 Class-Cluster', {tags: ['@full', '@capar']}, () => {
           } else {
             data = data.replace(/replace_identity_name/g, ccID)
           }
+          // AWSClusterStaticIdentity only allows provisioning clusters in "fleet-default"
           cy.importYAML(data);
         });
         // Check CAPI cluster using its name
@@ -113,12 +104,6 @@ describe('Import CAPA RKE2 Class-Cluster', {tags: ['@full', '@capar']}, () => {
   })
 
   context('[CLUSTER-OPERATIONS]', () => {
-    qase(112,
-      (isRancherManagerVersion('>2.14') ? it.skip : it)('Install App on imported cluster', {retries: 1}, () => {
-        cy.checkChart(clusterName, 'Install', 'Logging', 'cattle-logging-system');
-      })
-    );
-
     qase(312, it("Scale up imported CAPA cluster by patching class-cluster yaml", () => {
       cy.readFile(classClusterFileName).then((data) => {
         data = data.replace(/replicas: 2/g, 'replicas: 3')
@@ -132,7 +117,6 @@ describe('Import CAPA RKE2 Class-Cluster', {tags: ['@full', '@capar']}, () => {
         } else {
           data = data.replace(/replace_identity_name/g, ccID)
         }
-        // AWSClusterStaticIdentity only allows provisioning clusters in "fleet-default"
         cy.importYAML(data);
       })
 
@@ -143,6 +127,12 @@ describe('Import CAPA RKE2 Class-Cluster', {tags: ['@full', '@capar']}, () => {
       cy.get('.content > .count', {timeout: timeout}).should('have.text', '3');
       cy.checkCAPIClusterActive(clusterName);
     })
+    );
+
+    qase(112,
+      (isRancherManagerVersion('>2.14') ? it.skip : it)('Install App on imported cluster', {retries: 1}, () => {
+        cy.checkChart(clusterName, 'Install', 'Logging', 'cattle-logging-system');
+      })
     );
 
     it('Check for any errors in Turtles logs', () => {
@@ -161,7 +151,6 @@ describe('Import CAPA RKE2 Class-Cluster', {tags: ['@full', '@capar']}, () => {
       })
       );
 
-
       qase(114,
         it('Delete the CAPA cluster', {retries: 1}, () => {
           // Remove CAPI Resources related to the cluster
@@ -175,6 +164,7 @@ describe('Import CAPA RKE2 Class-Cluster', {tags: ['@full', '@capar']}, () => {
           cy.removeFleetGitRepo(clusterClassRepoName);
           // Cleanup other resources
           capaResourcesCleanup();
+          cy.deleteCloudCredsAWS(providerName);
         })
       );
     }

--- a/tests/cypress/latest/e2e/providers_setup.spec.ts
+++ b/tests/cypress/latest/e2e/providers_setup.spec.ts
@@ -86,9 +86,9 @@ describe('Enable CAPI Providers', () => {
       azure: 'v1.22.0'
     },
     'prod-v2.15': {
-      capi: 'v1.13.2',
+      capi: 'v1.13.3',
       rke2: 'v0.25.0',
-      kubeadm: 'v1.13.2',
+      kubeadm: 'v1.13.3',
       fleet: 'v0.15.0',
       vsphere: 'v1.16.1',
       amazon: 'v2.11.1',
@@ -116,9 +116,9 @@ describe('Enable CAPI Providers', () => {
       azure: 'v1.22.0'
     },
     'dev-v2.15': {
-      capi: 'v1.13.2',
+      capi: 'v1.13.3',
       rke2: 'v0.25.0',
-      kubeadm: 'v1.13.2',
+      kubeadm: 'v1.13.3',
       fleet: 'v0.15.0',
       vsphere: 'v1.16.1',
       amazon: 'v2.11.1',

--- a/tests/cypress/latest/e2e/providers_setup_legacy.spec.ts
+++ b/tests/cypress/latest/e2e/providers_setup_legacy.spec.ts
@@ -194,12 +194,9 @@ describe('Enable CAPI Providers (2.12)', () => {
 
     qase(505, it('Create CAPA provider', {tags: ['@capak', '@capar', '@capaeks']}, () => {
       const namespace = 'capa-system'
-      cy.createNamespace([namespace]);
-      cy.burgerMenuOperate('open');
-      // Create AWS Infrastructure provider
-      cy.addCloudCredsAWS(amazonProvider, Cypress.expose('aws_access_key'), Cypress.expose('aws_secret_key'));
-      cy.burgerMenuOperate('open');
-      cy.addInfraProvider('Amazon', namespace, amazonProvider);
+      const providerName = 'aws'
+      cy.createCAPIProvider(providerName);
+      cy.checkCAPIProvider(providerName);
       matchAndWaitForProviderReadyStatus(amazonProvider, providerType, amazonProvider, amazonProviderVersion, namespace);
     })
     );

--- a/tests/cypress/latest/fixtures/aws/capa-rke2-class-cluster-nocaapf.yaml
+++ b/tests/cypress/latest/fixtures/aws/capa-rke2-class-cluster-nocaapf.yaml
@@ -1,0 +1,141 @@
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Cluster
+metadata:
+  labels:
+    cluster-api.cattle.io/rancher-auto-import: "true"
+    cloud-provider: aws
+    csi: aws-ebs-csi-driver
+  name: replace_cluster_name
+  namespace: fleet-default
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+  topology:
+    classRef:
+      name: aws-rke2-example
+      namespace: capi-classes
+    controlPlane:
+      replicas: 3
+    variables:
+      - name: region
+        value: ap-south-2
+      - name: sshKeyName
+        value: turtles-qa-rke2
+      - name: controlPlaneMachineType
+        value: t3.2xlarge
+      - name: workerMachineType
+        value: t3.2xlarge
+      - name: amiID
+        value: replace_amiID
+      - name: cni
+        value: calico
+      - name: awsClusterIdentityName
+        value: replace_identity_name
+    version: replace_rke2_version
+    workers:
+      machineDeployments:
+        - class: default-worker
+          name: md-0
+          replicas: 2
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta2
+kind: ClusterResourceSet
+metadata:
+  name: cloud-provider-aws
+  namespace: fleet-default
+spec:
+  strategy: Reconcile
+  clusterSelector:
+    matchLabels:
+      cloud-provider: aws
+  resources:
+    - name: cloud-provider-aws
+      kind: ConfigMap
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cloud-provider-aws
+  namespace: fleet-default
+data:
+  cloud-provider-aws.yaml: |-
+    apiVersion: helm.cattle.io/v1
+    kind: HelmChart
+    metadata:
+      name: aws-cloud-controller-manager
+      namespace: kube-system
+    spec:
+      chart: aws-cloud-controller-manager
+      repo: https://kubernetes.github.io/cloud-provider-aws
+      version: 0.0.11
+      targetNamespace: kube-system
+      bootstrap: true
+      valuesContent: |-
+        hostNetworking: "true"
+        args:
+          - --v=2
+          - --cloud-provider=aws
+          - --use-service-account-credentials=true
+          - --configure-cloud-routes=false
+        nodeSelector:
+          node-role.kubernetes.io/control-plane: "true"
+        clusterRoleRules:
+          - apiGroups:
+              - ""
+            resources:
+              - events
+              - nodes
+              - nodes/status
+              - services
+              - services/status
+              - serviceaccounts
+              - persistentvolumes
+              - configmaps
+              - serviceaccounts/token
+              - endpoints
+            verbs:
+              - "*"
+          - apiGroups:
+              - coordination.k8s.io
+            resources:
+              - leases
+            verbs:
+              - create
+              - get
+              - list
+              - watch
+              - update
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta2
+kind: ClusterResourceSet
+metadata:
+  name: aws-ebs-csi
+  namespace: fleet-default
+spec:
+  strategy: Reconcile
+  clusterSelector:
+    matchLabels:
+      csi: aws-ebs-csi-driver
+  resources:
+    - name: aws-ebs-csi
+      kind: ConfigMap
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aws-ebs-csi
+  namespace: fleet-default
+data:
+  aws-ebs-csi.yaml: |-
+    apiVersion: helm.cattle.io/v1
+    kind: HelmChart
+    metadata:
+      name: aws-ebs-csi-driver
+      namespace: kube-system
+    spec:
+      chart: aws-ebs-csi-driver
+      repo: https://kubernetes-sigs.github.io/aws-ebs-csi-driver
+      version: 2.62.0
+      targetNamespace: kube-system

--- a/tests/cypress/latest/fixtures/aws/capa-rke2-class-cluster.yaml
+++ b/tests/cypress/latest/fixtures/aws/capa-rke2-class-cluster.yaml
@@ -7,6 +7,7 @@ metadata:
     csi: aws-ebs-csi-driver
     cluster-api.cattle.io/rancher-auto-import: "true"
   name: replace_cluster_name
+  namespace: fleet-default
 spec:
   clusterNetwork:
     pods:
@@ -32,7 +33,7 @@ spec:
     - name: cni
       value: none
     - name: awsClusterIdentityName
-      value: cluster-identity
+      value: replace_identity_name
     version: replace_rke2_version
     workers:
       machineDeployments:

--- a/tests/cypress/latest/support/cleanup_support.ts
+++ b/tests/cypress/latest/support/cleanup_support.ts
@@ -1,14 +1,14 @@
 import {vars} from '../support/variables';
 
-export const v3ClusterDeleteCommand = (clusterName: string): string => {
-  return `kubectl delete clusters.management.cattle.io -l cluster-api.cattle.io/capi-cluster-owner=${clusterName} -l cluster-api.cattle.io/capi-cluster-owner-ns=${vars.capiClustersNS}`;
+export const v3ClusterDeleteCommand = (clusterName: string, namespace: string = vars.capiClustersNS): string => {
+  return `kubectl delete clusters.management.cattle.io -l cluster-api.cattle.io/capi-cluster-owner=${clusterName} -l cluster-api.cattle.io/capi-cluster-owner-ns=${namespace}`;
 };
 
 export const reImportClusterPatchCommand = (clusterName: string): string => {
   return `kubectl -n ${vars.capiClustersNS} patch clusters.cluster.x-k8s.io ${clusterName} --type="json" -p='[{"op":"remove","path":"/metadata/annotations/imported"}]'`;
 };
 
-export function importedRancherv3ClusterDeletion(clusterName: string) {
+export function importedRancherv3ClusterDeletion(clusterName: string, namespace: string = vars.capiClustersNS) {
   // Verify the imported cluster is present before deletion
   cy.searchCluster(clusterName);
   cy.get('table.sortable-table tbody tr').then(($rows) => {
@@ -18,7 +18,7 @@ export function importedRancherv3ClusterDeletion(clusterName: string) {
     }
 
     // Delete the imported mgmt v3 cluster from Cluster Management using kubectl
-    cy.kubectlExecute([v3ClusterDeleteCommand(clusterName)]);
+    cy.kubectlExecute([v3ClusterDeleteCommand(clusterName, namespace)]);
 
     // Ensure the cluster is not available on the home page
     cy.goToHome();

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -460,6 +460,17 @@ Cypress.Commands.add('addCloudCredsAWS', (name, accessKey, secretKey) => {
   cy.contains(name).should('be.visible');
 });
 
+Cypress.Commands.add('deleteCloudCredsAWS', (name) => {
+  cy.burgerMenuOperate('open');
+  cy.accesMenuSelection(['Cluster Management', 'Cloud Credentials']);
+  cy.contains('API Key').should('be.visible');
+  cy.getBySel('sortable-table-list-container').should('be.visible');
+  cy.typeInFilter(name);
+  cy.viewport(1920, 1080);
+  cy.getBySel('sortable-table_check_select_all').click();
+  cy.getBySel('sortable-table-promptRemove').click({ctrlKey: true});
+});
+
 // Command to add GCP Cloud Credentials
 Cypress.Commands.add('addCloudCredsGCP', (name, gcpCredentials) => {
   cy.accesMenuSelection(['Cluster Management', 'Cloud Credentials']);
@@ -1187,6 +1198,20 @@ Cypress.Commands.add('createAWSClusterStaticIdentity', (accessKey, secretKey) =>
     data = data.replace(/replace_access_key_id/g, accessKey)
     data = data.replace(/replace_secret_access_key/g, secretKey)
     cy.importYAML(data)
+  });
+});
+
+// Check AWSClusterStaticIdentity
+Cypress.Commands.add('checkAWSClusterStaticIdentity', () => {
+  cy.burgerMenuOperate('open');
+  cy.accesMenuSelection(['Cluster Management', 'Cloud Credentials']);
+  cy.getBySel('sortable-table-list-container').should('be.visible');
+  cy.typeInFilter('aws');
+  // Get the CC id
+  cy.getBySel('sortable-cell-0-0').then(($cell) => {
+    const ccID = $cell.text();
+    cy.task('suiteLog', `Cloud credential ID: ${ccID}`);
+    cy.checkKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'AWSClusterStaticIdentities'], ccID, true, 'capa-system');
   });
 });
 

--- a/tests/cypress/latest/support/e2e.ts
+++ b/tests/cypress/latest/support/e2e.ts
@@ -66,6 +66,7 @@ declare global {
       addInfraProvider(providerType: string, namespace: string, cloudCredentials?: string): Chainable<Element>;
       removeCAPIResource(resourceType: string, resourceName: string, timeout?: number): Chainable<Element>;
       addCloudCredsAWS(name: string, accessKey: string, secretKey: string): Chainable<Element>;
+      deleteCloudCredsAWS(name: string): Chainable<Element>;
       addCloudCredsGCP(name: string, gcpCredentials: string): Chainable<Element>;
       addCloudCredsAzure(name: string, clientID: string, clientSecret: string, subscriptionID: string): Chainable<Element>;
       addCloudCredsVMware(name: string, vsphere_username: string, vsphere_password: string, vsphere_server: string, vsphere_server_port: string): Chainable<Element>;
@@ -80,6 +81,7 @@ declare global {
       exploreCluster(clusterName: string): Chainable<Element>;
       createVSphereClusterIdentity(vsphere_username: string, vsphere_password: string): Chainable<Element>;
       createAWSClusterStaticIdentity(accessKey: string, secretKey: string): Chainable<Element>;
+      checkAWSClusterStaticIdentity(): Chainable<Element>;
       createCAPIProvider(providerName: string): Chainable<Element>;
       checkCAPIProvider(providerName: string): Chainable<Element>;
       verifyCAPIProviderImage(providerNamespace: string): Chainable<Element>;


### PR DESCRIPTION
### What does this PR do?
- Adds CAPA RKE2 No-Caapf tests
- Changes CAPI cluster namespace to fleet-default as per https://github.com/rancher/turtles/issues/2455

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [ ] Added/Modified Qase IDs
- [ ] GitHub Actions (if applicable)

### Special notes for your reviewer:

<!-- e2e-result-start -->
### E2E Test Results:

| Run Name | Run Result | Notes |
|----------|------------|-------|
| [[4991] Rancher-head/2.14 - **@install @capar** dev=true destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29245600638) | ❌ Fail | InstallApp failure |
| [[4992] Rancher-prime-alpha/2.15.0-alpha17 - **@install @capar** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29246224717) | ✅ Pass | |
<!-- e2e-result-end -->



