### PR TITLE
Fix V213PlusRegistry function

### DIFF
--- a/tests/cypress/latest/support/commands.ts
+++ b/tests/cypress/latest/support/commands.ts
@@ -28,6 +28,7 @@ import {
   isPreRelease,
   isPrimeChannel,
   isRancherManagerVersion,
+  isStgRegistryVersions,
   isTurtlesDevChart,
   isTurtlesPrimeBuild,
   isUpgrade, turtlesNamespace
@@ -1298,16 +1299,16 @@ const PROVIDER_REGISTRIES = {
  */
 function getV213PlusRegistry(providerNamespace: string): string {
   const isPrimeDev = isTurtlesDevChart && isTurtlesPrimeBuild();
-  const usesStgRegistry = isPrePrimeChannel() || (isRancherManagerVersion('2.13') && isHeadBuild);
+  const usesStgRegistry = isPrePrimeChannel() || (isStgRegistryVersions && isHeadBuild);
 
-  // Special handling for 2.13 prerelease community builds
-  if (isRancherManagerVersion('2.13') && isPreRelease && !isPrimeChannel()) {
+  // Special handling for 2.13, 2.14 prerelease community builds
+  if (isStgRegistryVersions && isPreRelease && !isPrimeChannel()) {
     return isPrimeDev ? PROVIDER_REGISTRIES.RANCHER_PRIME : getCommunityRegistry(providerNamespace);
   }
 
   // Staging registry takes precedence for:
   // - Prime prerelease channels (prime-alpha, prime-rc)
-  // - 2.13 head builds (2.13 alpha/rc community builds already handled above)
+  // - 2.13, 2.14 head builds (2.13, 2.14 alpha/rc community builds already handled above)
   if (usesStgRegistry) {
     return PROVIDER_REGISTRIES.RANCHER_STG_PRIME;
   }

--- a/tests/cypress/latest/support/utils.ts
+++ b/tests/cypress/latest/support/utils.ts
@@ -33,6 +33,7 @@ export const isPrePrimeChannel = (): boolean => {
 
 export const isPreRelease = /(-alpha|-rc)/.test(rancherVersion);
 export const isHeadBuild = rancherVersion.includes('head');
+export const isStgRegistryVersions = rancherVersion.includes('2.13') || rancherVersion.includes('2.14');
 
 
 // Check if Rancher should use staging registry to install Rancher Turtles Providers Chart


### PR DESCRIPTION
### What does this PR do?
Fix V213PlusRegistry function, with respect to 2.14

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [ ] Added/Modified Qase IDs
- [ ] GitHub Actions (if applicable)

### Special notes for your reviewer:

<!-- e2e-result-start -->
### E2E Test Results:

| Run Name | Run Result | Notes |
|----------|------------|-------|
| [[5295] Rancher-prime/2.14.4 - **@install ** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/31093675760) | ✅ Pass | |
| [[5294] Rancher-head/2.14 - **@install ** dev=false destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/31093616091) | ✅ Pass | |
| [[5293] Rancher-head/2.14 - **@install ** dev=true destroy=true](https://github.com/rancher/rancher-turtles-e2e/actions/runs/31093585860) | ✅ Pass | |
<!-- e2e-result-end -->



