### PR TITLE
Switch to managedDisks on CAPZ for <=2.13

### DIFF
--- a/tests/cypress/latest/fixtures/azure/azure-rke-config-v1beta1.yaml
+++ b/tests/cypress/latest/fixtures/azure/azure-rke-config-v1beta1.yaml
@@ -15,7 +15,7 @@ environment: AzurePublicCloud
 faultDomainCount: "3"
 image: canonical:UbuntuServer:18.04-LTS:latest
 location: centralindia
-managedDisks: false
+managedDisks: true
 noPublicIp: false
 nsg: rancher-managed-BZhXsqxh
 resourceGroup: replace_cluster_name


### PR DESCRIPTION
### What does this PR do?
fixes v2prov rke2 capz tests on <=2.13

Without this change the azure provisioning is failing on:
```
(turtles-qa-azure-v2-5aot-pool1-mkt7n-7b28p) Azure response  method="PUT" request="https://management.azure.com/subscriptions/fxxx/resourceGroups/turtles-qa-azure-v2-5aot/providers/Microsoft.Compute/virtualMachines/turtles-qa-azure-v2-5aot-pool1-mkt7n-7b28p?api-version=2019-12-01" x-ms-request-id="fxxx" status="400 Bad Request"
error creating machine: error in driver during machine creation: compute.VirtualMachinesClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: Code="BadRequest" Message="Unmanaged disks have been retired. Please migrate to Managed Disks. More details available here: https://learn.microsoft.com/en-us/azure/virtual-machines/unmanaged-disks-deprecation"
```

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [x] Squashed commits into logical changes
- [ ] Documentation
- [ ] Added/Modified Qase IDs
- [ ] GitHub Actions (if applicable)

### Special notes for your reviewer:

migration on `2.13.8-alpha5` using the commit (from another branch) https://github.com/rancher/rancher-turtles-e2e/actions/runs/29817105096

<!-- e2e-result-start -->
### E2E Test Results:

| Run Name | Run Result | Notes |
|----------|------------|-------|
| [[5115] Rancher-prime-alpha/2.13.8-alpha5 - **@install @short** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/29821418490) | ✅ Pass | |
<!-- e2e-result-end -->

