### PR TITLE
Upgrade tests refactor

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -520,8 +520,8 @@ jobs:
             e2e/turtles_chart_legacy.spec.ts
             e2e/turtles_ui_extension.spec.ts
             e2e/menu.spec.ts
-            e2e/capd_rke2_migration_clusterclass.spec.ts
             ${{ env.SPECS }}
+            e2e/capd_rke2_migration_clusterclass.spec.ts
             e2e/capd_rke2_upgrade_clusterclass.spec.ts
             e2e/pre_upgrade_setup.spec.ts
         run: |
@@ -553,14 +553,36 @@ jobs:
             QASE_TESTOPS_RUN_ID=$(cat tests/cypress/latest/QASE_TESTOPS_RUN_ID.txt)
             echo "qase_run_id=${QASE_TESTOPS_RUN_ID}" >> ${GITHUB_OUTPUT}
           fi
-      - name: Set Rancher Manager Upgrade version
+      - name: Set Rancher Manager version for Migration
         if: ${{ contains(inputs.grep_test_by_tag, '@migration') }}
         run: |
-          echo "RANCHER_VERSION=head/2.13" >> ${GITHUB_ENV}
-      - name: Set Rancher Manager Upgrade version
+          # Check if Rancher Version input is equal to nightly run version
+          if [[ "${{ inputs.rancher_version }}" != "head/2.15" ]]; then
+            # Check if Rancher Version input is valid for migration
+            if [[ "${{ inputs.rancher_version }}" != *"2.13"* ]]; then
+              echo "ERROR: Migration is only allowed to 2.13 Rancher Version"
+              exit 1
+            else
+              echo "RANCHER_VERSION=${{ inputs.rancher_version }}" >> ${GITHUB_ENV}
+            fi
+          else
+            echo "RANCHER_VERSION=head/2.13" >> ${GITHUB_ENV}
+          fi
+      - name: Set Rancher Manager version for Upgrade
         if: ${{ contains(inputs.grep_test_by_tag, '@upgrade') }}
         run: |
-          echo "RANCHER_VERSION=prime-alpha/2.14.4-alpha7" >> ${GITHUB_ENV}
+          # Check if Rancher Version input is equal to nightly run version
+          if [[ "${{ inputs.rancher_version }}" != "head/2.15" ]]; then
+            # Check if Rancher Version input is valid for upgrade
+            if [[ "${{ inputs.rancher_version }}" != *"2.14"* ]]; then
+              echo "ERROR: Upgrade is only allowed to 2.14 Rancher Version"
+              exit 1
+            else
+              echo "RANCHER_VERSION=${{ inputs.rancher_version }}" >> ${GITHUB_ENV}
+            fi
+          else
+            echo "RANCHER_VERSION=prime/2.14.4" >> ${GITHUB_ENV}
+          fi
       - name: Upgrade Rancher Manager
         if: ${{ contains(inputs.grep_test_by_tag, '@migration') || contains(inputs.grep_test_by_tag, '@upgrade') }}
         env:
@@ -593,8 +615,8 @@ jobs:
           SPEC: |
             e2e/capd_rke2_migration_clusterclass.spec.ts
             e2e/post_upgrade_setup.spec.ts
-            e2e/capd_rke2_upgrade_clusterclass.spec.ts
             ${{ env.COMMON_SPECS }}
+            e2e/capd_rke2_upgrade_clusterclass.spec.ts
         run: |
           if [ ${{ inputs.turtles_dev_chart }} == true ]; then
             export CHARTMUSEUM_REPO=http://${{ needs.create-runner.outputs.public_dns }}

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -556,17 +556,14 @@ jobs:
       - name: Set Rancher Manager version for Migration
         if: ${{ contains(inputs.grep_test_by_tag, '@migration') }}
         run: |
-          # Check if Rancher Version input is equal to nightly run version
-          if [[ "${{ inputs.rancher_version }}" != "head/2.15" ]]; then
-            # Check if Rancher Version input is valid for migration
-            if [[ "${{ inputs.rancher_version }}" != *"2.13"* ]]; then
-              echo "ERROR: Migration is only allowed to 2.13 Rancher Version"
-              exit 1
-            else
-              echo "RANCHER_VERSION=${{ inputs.rancher_version }}" >> ${GITHUB_ENV}
-            fi
+          VERSION="${{ inputs.rancher_version }}"
+          if [[ "$VERSION" == *"2.13"* ]]; then
+            echo "RANCHER_VERSION=$VERSION" >> "$GITHUB_ENV"
+          elif [[ "$VERSION" == head/* ]]; then
+            echo "RANCHER_VERSION=head/2.13" >> "$GITHUB_ENV"
           else
-            echo "RANCHER_VERSION=head/2.13" >> ${GITHUB_ENV}
+            echo "ERROR: Migration is only allowed to 2.13 Rancher Version"
+            exit 1
           fi
       - name: Set Rancher Manager version for Upgrade
         if: ${{ contains(inputs.grep_test_by_tag, '@upgrade') }}

--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -571,17 +571,14 @@ jobs:
       - name: Set Rancher Manager version for Upgrade
         if: ${{ contains(inputs.grep_test_by_tag, '@upgrade') }}
         run: |
-          # Check if Rancher Version input is equal to nightly run version
-          if [[ "${{ inputs.rancher_version }}" != "head/2.15" ]]; then
-            # Check if Rancher Version input is valid for upgrade
-            if [[ "${{ inputs.rancher_version }}" != *"2.14"* ]]; then
-              echo "ERROR: Upgrade is only allowed to 2.14 Rancher Version"
-              exit 1
-            else
-              echo "RANCHER_VERSION=${{ inputs.rancher_version }}" >> ${GITHUB_ENV}
-            fi
+          VERSION="${{ inputs.rancher_version }}"
+          if [[ "$VERSION" == *"2.14"* ]]; then
+            echo "RANCHER_VERSION=$VERSION" >> "$GITHUB_ENV"
+          elif [[ "$VERSION" == head/* ]]; then
+            echo "RANCHER_VERSION=prime/2.14.4" >> "$GITHUB_ENV"
           else
-            echo "RANCHER_VERSION=prime/2.14.4" >> ${GITHUB_ENV}
+            echo "ERROR: Upgrade is only allowed to 2.14 Rancher Version"
+            exit 1
           fi
       - name: Upgrade Rancher Manager
         if: ${{ contains(inputs.grep_test_by_tag, '@migration') || contains(inputs.grep_test_by_tag, '@upgrade') }}

--- a/.github/workflows/ui-e2e.yaml
+++ b/.github/workflows/ui-e2e.yaml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
     inputs:
       rancher_version:
-        description: Rancher Manager channel/<version|head_version>[/head_version] to use for installation
+        description: Rancher Manager channel/<version|head_version>[/head_version] to use for installation/upgrade/migration
         default: head/2.15
         type: string
       grep_test_by_tag:

--- a/tests/cypress/latest/e2e/capd_rke2_upgrade_clusterclass.spec.ts
+++ b/tests/cypress/latest/e2e/capd_rke2_upgrade_clusterclass.spec.ts
@@ -174,12 +174,6 @@ describe('Import CAPD RKE2 Class-Cluster for Upgrade', {tags: '@upgrade'}, () =>
           capdResourcesCleanup();
         })
         );
-
-        qase(419, it('Delete the Pre-upgrade resources', () => {
-          cy.removeFleetGitRepo('helm-ops');
-          cy.deleteKubernetesResource('local', ['Storage', 'ConfigMaps'], 'docker-rke2-lb-config', vars.capiClustersNS);
-        })
-        );
       }
     }
   })

--- a/tests/cypress/latest/e2e/post_upgrade_setup.spec.ts
+++ b/tests/cypress/latest/e2e/post_upgrade_setup.spec.ts
@@ -1,6 +1,6 @@
 import '../support/commands';
 import {vars} from '../support/variables';
-import {isTurtlesDevChart, turtlesNamespace, skipClusterDeletion} from '../support/utils';
+import {isTurtlesDevChart, turtlesNamespace} from '../support/utils';
 
 Cypress.config();
 describe('Post Rancher Upgrade Setup - @upgrade', {tags: '@upgrade'}, () => {

--- a/tests/cypress/latest/e2e/post_upgrade_setup.spec.ts
+++ b/tests/cypress/latest/e2e/post_upgrade_setup.spec.ts
@@ -1,6 +1,6 @@
 import '../support/commands';
 import {vars} from '../support/variables';
-import {isTurtlesDevChart, turtlesNamespace} from '../support/utils';
+import {isTurtlesDevChart, turtlesNamespace, skipClusterDeletion} from '../support/utils';
 
 Cypress.config();
 describe('Post Rancher Upgrade Setup - @upgrade', {tags: '@upgrade'}, () => {
@@ -32,4 +32,9 @@ describe('Post Rancher Upgrade Setup - @upgrade', {tags: '@upgrade'}, () => {
   })
   );
 
+  qase(419, it('Delete the Pre-upgrade resources', () => {
+    cy.removeFleetGitRepo('helm-ops');
+    cy.deleteKubernetesResource('local', ['Storage', 'ConfigMaps'], 'docker-rke2-lb-config', vars.capiClustersNS);
+  })
+  );
 });

--- a/tests/cypress/latest/e2e/providers_setup.spec.ts
+++ b/tests/cypress/latest/e2e/providers_setup.spec.ts
@@ -192,17 +192,15 @@ describe('Enable CAPI Providers', () => {
       })
       );
     })
-  });
 
-  context('Docker provider', {tags: ['@short', '@short-nocaapf', '@nocaapf', '@capdk', '@capdr', '@upgrade', '@switch', '@use-caapf-switch', '@capdk-nocaapf', '@capdr-nocaapf']}, () => {
-    const dockerProviderNamespace = 'capd-system'
     qase(422, it('Verify CAPD provider', () => {
       // Verify Docker Infrastructure provider
+      const dockerProviderNamespace = 'capd-system'
       cy.navigateToProviders();
       matchAndWaitForProviderReadyStatus(providers.dockerProvider, 'infrastructure', providers.dockerProvider, providers.kubeadmProviderVersion, dockerProviderNamespace);
     })
     );
-  })
+  });
 
   context('vSphere provider', {tags: ['@vsphere', '@vsphere-nocaapf', '@capvk', '@capvk-nocaapf', '@capvr', '@capvr-nocaapf']}, () => {
     const vsphereProviderNamespace = 'capv-system'

--- a/tests/cypress/latest/e2e/providers_setup.spec.ts
+++ b/tests/cypress/latest/e2e/providers_setup.spec.ts
@@ -104,12 +104,11 @@ describe('Enable CAPI Providers', () => {
         // @ts-ignore
         text.providers.controlplaneKubeadm.enableAutomaticUpdate = true;
 
-        if (isCypressTag('@short') || isCypressTag('@nocaapf') || isCypressTag('@capd') || isCypressTag('@upgrade') || isCypressTag('@switch') || isCypressTag('@use-caapf-switch')) {
-            // @ts-ignore
-            text.providers.infrastructureDocker.enabled = true;
-            // @ts-ignore
-            text.providers.infrastructureDocker.enableAutomaticUpdate = true;
-          }
+        // @ts-ignore
+        text.providers.infrastructureDocker.enabled = true;
+        // @ts-ignore
+        text.providers.infrastructureDocker.enableAutomaticUpdate = true;
+
         // there is no easy way to only install a specific provider when something like `@capgke` is passed, so we enable all the cloud providers
         if (isCypressTag('@full') || isCypressTag('@nocaapf') || isCypressTag('@capg') || isCypressTag('@capa') || isCypressTag('@capz')) {
             // @ts-ignore

--- a/tests/cypress/latest/e2e/providers_setup_legacy.spec.ts
+++ b/tests/cypress/latest/e2e/providers_setup_legacy.spec.ts
@@ -103,9 +103,7 @@ describe('Enable CAPI Providers (2.12)', () => {
       })
       );
     })
-  })
-
-  context('Docker provider', {tags: ['@short', '@capdk', '@capdr']}, () => {
+    
     const dockerProviderNamespace = 'capd-system'
     qase(500, it('Create Docker CAPIProvider Namespace', () => {
       cy.createNamespace([dockerProviderNamespace]);


### PR DESCRIPTION
### What does this PR do?
- Always install Docker provider as its most widely used
- Rancher Version to Upgrade/Migrate to can be provided as CI Input
- Refactor upgrade tests flow so that providers are installed before post-upgrade tests

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes - part of https://github.com/rancher/rancher-turtles-e2e/issues/588

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [ ] Added/Modified Qase IDs
- [ ] GitHub Actions (if applicable)

### Special notes for your reviewer:

<!-- e2e-result-start -->
### E2E Test Results:

| Run Name | Run Result | Notes |
|----------|------------|-------|
| [[5265] Rancher-head/2.15 - **@install @migration** dev=true destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/30885447658) | ✅ Pass | |
| [[5268] Rancher-head/2.15 - **@install @short** dev=true destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/30885522500) | ✅ Pass | |
| [[5267] Rancher-prime-alpha/2.14.4-alpha4 - **@install @upgrade** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/30885503269) | ✅ Pass | Custom input |
| [[5272] Rancher-prime/2.14.4 - **@install @migration** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/30905705304) | ❌ Fail | Forced failure|
| [[5273] Rancher-prime-alpha/2.15.0-alpha21 - **@install @upgrade** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/30905743620) | ❌ Fail | Forced failure|
| [[5274] Rancher-head/2.15 - **@install @upgrade** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/30910301447) | ❌ Fail | |
<!-- e2e-result-end -->












