### PR TITLE
Cleanup

### DIFF
--- a/tests/cypress/latest/e2e/turtles_chart.spec.ts
+++ b/tests/cypress/latest/e2e/turtles_chart.spec.ts
@@ -26,21 +26,6 @@ describe('Install Turtles Chart - @install', {tags: '@install'}, () => {
     cy.burgerMenuOperate('open');
   });
 
-  qase(151, it("Change helm charts to Include Prerelease Versions", () => {
-    // this test should be run before the turtles repository is added; so that it can fetch the prereleased versions
-
-    // toggle the navigation menu to a close
-    cy.burgerMenuOperate('close');
-
-    cy.getBySel('nav_header_showUserMenu').click();
-    cy.contains('Preferences').click();
-    cy.contains("Include Prerelease Versions").scrollIntoView().should('be.visible').click();
-    cy.reload();
-    // check that the prerelease version is selected by ensuring it does not have `bg-disabled` class
-    cy.contains("Include Prerelease Versions").scrollIntoView().should('not.have.class', 'bg-disabled');
-  })
-  );
-
   let addTurtlesProvidersRepo = function () {
     cy.task('suiteLog', "Adding turtles-providers-chart repo");
     cy.addRepository('turtles-providers-chart', vars.turtlesProvidersOCIRepo, 'oci', 'none')

--- a/tests/cypress/latest/support/cleanup_support.ts
+++ b/tests/cypress/latest/support/cleanup_support.ts
@@ -73,13 +73,11 @@ export function capiClusterDeletion(clusterName: string, timeout: number, cluste
   }
 }
 
-const capiClustersNS = 'capi-clusters'
-
 export function capzResourcesCleanup(aso: boolean = false) {
   if (aso) {
-    cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], 'aso-credential-secret', capiClustersNS)
+    cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], 'aso-credential-secret', vars.capiClustersNS)
   } else {
-    cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'AzureClusterIdentities'], 'cluster-identity', capiClustersNS)
+    cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'AzureClusterIdentities'], 'cluster-identity', vars.capiClustersNS)
     cy.deleteKubernetesResource('local', ['More Resources', 'Core', 'Secrets'], 'cluster-identity', 'capz-system')
   }
 }
@@ -95,10 +93,10 @@ export function capvResourcesCleanup(provider: 'kubeadm' | 'rke2') {
   cy.deleteKubernetesResource('local', ['More Resources', 'Cluster Provisioning', 'VSphereClusterIdentities'], 'cluster-identity');
   cy.deleteKubernetesResource('local', ['Storage', 'Secrets'], "capv-helm-values", 'capv-system')
   if (provider === 'rke2') {
-    cy.deleteKubernetesResource('local', ['Storage', 'Secrets'], "capv-docker-token", capiClustersNS)
+    cy.deleteKubernetesResource('local', ['Storage', 'Secrets'], "capv-docker-token", vars.capiClustersNS)
   }
 }
 
 export function capdResourcesCleanup() {
-  cy.deleteKubernetesResource('local', ['Storage', 'Secrets'], 'capd-docker-token', capiClustersNS)
+  cy.deleteKubernetesResource('local', ['Storage', 'Secrets'], 'capd-docker-token', vars.capiClustersNS)
 }

--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -52,7 +52,7 @@ Cypress.Commands.add('namespaceAutoImport', (mode) => {
     .should('be.visible');
 
   // Select capi-clusters namespace
-  cy.setNamespace('capi-clusters');
+  cy.setNamespace(vars.capiClustersNS);
   cy.setAutoImport(mode);
   cy.namespaceReset();
 });
@@ -1537,7 +1537,6 @@ export function matchAndWaitForProviderReadyStatus(
     // Verify provider image
     cy.verifyCAPIProviderImage(providerNamespace);
 }
-
 
 export function setUseCAAPFFeatureGate(enabled: boolean, wait: boolean=true) {
   const resourceKind = 'ConfigMap';


### PR DESCRIPTION
### What does this PR do?
1. Removing test that sets `Pre release`, this was required when Rancher Turtles was installed as an external chart; this is no longer required since there will be no new release for external chart.
2. Use constant defined for namespace
### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [ ] Added/Modified Qase IDs
- [ ] GitHub Actions (if applicable)

### Special notes for your reviewer:

<!-- e2e-result-start -->
### E2E Test Results:

| Run Name | Run Result | Notes |
|----------|------------|-------|
| [[5101] Rancher-prime/2.12.11 - **@install** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29755093737) | ❌ Fail | Known failure related to CAPI image verification but turtles was installed successfully |
| [[5102] Rancher-prime-alpha/2.14.4-alpha4 - **@install** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29755123645) | ✅ Pass | |
| [[5109] Rancher-head/2.14 - **@install @short** dev=true destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29809893985) | ✅ Pass | |
| [[5126] Rancher-prime-alpha/2.14.4-alpha4 - **@install @capdk** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29839093936) | ✅ Pass | |
<!-- e2e-result-end -->





